### PR TITLE
Replace homepage tagline with an about line

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <title>Nestor G Pestelos Jr — Senior Software Engineer</title>
   <meta name="description" content="Senior software engineer. 25 years shipping production software. Rails modernization, payments, agents in the loop with a human gate.">
   <meta property="og:title" content="Nestor G Pestelos Jr — Senior Software Engineer">
-  <meta property="og:description" content="I ship production software with agents in the loop and a human gate. Rails is the public proof.">
+  <meta property="og:description" content="I ship production software with agents in the loop and a human gate: agents write the code, I decide what ships. Rails is the public proof.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://ngpestelos.com">
   <link rel="canonical" href="https://ngpestelos.com/">
@@ -34,9 +34,9 @@
   <main>
     <header>
       <h1>Nestor G Pestelos Jr</h1>
-      <p class="tagline">Senior Software Engineer &middot; Product Development &amp; Platform Reliability</p>
+      <p class="tagline">25 years shipping production software, most of it leading remote teams across time zones. Manila, UTC+8. BS Computer Science, University of the Philippines.</p>
       <p class="header-links"><a href="mailto:nestor@pestelos.net">nestor@pestelos.net</a> &middot; <a href="https://github.com/ngpestelos">GitHub</a> &middot; <a href="https://www.linkedin.com/in/ngpestelos/">LinkedIn</a> &middot; <a href="https://x.com/ngpestelos">X</a> &middot; <a href="https://calendly.com/ngpestelos/25min">Calendly</a> &middot; <a href="https://162381607157.gumroad.com/l/rails-readiness-read">Gumroad</a> &middot; <a href="/writing/">Writing</a> &middot; <a href="/eli5/">ELI5</a> &middot; <a href="/trees/">Trees</a> &middot; <a href="/reference/">Reference</a></p>
-      <p class="positioning">I ship production software with agents in the loop and a human gate. <a href="https://rubyonrails.org">Rails</a> is the public proof.</p>
+      <p class="positioning">I ship production software with agents in the loop and a human gate: agents write the code, I decide what ships. <a href="https://rubyonrails.org">Rails</a> is the public proof.</p>
       <p class="writing-pins">Start here: <a href="/writing/meat-proxy-problem/">The Meat Proxy Problem</a> · <a href="/writing/instapay-is-not-ach/">InstaPay Is Not ACH</a> · <a href="/writing/five-checks-against-motivated-reasoning/">Five Checks Against Motivated Reasoning</a>. <a href="/writing/">All writing</a>.</p>
       <p class="next-step">If you have a production system you need to understand, especially old Rails or wiring agents into a real codebase, <a href="mailto:nestor@pestelos.net?subject=About%20the%20codebase%20(homepage)&amp;body=What%20does%20the%20product%20do%2C%20and%20who%20uses%20it%3F%0A%0AWhat%20prompted%20you%20to%20look%20at%20this%20now%3F%0A%0AStack%20and%20versions%20%28language%2C%20framework%2C%20database%2C%20hosting%2C%20agents%20if%20any%29%3A%0A">write me</a>. Three questions is enough. Or <a href="https://calendly.com/ngpestelos/25min">book 25 minutes</a>. <a href="/samples/ninthgreen/">Sample of a written read</a>.</p>
     </header>


### PR DESCRIPTION
Replace the job-title tagline with one about line, and add an example to the positioning line.

- Tagline: 25 years, remote time zones, Manila UTC+8, UP CS
- Positioning: agents write the code, I decide what ships
- `og:description` matches the new positioning sentence (plain text)
- `<title>` and `meta description` unchanged

`style.css` and `/writing/` untouched.

Closes #8
