### PR TITLE
Template writing layout so chrome changes in one place

### DIFF
--- a/scripts/test_writing_layout.py
+++ b/scripts/test_writing_layout.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Tests for writing chrome split/render."""
+
+import re
+import unittest
+from pathlib import Path
+
+import writing_layout
+
+SCRIPTS = Path(__file__).resolve().parent
+ROOT = SCRIPTS.parent
+ESSAY = ROOT / "writing" / "debt-with-diff-attached" / "index.html"
+INDEX = ROOT / "writing" / "index.html"
+
+
+class WritingLayoutTests(unittest.TestCase):
+    def test_css_ver_comes_from_layout(self):
+        layout = writing_layout.layout_text()
+        tokens = re.findall(r"style\.css\?v=[^\"'\s>]+", layout)
+        self.assertEqual(len(tokens), 1, layout)
+        token = tokens[0]
+        page = writing_layout.split(ESSAY.read_text(encoding="utf-8"))
+        rendered = writing_layout.render(page)
+        self.assertIn(token, rendered)
+        self.assertEqual(rendered.count("style.css?v="), 1)
+
+    def test_essay_roundtrip_preserves_body(self):
+        page = writing_layout.split(ESSAY.read_text(encoding="utf-8"))
+        rendered = writing_layout.render(page)
+        self.assertIn("AI-DDoS", rendered)
+        self.assertIn('<div class="tldr">', rendered)
+        self.assertIn("main class=\"article\"", rendered)
+        self.assertIn('id="top"', rendered)
+        self.assertNotIn('class="next-step"', rendered)
+
+    def test_index_keeps_list_and_knock(self):
+        page = writing_layout.split(INDEX.read_text(encoding="utf-8"))
+        rendered = writing_layout.render(page)
+        self.assertIn('id="writing"', rendered)
+        self.assertIn('class="next-step"', rendered)
+        self.assertIn("js-paged", rendered)
+        self.assertNotIn("main class=\"article\"", rendered)
+
+    def test_essay_crumb_gold(self):
+        page = writing_layout.split(ESSAY.read_text(encoding="utf-8"))
+        rendered = writing_layout.render(page)
+        self.assertIn(
+            '<p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a>',
+            rendered,
+        )
+        self.assertIn('<a href="/writing/">Writing</a>', rendered)
+        self.assertIn(
+            '<span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span>',
+            rendered,
+        )
+        self.assertNotIn('<a class="back"', rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_writing_layout.py
+++ b/scripts/test_writing_layout.py
@@ -35,6 +35,7 @@ class WritingLayoutTests(unittest.TestCase):
 
     def test_index_keeps_list_and_knock(self):
         page = writing_layout.split(INDEX.read_text(encoding="utf-8"))
+        page["path"] = "writing/index.html"
         rendered = writing_layout.render(page)
         self.assertIn('id="writing"', rendered)
         self.assertIn('class="next-step"', rendered)
@@ -54,6 +55,46 @@ class WritingLayoutTests(unittest.TestCase):
             rendered,
         )
         self.assertNotIn('<a class="back"', rendered)
+
+    def test_inner_placeholder_syntax_is_preserved(self):
+        page = writing_layout.split(ESSAY.read_text(encoding="utf-8"))
+        page["path"] = "writing/example/index.html"
+        literal = "<p>Literal {{title}} {{to_top}} {{footer}} {{unknown}}</p>"
+        page["inner"] = "    " + literal + "\n"
+        rendered = writing_layout.render(page)
+        self.assertIn(literal, rendered)
+        self.assertEqual(rendered.count(writing_layout.ESSAY_TO_TOP), 1)
+
+    def test_meta_attribute_quotes_are_escaped(self):
+        page = writing_layout.split(ESSAY.read_text(encoding="utf-8"))
+        page["path"] = "writing/example/index.html"
+        page["description"] = 'Say "just validate it" now.'
+        page["og_description"] = page["description"]
+        rendered = writing_layout.render(page)
+        escaped = 'content="Say &quot;just validate it&quot; now."'
+        self.assertEqual(rendered.count(escaped), 2)
+
+    def test_essay_with_writing_id_keeps_essay_chrome(self):
+        page = writing_layout.split(ESSAY.read_text(encoding="utf-8"))
+        page["path"] = "writing/example/index.html"
+        page["inner"] = '    <section id="writing">Example</section>\n'
+        rendered = writing_layout.render(page)
+        self.assertIn(writing_layout.GOLD_CRUMB, rendered)
+        self.assertIn(writing_layout.ESSAY_TO_TOP, rendered)
+        self.assertIn('<footer class="meta">', rendered)
+
+    def test_all_writing_metadata_survives_render(self):
+        fields = ("description", "og_title", "og_description", "og_type", "canonical")
+        for path in sorted((ROOT / "writing").rglob("index.html")):
+            with self.subTest(path=path):
+                page = writing_layout.split(path.read_text(encoding="utf-8"))
+                page["path"] = str(path.relative_to(ROOT))
+                rendered = writing_layout.render(page)
+                rerendered = writing_layout.split(rendered)
+                self.assertEqual(
+                    tuple(page[field] for field in fields),
+                    tuple(rerendered[field] for field in fields),
+                )
 
 
 if __name__ == "__main__":

--- a/scripts/writing-layout.html
+++ b/scripts/writing-layout.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{title}}</title>
+  <meta name="description" content="{{description}}">
+  <meta property="og:title" content="{{og_title}}">
+  <meta property="og:description" content="{{og_description}}">
+  <meta property="og:type" content="{{og_type}}">
+  <meta property="og:url" content="{{canonical}}">
+  <link rel="canonical" href="{{canonical}}">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=20260813f">
+  <link rel="icon" href="/favicon-192.png?v=20260813f" type="image/png" sizes="192x192">
+  <link rel="icon" href="/favicon-32.png?v=20260813f" type="image/png" sizes="32x32">
+  <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
+  <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="stylesheet" href="/style.css?v=20260903b">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TLBY8P4GG9');
+  </script>
+</head>
+<body>
+  <main{{main_attrs}}>
+{{crumb}}{{inner}}{{to_top}}{{footer}}  </main>
+{{extra_scripts}}  <button id="backToTop" class="back-to-top" aria-label="Back to top" title="Back to top">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M18 15l-6-6-6 6"/>
+    </svg>
+  </button>
+
+  <script>
+    const btt = document.getElementById("backToTop");
+    window.addEventListener("scroll", () => {
+      if (window.scrollY > 250) {
+        btt.classList.add("visible");
+      } else {
+        btt.classList.remove("visible");
+      }
+    }, { passive: true });
+    btt.addEventListener("click", () => {
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    });
+  </script>
+</body>
+</html>

--- a/scripts/writing_layout.py
+++ b/scripts/writing_layout.py
@@ -44,6 +44,12 @@ def _attr(tag: str, name: str) -> str:
     return m.group(1) if m else ""
 
 
+def _content_attr(tag: str) -> str:
+    # content is last; greedy to the closing quote so inner quotes survive.
+    m = re.search(r'\bcontent="(.*)"', tag, re.S)
+    return m.group(1) if m else ""
+
+
 def _head_tag(html: str, pattern: str) -> str:
     m = re.search(pattern, html)
     return m.group(0) if m else ""
@@ -59,7 +65,7 @@ def _meta_name(html: str, name: str) -> str:
         rf'<meta\b[^>]*\bname="{re.escape(name)}"[^>]*>',
         html,
     )
-    return _attr(m.group(0), "content") if m else ""
+    return _content_attr(m.group(0)) if m else ""
 
 
 def _meta_prop(html: str, prop: str) -> str:
@@ -67,7 +73,7 @@ def _meta_prop(html: str, prop: str) -> str:
         rf'<meta\b[^>]*\bproperty="{re.escape(prop)}"[^>]*>',
         html,
     )
-    return _attr(m.group(0), "content") if m else ""
+    return _content_attr(m.group(0)) if m else ""
 
 
 def _block(text: str) -> str:
@@ -89,10 +95,10 @@ def split(html: str) -> dict:
     if not main_m:
         raise ValueError("no <main> in html")
     main_attrs = main_m.group(1)
-    inner = main_m.group(2)
+    inner = main_m.group(2).lstrip("\n")
 
     crumb = ""
-    crumb_m = re.match(r'\s*(<p class="back"[^>]*>.*?</p>)', inner, re.S)
+    crumb_m = re.match(r'\s*(<p class="back"[^>]*>.*?</p>)\n*', inner, re.S)
     if crumb_m:
         crumb = crumb_m.group(1)
         inner = inner[crumb_m.end() :]
@@ -106,6 +112,8 @@ def split(html: str) -> dict:
     to_top_m = re.search(r'\s*<p class="to-top">.*?</p>\s*$', inner, re.S)
     if to_top_m:
         inner = inner[: to_top_m.start()]
+
+    inner = inner.rstrip() + "\n"
 
     after = html.split("</main>", 1)[1] if "</main>" in html else ""
     after = re.sub(r"</body>\s*</html>\s*$", "", after, flags=re.I | re.S)

--- a/scripts/writing_layout.py
+++ b/scripts/writing_layout.py
@@ -19,22 +19,6 @@ GOLD_CRUMB = (
     '<a href="#print" onclick="window.print();return false">Print</a></span></p>'
 )
 ESSAY_TO_TOP = '<p class="to-top"><a href="#top">Back to top</a></p>'
-PLACEHOLDERS = (
-    "title",
-    "description",
-    "og_title",
-    "og_description",
-    "og_type",
-    "canonical",
-    "main_attrs",
-    "crumb",
-    "inner",
-    "to_top",
-    "footer",
-    "extra_scripts",
-)
-
-
 def layout_text() -> str:
     return LAYOUT_PATH.read_text(encoding="utf-8")
 
@@ -82,12 +66,13 @@ def _block(text: str) -> str:
     return str(text).strip("\n") + "\n"
 
 
+def _quoted_attr(value: str) -> str:
+    return str(value or "").replace('"', "&quot;")
+
+
 def is_writing_index(page: dict) -> bool:
-    inner = page.get("inner", "")
-    if 'id="writing"' in inner:
-        return True
     path = str(page.get("path") or "").replace("\\", "/")
-    return path.endswith("writing/index.html")
+    return path == "writing/index.html"
 
 
 def split(html: str) -> dict:
@@ -156,11 +141,11 @@ def split(html: str) -> dict:
 def render(page: dict) -> str:
     values = {
         "title": page.get("title", ""),
-        "description": page.get("description", ""),
-        "og_title": page.get("og_title", ""),
-        "og_description": page.get("og_description", ""),
-        "og_type": page.get("og_type", ""),
-        "canonical": page.get("canonical", ""),
+        "description": _quoted_attr(page.get("description", "")),
+        "og_title": _quoted_attr(page.get("og_title", "")),
+        "og_description": _quoted_attr(page.get("og_description", "")),
+        "og_type": _quoted_attr(page.get("og_type", "")),
+        "canonical": _quoted_attr(page.get("canonical", "")),
         "main_attrs": page.get("main_attrs", ""),
         "inner": page.get("inner", ""),
         "extra_scripts": page.get("extra_scripts", ""),
@@ -175,13 +160,13 @@ def render(page: dict) -> str:
         values["to_top"] = _block("    " + ESSAY_TO_TOP)
         values["footer"] = _block(page.get("footer") or "")
 
-    html = layout_text()
-    for key in PLACEHOLDERS:
-        html = html.replace("{{" + key + "}}", values.get(key, ""))
-    leftover = re.findall(r"\{\{[^}]+\}\}", html)
-    if leftover:
-        raise ValueError("leftover placeholders: " + ", ".join(leftover))
-    return html
+    def _replace_placeholder(match: re.Match) -> str:
+        key = match.group(1)
+        if key not in values:
+            raise ValueError("unknown placeholder: " + match.group(0))
+        return values[key]
+
+    return re.sub(r"\{\{([^}]+)\}\}", _replace_placeholder, layout_text())
 
 
 def rebuild(root: Path | None = None) -> list[Path]:

--- a/scripts/writing_layout.py
+++ b/scripts/writing_layout.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Fill writing-layout.html from existing writing HTML. No markdown parse."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent
+ROOT = SCRIPTS.parent
+LAYOUT_PATH = SCRIPTS / "writing-layout.html"
+
+GOLD_CRUMB = (
+    '<p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a>'
+    ' &middot; <a href="/writing/">Writing</a>'
+    '<span class="print"> &middot; '
+    '<a href="#print" onclick="window.print();return false">Print</a></span></p>'
+)
+ESSAY_TO_TOP = '<p class="to-top"><a href="#top">Back to top</a></p>'
+PLACEHOLDERS = (
+    "title",
+    "description",
+    "og_title",
+    "og_description",
+    "og_type",
+    "canonical",
+    "main_attrs",
+    "crumb",
+    "inner",
+    "to_top",
+    "footer",
+    "extra_scripts",
+)
+
+
+def layout_text() -> str:
+    return LAYOUT_PATH.read_text(encoding="utf-8")
+
+
+def _attr(tag: str, name: str) -> str:
+    m = re.search(rf'\b{re.escape(name)}="([^"]*)"', tag)
+    return m.group(1) if m else ""
+
+
+def _head_tag(html: str, pattern: str) -> str:
+    m = re.search(pattern, html)
+    return m.group(0) if m else ""
+
+
+def _title(html: str) -> str:
+    m = re.search(r"<title>(.*?)</title>", html, re.S)
+    return m.group(1) if m else ""
+
+
+def _meta_name(html: str, name: str) -> str:
+    m = re.search(
+        rf'<meta\b[^>]*\bname="{re.escape(name)}"[^>]*>',
+        html,
+    )
+    return _attr(m.group(0), "content") if m else ""
+
+
+def _meta_prop(html: str, prop: str) -> str:
+    m = re.search(
+        rf'<meta\b[^>]*\bproperty="{re.escape(prop)}"[^>]*>',
+        html,
+    )
+    return _attr(m.group(0), "content") if m else ""
+
+
+def _block(text: str) -> str:
+    if not text or not str(text).strip():
+        return ""
+    return str(text).strip("\n") + "\n"
+
+
+def is_writing_index(page: dict) -> bool:
+    inner = page.get("inner", "")
+    if 'id="writing"' in inner:
+        return True
+    path = str(page.get("path") or "").replace("\\", "/")
+    return path.endswith("writing/index.html")
+
+
+def split(html: str) -> dict:
+    main_m = re.search(r"<main([^>]*)>(.*?)</main>", html, re.S)
+    if not main_m:
+        raise ValueError("no <main> in html")
+    main_attrs = main_m.group(1)
+    inner = main_m.group(2)
+
+    crumb = ""
+    crumb_m = re.match(r'\s*(<p class="back"[^>]*>.*?</p>)', inner, re.S)
+    if crumb_m:
+        crumb = crumb_m.group(1)
+        inner = inner[crumb_m.end() :]
+
+    footer = ""
+    foot_m = re.search(r'(\s*<footer class="meta">.*?</footer>)\s*$', inner, re.S)
+    if foot_m:
+        footer = foot_m.group(1).strip("\n") + "\n"
+        inner = inner[: foot_m.start()]
+
+    to_top_m = re.search(r'\s*<p class="to-top">.*?</p>\s*$', inner, re.S)
+    if to_top_m:
+        inner = inner[: to_top_m.start()]
+
+    after = html.split("</main>", 1)[1] if "</main>" in html else ""
+    after = re.sub(r"</body>\s*</html>\s*$", "", after, flags=re.I | re.S)
+    after = re.sub(
+        r'\s*<button\b[^>]*\bid="backToTop"[^>]*>.*?</button>',
+        "",
+        after,
+        flags=re.S,
+    )
+
+    def _keep_script(match: re.Match) -> str:
+        return "" if "backToTop" in match.group(0) else match.group(0)
+
+    after = re.sub(r"\s*<script\b[^>]*>.*?</script>", _keep_script, after, flags=re.S)
+    extra_scripts = after.strip("\n")
+    if extra_scripts.strip():
+        extra_scripts = extra_scripts + "\n"
+    else:
+        extra_scripts = ""
+
+    canon_tag = _head_tag(html, r'<link\b[^>]*\brel="canonical"[^>]*>')
+    canonical = _attr(canon_tag, "href")
+
+    return {
+        "title": _title(html),
+        "description": _meta_name(html, "description"),
+        "og_title": _meta_prop(html, "og:title"),
+        "og_description": _meta_prop(html, "og:description"),
+        "og_type": _meta_prop(html, "og:type"),
+        "canonical": canonical,
+        "main_attrs": main_attrs,
+        "crumb": crumb,
+        "inner": inner,
+        "to_top": "",
+        "footer": footer,
+        "extra_scripts": extra_scripts,
+    }
+
+
+def render(page: dict) -> str:
+    values = {
+        "title": page.get("title", ""),
+        "description": page.get("description", ""),
+        "og_title": page.get("og_title", ""),
+        "og_description": page.get("og_description", ""),
+        "og_type": page.get("og_type", ""),
+        "canonical": page.get("canonical", ""),
+        "main_attrs": page.get("main_attrs", ""),
+        "inner": page.get("inner", ""),
+        "extra_scripts": page.get("extra_scripts", ""),
+    }
+    if is_writing_index(page):
+        crumb = page.get("crumb") or ""
+        values["crumb"] = _block("    " + crumb) if crumb.strip() else ""
+        values["to_top"] = ""
+        values["footer"] = ""
+    else:
+        values["crumb"] = _block("    " + GOLD_CRUMB)
+        values["to_top"] = _block("    " + ESSAY_TO_TOP)
+        values["footer"] = _block(page.get("footer") or "")
+
+    html = layout_text()
+    for key in PLACEHOLDERS:
+        html = html.replace("{{" + key + "}}", values.get(key, ""))
+    leftover = re.findall(r"\{\{[^}]+\}\}", html)
+    if leftover:
+        raise ValueError("leftover placeholders: " + ", ".join(leftover))
+    return html
+
+
+def rebuild(root: Path | None = None) -> list[Path]:
+    base = root or ROOT
+    writing = base / "writing"
+    written: list[Path] = []
+    for path in sorted(writing.rglob("index.html")):
+        page = split(path.read_text(encoding="utf-8"))
+        page["path"] = str(path.relative_to(base))
+        path.write_text(render(page), encoding="utf-8")
+        written.append(path)
+    return written
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--rebuild",
+        action="store_true",
+        help="rewrite writing/**/index.html from the layout template",
+    )
+    args = parser.parse_args(argv)
+    if not args.rebuild:
+        parser.print_help()
+        return 2
+    rebuild()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/writing/45/index.html
+++ b/writing/45/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>45</h1>
 <p class="byline">Published February 13, 2026</p>
 

--- a/writing/addiction-to-being-right-is-rarer-than-you-think/index.html
+++ b/writing/addiction-to-being-right-is-rarer-than-you-think/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>The Addiction to Being Right Is Rarer Than You Think</h1>
 <p class="byline">Published July 24, 2026</p>
 

--- a/writing/agency-dims-as-the-timeframe-collapses/index.html
+++ b/writing/agency-dims-as-the-timeframe-collapses/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>Agency Dims as the Timeframe Collapses</h1>
 <p class="byline">Published August 11, 2026</p>
 

--- a/writing/agent-didnt-get-dumber-chat-got-contaminated/index.html
+++ b/writing/agent-didnt-get-dumber-chat-got-contaminated/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>The Agent Didn&#x27;t Get Dumber. The Chat Got Contaminated</h1>
 <p class="byline">Published July 31, 2026</p>
 

--- a/writing/agent-rail-war-red-herring/index.html
+++ b/writing/agent-rail-war-red-herring/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>The Agent Rail War Is a Red Herring</h1>
 <p class="byline">Published July 8, 2026</p>
 

--- a/writing/agents-plan-b-destroy-data/index.html
+++ b/writing/agents-plan-b-destroy-data/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>Your Agent&#x27;s Plan B Will Destroy Your Data</h1>
 
 

--- a/writing/ai-rerunning-the-nuclear-script/index.html
+++ b/writing/ai-rerunning-the-nuclear-script/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>AI Is Rerunning the Nuclear Script, Not the Part You Think</h1>
 <p class="byline">Published July 24, 2026</p>
 

--- a/writing/ai-writes-code-plan-becomes-work/index.html
+++ b/writing/ai-writes-code-plan-becomes-work/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>When the AI Writes the Code, the Plan Becomes the Work</h1>
 <p class="byline">Published August 11, 2026</p>
 

--- a/writing/anxiety-present-tense-problem/index.html
+++ b/writing/anxiety-present-tense-problem/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>Anxiety Is a Present-Tense Problem</h1>
 <p class="byline">Published July 21, 2026</p>
 

--- a/writing/basb-claude-code-setup/index.html
+++ b/writing/basb-claude-code-setup/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>Building a Second Brain with Claude Code - The Setup</h1>
 <p class="byline">Published March 19, 2026</p>
 

--- a/writing/bottleneck-is-you/index.html
+++ b/writing/bottleneck-is-you/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>The Bottleneck Is You</h1>
 <p class="byline">Published July 19, 2026</p>
 

--- a/writing/build-source-of-truth-before-index/index.html
+++ b/writing/build-source-of-truth-before-index/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>Build the Source of Truth Before the Index</h1>
 <p class="byline">Published August 18, 2026</p>
 

--- a/writing/capacity-is-your-lowest-ceiling/index.html
+++ b/writing/capacity-is-your-lowest-ceiling/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>Capacity Is Your Lowest Ceiling</h1>
 <p class="byline">Published July 11, 2026</p>
 

--- a/writing/career-ceiling-i-was-worried-about-already-existed/index.html
+++ b/writing/career-ceiling-i-was-worried-about-already-existed/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>The Career Ceiling I Was Worried About Already Existed</h1>
 <p class="byline">Published August 14, 2026</p>
 

--- a/writing/certainty-wellbeing-variable/index.html
+++ b/writing/certainty-wellbeing-variable/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>Certainty as a Wellbeing Variable</h1>
 <p class="byline">Published July 3, 2026</p>
 

--- a/writing/cheap-code-expensive-context/index.html
+++ b/writing/cheap-code-expensive-context/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>Cheap Code, Expensive Context</h1>
 <p class="byline">Published July 12, 2026</p>
 

--- a/writing/debug-system-not-prompt/index.html
+++ b/writing/debug-system-not-prompt/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>Debug the System Not the Prompt</h1>
 <p class="byline">Published March 24, 2026</p>
 

--- a/writing/deleting-24k-lines-ai-instructions/index.html
+++ b/writing/deleting-24k-lines-ai-instructions/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>Deleting 24K Lines of AI Instructions</h1>
 <p class="byline">Published March 17, 2026</p>
 

--- a/writing/developers-job-judgment-now/index.html
+++ b/writing/developers-job-judgment-now/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>The Developer&#x27;s Job is Judgment Now</h1>
 <p class="byline">Published February 27, 2026</p>
 

--- a/writing/engineer-the-downside-when-you-cannot-forecast/index.html
+++ b/writing/engineer-the-downside-when-you-cannot-forecast/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>Engineer the Downside When You Cannot Forecast the Upside</h1>
 <p class="byline">Published July 23, 2026</p>
 

--- a/writing/enter-key-problem/index.html
+++ b/writing/enter-key-problem/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>The Enter Key Problem</h1>
 <p class="byline">Published March 19, 2026</p>
 

--- a/writing/governing-delegation-scope-creep/index.html
+++ b/writing/governing-delegation-scope-creep/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>Governing Delegation - Using Architecture to Stop AI Scope Creep</h1>
 <p class="byline">Published July 3, 2026</p>
 

--- a/writing/half-agent-infrastructure-depreciating-asset-20260802/index.html
+++ b/writing/half-agent-infrastructure-depreciating-asset-20260802/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>Half of Your Agent Infrastructure Is a Depreciating Asset</h1>
 <p class="byline">Published August 2, 2026. This is the original version published on that date. The current version is at [half-agent-infrastructure-depreciating-asset](https://ngpestelos.com/writing/half-agent-infrastructure-depreciating-asset/).</p>
 

--- a/writing/half-agent-infrastructure-depreciating-asset/index.html
+++ b/writing/half-agent-infrastructure-depreciating-asset/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>Half of Your Agent Infrastructure Is a Depreciating Asset</h1>
 <p class="byline">Published August 2, 2026. Revised September 2, 2026.</p>
 

--- a/writing/havent-written-a-test-in-a-year/index.html
+++ b/writing/havent-written-a-test-in-a-year/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>I Haven&#x27;t Written a Test in a Year</h1>
 <p class="byline">Published July 20, 2026</p>
 

--- a/writing/instapay-is-not-ach/index.html
+++ b/writing/instapay-is-not-ach/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>InstaPay Is Not ACH</h1>
 <p class="byline">Published August 18, 2026</p>
 

--- a/writing/juanito-p-galvez-1928-2022/index.html
+++ b/writing/juanito-p-galvez-1928-2022/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>Juanito P. Galvez (1928–2022)</h1>
     <p class="byline">Published October 26, 2022</p>
 

--- a/writing/ledger-that-stayed-empty/index.html
+++ b/writing/ledger-that-stayed-empty/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>The Ledger That Stayed Empty</h1>
 <p class="byline">Published August 14, 2026</p>
 

--- a/writing/meat-proxy-problem-20260819/index.html
+++ b/writing/meat-proxy-problem-20260819/index.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>20260819 The Meat Proxy Problem — Nestor G Pestelos Jr</title>
-  <meta name="description" content="Forwarding an AI's answer unread, with nothing else checking the claim, severs accountability. Telling people to "just validate it" will not fix that. Review culture already rubber-stamps real code. The fix has to survive the same incentives.">
+  <meta name="description" content="Forwarding an AI's answer unread, with nothing else checking the claim, severs accountability. Telling people to ">
   <meta property="og:title" content="20260819 The Meat Proxy Problem">
-  <meta property="og:description" content="Forwarding an AI's answer unread, with nothing else checking the claim, severs accountability. Telling people to "just validate it" will not fix that. Review culture already rubber-stamps real code. The fix has to survive the same incentives.">
+  <meta property="og:description" content="Forwarding an AI's answer unread, with nothing else checking the claim, severs accountability. Telling people to ">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://ngpestelos.com/writing/meat-proxy-problem-20260819/">
   <link rel="canonical" href="https://ngpestelos.com/writing/meat-proxy-problem-20260819/">

--- a/writing/meat-proxy-problem-20260819/index.html
+++ b/writing/meat-proxy-problem-20260819/index.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>20260819 The Meat Proxy Problem — Nestor G Pestelos Jr</title>
-  <meta name="description" content="Forwarding an AI's answer unread, with nothing else checking the claim, severs accountability. Telling people to ">
+  <meta name="description" content="Forwarding an AI's answer unread, with nothing else checking the claim, severs accountability. Telling people to &quot;just validate it&quot; will not fix that. Review culture already rubber-stamps real code. The fix has to survive the same incentives.">
   <meta property="og:title" content="20260819 The Meat Proxy Problem">
-  <meta property="og:description" content="Forwarding an AI's answer unread, with nothing else checking the claim, severs accountability. Telling people to ">
+  <meta property="og:description" content="Forwarding an AI's answer unread, with nothing else checking the claim, severs accountability. Telling people to &quot;just validate it&quot; will not fix that. Review culture already rubber-stamps real code. The fix has to survive the same incentives.">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://ngpestelos.com/writing/meat-proxy-problem-20260819/">
   <link rel="canonical" href="https://ngpestelos.com/writing/meat-proxy-problem-20260819/">

--- a/writing/meat-proxy-problem/index.html
+++ b/writing/meat-proxy-problem/index.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>The Meat Proxy Problem — Nestor G Pestelos Jr</title>
-  <meta name="description" content="Forwarding an AI's answer unread, with nothing else checking the claim, severs accountability. Telling people to ">
+  <meta name="description" content="Forwarding an AI's answer unread, with nothing else checking the claim, severs accountability. Telling people to &quot;just validate it&quot; will not fix that. Review culture already rubber-stamps real code. The fix has to survive the same incentives.">
   <meta property="og:title" content="The Meat Proxy Problem">
-  <meta property="og:description" content="Forwarding an AI's answer unread, with nothing else checking the claim, severs accountability. Telling people to ">
+  <meta property="og:description" content="Forwarding an AI's answer unread, with nothing else checking the claim, severs accountability. Telling people to &quot;just validate it&quot; will not fix that. Review culture already rubber-stamps real code. The fix has to survive the same incentives.">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://ngpestelos.com/writing/meat-proxy-problem/">
   <link rel="canonical" href="https://ngpestelos.com/writing/meat-proxy-problem/">

--- a/writing/meat-proxy-problem/index.html
+++ b/writing/meat-proxy-problem/index.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>The Meat Proxy Problem — Nestor G Pestelos Jr</title>
-  <meta name="description" content="Forwarding an AI's answer unread, with nothing else checking the claim, severs accountability. Telling people to "just validate it" will not fix that. Review culture already rubber-stamps real code. The fix has to survive the same incentives.">
+  <meta name="description" content="Forwarding an AI's answer unread, with nothing else checking the claim, severs accountability. Telling people to ">
   <meta property="og:title" content="The Meat Proxy Problem">
-  <meta property="og:description" content="Forwarding an AI's answer unread, with nothing else checking the claim, severs accountability. Telling people to "just validate it" will not fix that. Review culture already rubber-stamps real code. The fix has to survive the same incentives.">
+  <meta property="og:description" content="Forwarding an AI's answer unread, with nothing else checking the claim, severs accountability. Telling people to ">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://ngpestelos.com/writing/meat-proxy-problem/">
   <link rel="canonical" href="https://ngpestelos.com/writing/meat-proxy-problem/">

--- a/writing/metric-already-happened-upstream/index.html
+++ b/writing/metric-already-happened-upstream/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>The Metric You&#x27;re Watching Already Happened Upstream</h1>
 <p class="byline">Published August 15, 2026</p>
 

--- a/writing/most-expensive-avoidance-looks-like-prudence/index.html
+++ b/writing/most-expensive-avoidance-looks-like-prudence/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>The Most Expensive Avoidance Looks Exactly Like Prudence</h1>
 <p class="byline">Published July 28, 2026</p>
 

--- a/writing/new-art-learning/index.html
+++ b/writing/new-art-learning/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>The New Art of Learning</h1>
 <p class="byline">Published March 8, 2026</p>
 

--- a/writing/nine-security-issues-zero-lines-i-wrote/index.html
+++ b/writing/nine-security-issues-zero-lines-i-wrote/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>Nine Security Issues, Zero Lines I Wrote</h1>
 <p class="byline">Published August 12, 2026</p>
 

--- a/writing/orchestrator-identity/index.html
+++ b/writing/orchestrator-identity/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>The Orchestrator Identity</h1>
 <p class="byline">Published July 24, 2026</p>
 

--- a/writing/parallelizing-sftp-downloads-ruby/index.html
+++ b/writing/parallelizing-sftp-downloads-ruby/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>Parallelizing SFTP Downloads in Ruby</h1>
 <p class="byline">Published February 8, 2026</p>
 

--- a/writing/pattern-capture-auto-activating-skill-library/index.html
+++ b/writing/pattern-capture-auto-activating-skill-library/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>Pattern Capture - How I Built an Auto-Activating Skill Library</h1>
 <p class="byline">Published July 10, 2026</p>
 

--- a/writing/payments-glossary/index.html
+++ b/writing/payments-glossary/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>Payments Glossary</h1>
 <p class="byline">Published August 18, 2026</p>
 

--- a/writing/pkm-bottleneck-was-never-capture/index.html
+++ b/writing/pkm-bottleneck-was-never-capture/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>The PKM Bottleneck Was Never Capture</h1>
 
 <p class="series">Personal knowledge management across 8 tools and 20 years (published March 24, 2026)</p>

--- a/writing/polish-is-free-thinking-isnt/index.html
+++ b/writing/polish-is-free-thinking-isnt/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>Polish Is Free. Thinking Isn&#x27;t</h1>
 <p class="byline">Published July 11, 2026</p>
 

--- a/writing/positioning-demotes-prediction/index.html
+++ b/writing/positioning-demotes-prediction/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>Positioning Doesn&#x27;t Escape Prediction, It Demotes It</h1>
 <p class="byline">Published August 14, 2026</p>
 

--- a/writing/run-dead-internet-on-purpose/index.html
+++ b/writing/run-dead-internet-on-purpose/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>I Run a Dead Internet on Purpose</h1>
 <p class="byline">Published July 26, 2026</p>
 

--- a/writing/same-tunnel-ships-work-drops-room/index.html
+++ b/writing/same-tunnel-ships-work-drops-room/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>The Same Tunnel That Ships the Work Drops the Room</h1>
 <p class="byline">Published July 31, 2026</p>
 

--- a/writing/scanner-that-feeds-pipeline/index.html
+++ b/writing/scanner-that-feeds-pipeline/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>The Scanner That Feeds the Pipeline</h1>
 <p class="byline">Published August 13, 2026</p>
 

--- a/writing/second-brain-fails-you/index.html
+++ b/writing/second-brain-fails-you/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>The Moment Your Second Brain Fails You</h1>
 
 

--- a/writing/selection-beats-execution-when-games-differ/index.html
+++ b/writing/selection-beats-execution-when-games-differ/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>Selection Beats Execution Only When the Games Differ</h1>
 <p class="byline">Published July 23, 2026</p>
 

--- a/writing/tell-me-whats-wrong-with-it-isnt-review/index.html
+++ b/writing/tell-me-whats-wrong-with-it-isnt-review/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>&#x27;Tell Me What&#x27;s Wrong With It&#x27; Isn&#x27;t a Review</h1>
 <p class="byline">Published July 13, 2026</p>
 

--- a/writing/the-bugs-that-hide-between-your-agents/index.html
+++ b/writing/the-bugs-that-hide-between-your-agents/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>The Bugs That Hide Between Your Agents</h1>
 <p class="byline">Published July 8, 2026</p>
 

--- a/writing/the-employee-you-cant-stop-managing/index.html
+++ b/writing/the-employee-you-cant-stop-managing/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>The Employee You Can&#x27;t Stop Managing</h1>
 <p class="byline">Published August 21, 2026</p>
 

--- a/writing/triage-system-not-your-toolbox/index.html
+++ b/writing/triage-system-not-your-toolbox/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>Triage the System Not Your Toolbox</h1>
 <p class="byline">Published July 23, 2026</p>
 

--- a/writing/triffins-dilemma-escape-doesnt-work/index.html
+++ b/writing/triffins-dilemma-escape-doesnt-work/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>The Only Concrete Escape From Triffin&#x27;s Dilemma Doesn&#x27;t Work</h1>
 <p class="byline">Published August 14, 2026</p>
 

--- a/writing/urgency-conscientiousness-better-marketing/index.html
+++ b/writing/urgency-conscientiousness-better-marketing/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>Urgency Is Just Conscientiousness With Better Marketing</h1>
 <p class="byline">Published July 28, 2026</p>
 

--- a/writing/us-and-philippine-payment-rails/index.html
+++ b/writing/us-and-philippine-payment-rails/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>US and Philippine Payment Rails</h1>
 <p class="byline">Published August 18, 2026</p>
 

--- a/writing/what-actually-buys-you-the-power-to-say-no/index.html
+++ b/writing/what-actually-buys-you-the-power-to-say-no/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>What Actually Buys You the Power to Say No</h1>
 <p class="byline">Published August 21, 2026</p>
 

--- a/writing/when-your-mcp-server-breaks/index.html
+++ b/writing/when-your-mcp-server-breaks/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>When Your MCP Server Breaks</h1>
 
 

--- a/writing/your-living-spec-is-still-lying/index.html
+++ b/writing/your-living-spec-is-still-lying/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>Your Living Spec Is Still Lying</h1>
 <p class="byline">Published July 14, 2026</p>
 

--- a/writing/your-review-checklist-has-never-been-reviewed/index.html
+++ b/writing/your-review-checklist-has-never-been-reviewed/index.html
@@ -27,7 +27,7 @@
 </head>
 <body>
   <main class="article">
-    <p class="back" id="top"><a href="/writing/">← Writing</a> · <a href="/">Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
     <h1>Your Review Checklist Has Never Been Reviewed</h1>
 <p class="byline">Published July 14, 2026</p>
 


### PR DESCRIPTION
Closes #3

Writing chrome (head, crumb, CSS `?v=`, GA, back-to-top) now lives in `scripts/writing-layout.html`. `python3 scripts/writing_layout.py --rebuild` wraps existing essay bodies without re-parsing markdown.

Visual CSS is unchanged. Essays keep `main.article` and the gold crumb. `/writing/` keeps the list and knock path.

Follow-up (other repo): `md_to_essay.py` still embeds its own shell. New publishes should run `--rebuild` until the converter reads this template.
