### PR TITLE
Restyle landing to warm light paper

### DIFF
--- a/404.html
+++ b/404.html
@@ -11,7 +11,7 @@
   <link rel="icon" href="/favicon.ico" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
 </head>
 <body>
   <main>

--- a/404.html
+++ b/404.html
@@ -11,7 +11,7 @@
   <link rel="icon" href="/favicon.ico" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
 </head>
 <body>
   <main>

--- a/index.html
+++ b/index.html
@@ -88,8 +88,8 @@
     </section>
 
   </main>
-  <footer style="max-width:680px;margin:0 auto;padding:2rem 1.5rem 1rem;font-size:0.85rem;color:#888;">
-    <a href="/privacy.html" style="color:#888;">Privacy Policy</a>
+  <footer style="max-width:680px;margin:0 auto;padding:2rem 1.5rem 1rem;font-size:0.85rem;color:var(--muted);">
+    <a href="/privacy.html" style="color:var(--muted);">Privacy Policy</a>
   </footer>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="style.css?v=20260829b">
+  <link rel="stylesheet" href="style.css?v=20260903a">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="style.css?v=20260903a">
+  <link rel="stylesheet" href="style.css?v=20260903b">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>

--- a/privacy.html
+++ b/privacy.html
@@ -11,7 +11,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="style.css?v=20260829b">
+  <link rel="stylesheet" href="style.css?v=20260903a">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>

--- a/privacy.html
+++ b/privacy.html
@@ -11,7 +11,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="style.css?v=20260903a">
+  <link rel="stylesheet" href="style.css?v=20260903b">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>

--- a/style.css
+++ b/style.css
@@ -30,7 +30,7 @@ html {
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  font-family: "Iowan Old Style", "Palatino Linotype", Palatino, "Times New Roman", Times, serif;
   background: var(--bg);
   color: var(--fg);
   line-height: 1.6;
@@ -47,7 +47,6 @@ header {
 }
 
 h1 {
-  font-family: Georgia, "Iowan Old Style", "Palatino Linotype", "Times New Roman", serif;
   font-size: 2rem;
   font-weight: 700;
   letter-spacing: -0.02em;
@@ -61,6 +60,7 @@ h1 {
 }
 
 .header-links {
+  font-family: "Segoe UI", Helvetica, Arial, sans-serif;
   color: var(--muted);
   font-size: 0.9rem;
   margin-bottom: 1rem;
@@ -83,6 +83,7 @@ h1 {
 
 /* Landing chrome — never apply to essay pages */
 main:not(.article) h2 {
+  font-family: "Segoe UI", Helvetica, Arial, sans-serif;
   font-size: 1.1rem;
   font-weight: 600;
   text-transform: uppercase;

--- a/style.css
+++ b/style.css
@@ -1,11 +1,12 @@
 :root {
-  --bg: #111;
-  --fg: #e0e0e0;
-  --accent: #6cb4ee;
-  --muted: #888;
-  --card-bg: #1a1a1a;
-  --border: #333;
+  --bg: #f4efe6;
+  --fg: #1c1915;
+  --accent: #9a3412;
+  --muted: #5c564e;
+  --card-bg: #fffaf3;
+  --border: #d8d2c6;
   --max-width: 680px;
+  color-scheme: light;
 }
 
 * {
@@ -46,6 +47,7 @@ header {
 }
 
 h1 {
+  font-family: Georgia, "Iowan Old Style", "Palatino Linotype", "Times New Roman", serif;
   font-size: 2rem;
   font-weight: 700;
   letter-spacing: -0.02em;
@@ -98,6 +100,7 @@ section {
 .card {
   background: var(--card-bg);
   border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
   border-radius: 4px;
   padding: 1.25rem;
   margin-bottom: 1rem;
@@ -139,11 +142,13 @@ main:not(.article) li::before {
 
 a {
   color: var(--accent);
-  text-decoration: none;
+  text-decoration: underline;
+  text-decoration-thickness: 0.06em;
+  text-underline-offset: 0.14em;
 }
 
 a:hover {
-  text-decoration: underline;
+  color: #7a280e;
 }
 
 #contact p {
@@ -475,7 +480,7 @@ a:hover {
   color: var(--muted);
 }
 
-/* Writing paper: screen matches print. Homepage stays dark. */
+/* Writing paper: screen matches print. Landing uses :root light tokens. */
 body:has(main.article),
 body:has(#writing) {
   --paper: #faf8f4;

--- a/writing/45/index.html
+++ b/writing/45/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/45/index.html
+++ b/writing/45/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/addiction-to-being-right-is-rarer-than-you-think/index.html
+++ b/writing/addiction-to-being-right-is-rarer-than-you-think/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/addiction-to-being-right-is-rarer-than-you-think/index.html
+++ b/writing/addiction-to-being-right-is-rarer-than-you-think/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/agency-dims-as-the-timeframe-collapses/index.html
+++ b/writing/agency-dims-as-the-timeframe-collapses/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/agency-dims-as-the-timeframe-collapses/index.html
+++ b/writing/agency-dims-as-the-timeframe-collapses/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/agent-didnt-get-dumber-chat-got-contaminated/index.html
+++ b/writing/agent-didnt-get-dumber-chat-got-contaminated/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/agent-didnt-get-dumber-chat-got-contaminated/index.html
+++ b/writing/agent-didnt-get-dumber-chat-got-contaminated/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/agent-rail-war-red-herring/index.html
+++ b/writing/agent-rail-war-red-herring/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/agent-rail-war-red-herring/index.html
+++ b/writing/agent-rail-war-red-herring/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/agents-plan-b-destroy-data/index.html
+++ b/writing/agents-plan-b-destroy-data/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/agents-plan-b-destroy-data/index.html
+++ b/writing/agents-plan-b-destroy-data/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/ai-rerunning-the-nuclear-script/index.html
+++ b/writing/ai-rerunning-the-nuclear-script/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/ai-rerunning-the-nuclear-script/index.html
+++ b/writing/ai-rerunning-the-nuclear-script/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/ai-writes-code-plan-becomes-work/index.html
+++ b/writing/ai-writes-code-plan-becomes-work/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/ai-writes-code-plan-becomes-work/index.html
+++ b/writing/ai-writes-code-plan-becomes-work/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/anxiety-present-tense-problem/index.html
+++ b/writing/anxiety-present-tense-problem/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/anxiety-present-tense-problem/index.html
+++ b/writing/anxiety-present-tense-problem/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/basb-claude-code-setup/index.html
+++ b/writing/basb-claude-code-setup/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/basb-claude-code-setup/index.html
+++ b/writing/basb-claude-code-setup/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/bottleneck-is-you/index.html
+++ b/writing/bottleneck-is-you/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/bottleneck-is-you/index.html
+++ b/writing/bottleneck-is-you/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/build-source-of-truth-before-index/index.html
+++ b/writing/build-source-of-truth-before-index/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/build-source-of-truth-before-index/index.html
+++ b/writing/build-source-of-truth-before-index/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/capacity-is-your-lowest-ceiling/index.html
+++ b/writing/capacity-is-your-lowest-ceiling/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/capacity-is-your-lowest-ceiling/index.html
+++ b/writing/capacity-is-your-lowest-ceiling/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/career-ceiling-i-was-worried-about-already-existed/index.html
+++ b/writing/career-ceiling-i-was-worried-about-already-existed/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/career-ceiling-i-was-worried-about-already-existed/index.html
+++ b/writing/career-ceiling-i-was-worried-about-already-existed/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/certainty-wellbeing-variable/index.html
+++ b/writing/certainty-wellbeing-variable/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/certainty-wellbeing-variable/index.html
+++ b/writing/certainty-wellbeing-variable/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/cheap-code-expensive-context/index.html
+++ b/writing/cheap-code-expensive-context/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/cheap-code-expensive-context/index.html
+++ b/writing/cheap-code-expensive-context/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/credit-cures-plagiarism-not-permission-20260817/index.html
+++ b/writing/credit-cures-plagiarism-not-permission-20260817/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/credit-cures-plagiarism-not-permission-20260817/index.html
+++ b/writing/credit-cures-plagiarism-not-permission-20260817/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/credit-cures-plagiarism-not-permission/index.html
+++ b/writing/credit-cures-plagiarism-not-permission/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/credit-cures-plagiarism-not-permission/index.html
+++ b/writing/credit-cures-plagiarism-not-permission/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/debt-with-diff-attached-20260724/index.html
+++ b/writing/debt-with-diff-attached-20260724/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/debt-with-diff-attached-20260724/index.html
+++ b/writing/debt-with-diff-attached-20260724/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/debt-with-diff-attached/index.html
+++ b/writing/debt-with-diff-attached/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/debt-with-diff-attached/index.html
+++ b/writing/debt-with-diff-attached/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/debug-system-not-prompt/index.html
+++ b/writing/debug-system-not-prompt/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/debug-system-not-prompt/index.html
+++ b/writing/debug-system-not-prompt/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/deleting-24k-lines-ai-instructions/index.html
+++ b/writing/deleting-24k-lines-ai-instructions/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/deleting-24k-lines-ai-instructions/index.html
+++ b/writing/deleting-24k-lines-ai-instructions/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/developers-job-judgment-now/index.html
+++ b/writing/developers-job-judgment-now/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/developers-job-judgment-now/index.html
+++ b/writing/developers-job-judgment-now/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/engineer-the-downside-when-you-cannot-forecast/index.html
+++ b/writing/engineer-the-downside-when-you-cannot-forecast/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/engineer-the-downside-when-you-cannot-forecast/index.html
+++ b/writing/engineer-the-downside-when-you-cannot-forecast/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/enter-key-problem/index.html
+++ b/writing/enter-key-problem/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/enter-key-problem/index.html
+++ b/writing/enter-key-problem/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/five-checks-against-motivated-reasoning-20260824/index.html
+++ b/writing/five-checks-against-motivated-reasoning-20260824/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/five-checks-against-motivated-reasoning-20260824/index.html
+++ b/writing/five-checks-against-motivated-reasoning-20260824/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/five-checks-against-motivated-reasoning/index.html
+++ b/writing/five-checks-against-motivated-reasoning/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/five-checks-against-motivated-reasoning/index.html
+++ b/writing/five-checks-against-motivated-reasoning/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/governing-delegation-scope-creep/index.html
+++ b/writing/governing-delegation-scope-creep/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/governing-delegation-scope-creep/index.html
+++ b/writing/governing-delegation-scope-creep/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/half-agent-infrastructure-depreciating-asset-20260802/index.html
+++ b/writing/half-agent-infrastructure-depreciating-asset-20260802/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/half-agent-infrastructure-depreciating-asset-20260802/index.html
+++ b/writing/half-agent-infrastructure-depreciating-asset-20260802/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/half-agent-infrastructure-depreciating-asset/index.html
+++ b/writing/half-agent-infrastructure-depreciating-asset/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/half-agent-infrastructure-depreciating-asset/index.html
+++ b/writing/half-agent-infrastructure-depreciating-asset/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/havent-written-a-test-in-a-year/index.html
+++ b/writing/havent-written-a-test-in-a-year/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/havent-written-a-test-in-a-year/index.html
+++ b/writing/havent-written-a-test-in-a-year/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/index.html
+++ b/writing/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/index.html
+++ b/writing/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/instapay-is-not-ach/index.html
+++ b/writing/instapay-is-not-ach/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/instapay-is-not-ach/index.html
+++ b/writing/instapay-is-not-ach/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/juanito-p-galvez-1928-2022/index.html
+++ b/writing/juanito-p-galvez-1928-2022/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/juanito-p-galvez-1928-2022/index.html
+++ b/writing/juanito-p-galvez-1928-2022/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/ledger-that-stayed-empty/index.html
+++ b/writing/ledger-that-stayed-empty/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/ledger-that-stayed-empty/index.html
+++ b/writing/ledger-that-stayed-empty/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/meat-proxy-problem-20260819/index.html
+++ b/writing/meat-proxy-problem-20260819/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/meat-proxy-problem-20260819/index.html
+++ b/writing/meat-proxy-problem-20260819/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/meat-proxy-problem/index.html
+++ b/writing/meat-proxy-problem/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/meat-proxy-problem/index.html
+++ b/writing/meat-proxy-problem/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/metric-already-happened-upstream/index.html
+++ b/writing/metric-already-happened-upstream/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/metric-already-happened-upstream/index.html
+++ b/writing/metric-already-happened-upstream/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/most-expensive-avoidance-looks-like-prudence/index.html
+++ b/writing/most-expensive-avoidance-looks-like-prudence/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/most-expensive-avoidance-looks-like-prudence/index.html
+++ b/writing/most-expensive-avoidance-looks-like-prudence/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/new-art-learning/index.html
+++ b/writing/new-art-learning/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/new-art-learning/index.html
+++ b/writing/new-art-learning/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/nine-security-issues-zero-lines-i-wrote/index.html
+++ b/writing/nine-security-issues-zero-lines-i-wrote/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/nine-security-issues-zero-lines-i-wrote/index.html
+++ b/writing/nine-security-issues-zero-lines-i-wrote/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/orchestrator-identity/index.html
+++ b/writing/orchestrator-identity/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/orchestrator-identity/index.html
+++ b/writing/orchestrator-identity/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/parallelizing-sftp-downloads-ruby/index.html
+++ b/writing/parallelizing-sftp-downloads-ruby/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/parallelizing-sftp-downloads-ruby/index.html
+++ b/writing/parallelizing-sftp-downloads-ruby/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/pattern-capture-auto-activating-skill-library/index.html
+++ b/writing/pattern-capture-auto-activating-skill-library/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/pattern-capture-auto-activating-skill-library/index.html
+++ b/writing/pattern-capture-auto-activating-skill-library/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/payments-glossary/index.html
+++ b/writing/payments-glossary/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/payments-glossary/index.html
+++ b/writing/payments-glossary/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/pkm-bottleneck-was-never-capture/index.html
+++ b/writing/pkm-bottleneck-was-never-capture/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/pkm-bottleneck-was-never-capture/index.html
+++ b/writing/pkm-bottleneck-was-never-capture/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/polish-is-free-thinking-isnt/index.html
+++ b/writing/polish-is-free-thinking-isnt/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/polish-is-free-thinking-isnt/index.html
+++ b/writing/polish-is-free-thinking-isnt/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/positioning-demotes-prediction/index.html
+++ b/writing/positioning-demotes-prediction/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/positioning-demotes-prediction/index.html
+++ b/writing/positioning-demotes-prediction/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/run-dead-internet-on-purpose/index.html
+++ b/writing/run-dead-internet-on-purpose/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/run-dead-internet-on-purpose/index.html
+++ b/writing/run-dead-internet-on-purpose/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/same-tunnel-ships-work-drops-room/index.html
+++ b/writing/same-tunnel-ships-work-drops-room/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/same-tunnel-ships-work-drops-room/index.html
+++ b/writing/same-tunnel-ships-work-drops-room/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/scanner-that-feeds-pipeline/index.html
+++ b/writing/scanner-that-feeds-pipeline/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/scanner-that-feeds-pipeline/index.html
+++ b/writing/scanner-that-feeds-pipeline/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/second-brain-fails-you/index.html
+++ b/writing/second-brain-fails-you/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/second-brain-fails-you/index.html
+++ b/writing/second-brain-fails-you/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/selection-beats-execution-when-games-differ/index.html
+++ b/writing/selection-beats-execution-when-games-differ/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/selection-beats-execution-when-games-differ/index.html
+++ b/writing/selection-beats-execution-when-games-differ/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/tell-me-whats-wrong-with-it-isnt-review/index.html
+++ b/writing/tell-me-whats-wrong-with-it-isnt-review/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/tell-me-whats-wrong-with-it-isnt-review/index.html
+++ b/writing/tell-me-whats-wrong-with-it-isnt-review/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/the-bugs-that-hide-between-your-agents/index.html
+++ b/writing/the-bugs-that-hide-between-your-agents/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/the-bugs-that-hide-between-your-agents/index.html
+++ b/writing/the-bugs-that-hide-between-your-agents/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/the-employee-you-cant-stop-managing/index.html
+++ b/writing/the-employee-you-cant-stop-managing/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/the-employee-you-cant-stop-managing/index.html
+++ b/writing/the-employee-you-cant-stop-managing/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/triage-system-not-your-toolbox/index.html
+++ b/writing/triage-system-not-your-toolbox/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/triage-system-not-your-toolbox/index.html
+++ b/writing/triage-system-not-your-toolbox/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/triffins-dilemma-escape-doesnt-work/index.html
+++ b/writing/triffins-dilemma-escape-doesnt-work/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/triffins-dilemma-escape-doesnt-work/index.html
+++ b/writing/triffins-dilemma-escape-doesnt-work/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/urgency-conscientiousness-better-marketing/index.html
+++ b/writing/urgency-conscientiousness-better-marketing/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/urgency-conscientiousness-better-marketing/index.html
+++ b/writing/urgency-conscientiousness-better-marketing/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/us-and-philippine-payment-rails/index.html
+++ b/writing/us-and-philippine-payment-rails/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/us-and-philippine-payment-rails/index.html
+++ b/writing/us-and-philippine-payment-rails/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/what-actually-buys-you-the-power-to-say-no/index.html
+++ b/writing/what-actually-buys-you-the-power-to-say-no/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/what-actually-buys-you-the-power-to-say-no/index.html
+++ b/writing/what-actually-buys-you-the-power-to-say-no/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/when-your-mcp-server-breaks/index.html
+++ b/writing/when-your-mcp-server-breaks/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/when-your-mcp-server-breaks/index.html
+++ b/writing/when-your-mcp-server-breaks/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/your-living-spec-is-still-lying/index.html
+++ b/writing/your-living-spec-is-still-lying/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/your-living-spec-is-still-lying/index.html
+++ b/writing/your-living-spec-is-still-lying/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/your-review-checklist-has-never-been-reviewed/index.html
+++ b/writing/your-review-checklist-has-never-been-reviewed/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260903a">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/writing/your-review-checklist-has-never-been-reviewed/index.html
+++ b/writing/your-review-checklist-has-never-been-reviewed/index.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
   <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=20260829b">
+  <link rel="stylesheet" href="/style.css?v=20260903a">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];


### PR DESCRIPTION
## Summary

Landing pages (home, privacy, 404) switch from dark `#111` to warm paper: cream `#f4efe6`, ink `#1c1915`, rust accent `#9a3412`.

Writing paper is unchanged (cream `#faf8f4`, Georgia, ink). ELI5, Reference, Trees, and the Ninthgreen sample keep their own sheets.

## Why rust

The old sky-blue `#6cb4ee` fails as a link on cream. Rust matches ELI5 and clears WCAG AA on this background (6.38:1). Body ink is 15:1.

## Cache

Every HTML that loads `style.css` now uses `?v=20260903a` (including 404, which had no version).

## Out of scope

No theme toggle, webfonts, or skill HOW updates. `journal`/essay converter still documents “homepage stays dark” until those skills are patched separately.
