### PR TITLE
Landing: plain positioning line, InstaPay hook, door order, stubs out of the index

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,12 +41,12 @@
         <h2>Writing</h2>
         <ul class="pins">
           <li><a href="/writing/meat-proxy-problem/">The Meat Proxy Problem</a>. <span class="hook">Forwarding an AI's answer unread, with nothing else checking the claim, severs accountability.</span></li>
-          <li><a href="/writing/instapay-is-not-ach/">InstaPay Is Not ACH</a>. <span class="hook">BSP calls InstaPay an ACH.</span></li>
+          <li><a href="/writing/instapay-is-not-ach/">InstaPay Is Not ACH</a>. <span class="hook">BSP calls InstaPay an ACH, but the word is a local label for a retail scheme, not Nacha's batch network.</span></li>
           <li><a href="/writing/five-checks-against-motivated-reasoning/">Five Checks Against Motivated Reasoning</a>. <span class="hook">Wanting a thing to be true and it actually being true feel identical from the inside.</span></li>
         </ul>
         <p class="writing-more"><a href="/writing/">All writing</a> &middot; <a href="/eli5/">ELI5</a> &middot; <a href="/trees/">Trees</a> &middot; <a href="/reference/">Reference</a></p>
       </section>
-      <p class="next-step">If you have a production system you need to understand, especially old Rails or wiring agents into a real codebase, <a href="mailto:nestor@pestelos.net?subject=About%20the%20codebase%20(homepage)&amp;body=What%20does%20the%20product%20do%2C%20and%20who%20uses%20it%3F%0A%0AWhat%20prompted%20you%20to%20look%20at%20this%20now%3F%0A%0AStack%20and%20versions%20%28language%2C%20framework%2C%20database%2C%20hosting%2C%20agents%20if%20any%29%3A%0A">write me</a>. UTC+8 provides overnight coverage for US teams. Three questions is enough. Or <a href="https://calendly.com/ngpestelos/25min">book 25 minutes</a>. <a href="/samples/ninthgreen/">Sample of a written read</a>.</p>
+      <p class="next-step">If you have a production system you need to understand, especially old Rails or wiring agents into a real codebase, <a href="mailto:nestor@pestelos.net?subject=About%20the%20codebase%20(homepage)&amp;body=What%20does%20the%20product%20do%2C%20and%20who%20uses%20it%3F%0A%0AWhat%20prompted%20you%20to%20look%20at%20this%20now%3F%0A%0AStack%20and%20versions%20%28language%2C%20framework%2C%20database%2C%20hosting%2C%20agents%20if%20any%29%3A%0A">write me</a>. Three questions is enough. Or <a href="https://calendly.com/ngpestelos/25min">book 25 minutes</a>. <a href="/samples/ninthgreen/">Sample of a written read</a>. I work from Manila, UTC+8, so US teams get overnight coverage.</p>
     </header>
 
     <section id="my-work">

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <title>Nestor G Pestelos Jr — Senior Software Engineer</title>
   <meta name="description" content="Software engineer since 2001. Rails modernization, payments, agents in the loop with a human gate.">
   <meta property="og:title" content="Nestor G Pestelos Jr — Senior Software Engineer">
-  <meta property="og:description" content="I ship production software with agents in the loop and a human gate: agents write the code, I decide what ships. Rails is the public proof.">
+  <meta property="og:description" content="I maintain production Rails systems. These days agents write much of the code, and I review every change before it goes out.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://ngpestelos.com">
   <link rel="canonical" href="https://ngpestelos.com/">
@@ -36,7 +36,7 @@
       <h1>Nestor G Pestelos Jr</h1>
       <p class="tagline">Software engineer since 2001. Manila, UTC+8.</p>
       <p class="header-links"><a href="mailto:nestor@pestelos.net">nestor@pestelos.net</a> &middot; <a href="https://github.com/ngpestelos">GitHub</a> &middot; <a href="https://www.linkedin.com/in/ngpestelos/">LinkedIn</a> &middot; <a href="https://x.com/ngpestelos">X</a> &middot; <a href="https://calendly.com/ngpestelos/25min">Calendly</a> &middot; <a href="/writing/">Writing</a></p>
-      <p class="positioning">I ship production software with agents in the loop and a human gate: agents write the code, I decide what ships. <a href="https://rubyonrails.org">Rails</a> is the public proof.</p>
+      <p class="positioning">I maintain <a href="/writing/#systems">production Rails systems</a>. These days agents write much of the code, and I review every change before it goes out.</p>
       <section id="writing-pins">
         <h2>Writing</h2>
         <ul class="pins">

--- a/scripts/test_site_discoverability.py
+++ b/scripts/test_site_discoverability.py
@@ -117,11 +117,11 @@ class SiteDiscoverabilityTests(unittest.TestCase):
         self.assertIn("written readiness read", html)
         self.assertIn("Software engineer since 2001. Manila, UTC+8.", html)
         next_step = re.search(r'<p class="next-step">.*?</p>', html, re.S).group(0)
-        self.assertIn("UTC+8 provides overnight coverage for US teams", next_step)
+        self.assertIn("I work from Manila, UTC+8, so US teams get overnight coverage.", next_step)
         my_work = html.split('<section id="my-work">', 1)[1].split(
             '<section id="personal">', 1
         )[0]
-        self.assertNotIn("UTC+8 provides overnight coverage for US teams", my_work)
+        self.assertNotIn("overnight coverage", my_work)
         self.assertIn('<section id="my-work">', html)
         self.assertIn("<h2>My Work</h2>", html)
         self.assertIn("<h3>What I Do</h3>", html)

--- a/scripts/writing-catalog.json
+++ b/scripts/writing-catalog.json
@@ -404,19 +404,5 @@
     "date": "2022-10-26",
     "bucket": "essays",
     "pin": null
-  },
-  {
-    "slug": "legacy-rails-upgrade-with-agents",
-    "title": "A Legacy Rails Upgrade With Agents Under a Human Gate",
-    "date": "2026-09-03",
-    "bucket": "systems",
-    "pin": null
-  },
-  {
-    "slug": "upgrade-or-rewrite",
-    "title": "Upgrade or Rewrite",
-    "date": "2026-09-03",
-    "bucket": "systems",
-    "pin": null
   }
 ]

--- a/writing/atom.xml
+++ b/writing/atom.xml
@@ -4,22 +4,10 @@
   <link rel="self" href="https://ngpestelos.com/writing/atom.xml"/>
   <link href="https://ngpestelos.com/writing/"/>
   <id>https://ngpestelos.com/writing/</id>
-  <updated>2026-09-03T00:38:48Z</updated>
+  <updated>2026-09-03T02:45:43Z</updated>
   <author>
     <name>Nestor G Pestelos Jr</name>
   </author>
-  <entry>
-    <id>https://ngpestelos.com/writing/legacy-rails-upgrade-with-agents/</id>
-    <title>A Legacy Rails Upgrade With Agents Under a Human Gate</title>
-    <updated>2026-09-03T00:00:00+08:00</updated>
-    <link href="https://ngpestelos.com/writing/legacy-rails-upgrade-with-agents/"/>
-  </entry>
-  <entry>
-    <id>https://ngpestelos.com/writing/upgrade-or-rewrite/</id>
-    <title>Upgrade or Rewrite</title>
-    <updated>2026-09-03T00:00:00+08:00</updated>
-    <link href="https://ngpestelos.com/writing/upgrade-or-rewrite/"/>
-  </entry>
   <entry>
     <id>https://ngpestelos.com/writing/five-checks-against-motivated-reasoning/</id>
     <title>Five Checks Against Motivated Reasoning</title>

--- a/writing/index.html
+++ b/writing/index.html
@@ -43,8 +43,6 @@
           <li class="pin"><a href="/writing/ai-writes-code-plan-becomes-work/">When the AI Writes the Code, the Plan Becomes the Work</a> <time datetime="2026-08-11">11 Aug 2026</time></li>
           <li class="pin"><a href="/writing/nine-security-issues-zero-lines-i-wrote/">Nine Security Issues, Zero Lines I Wrote</a> <time datetime="2026-08-12">12 Aug 2026</time></li>
           <li class="pin"><a href="/writing/agents-plan-b-destroy-data/">Your Agent&#x27;s Plan B Will Destroy Your Data</a> <time datetime="2026-03-25">25 Mar 2026</time></li>
-          <li><a href="/writing/legacy-rails-upgrade-with-agents/">A Legacy Rails Upgrade With Agents Under a Human Gate</a> <time datetime="2026-09-03">3 Sep 2026</time></li>
-          <li><a href="/writing/upgrade-or-rewrite/">Upgrade or Rewrite</a> <time datetime="2026-09-03">3 Sep 2026</time></li>
           <li><a href="/writing/build-source-of-truth-before-index/">Build the Source of Truth Before the Index</a> <time datetime="2026-08-18">18 Aug 2026</time></li>
           <li><a href="/writing/ledger-that-stayed-empty/">The Ledger That Stayed Empty</a> <time datetime="2026-08-14">14 Aug 2026</time></li>
           <li><a href="/writing/scanner-that-feeds-pipeline/">The Scanner That Feeds the Pipeline</a> <time datetime="2026-08-13">13 Aug 2026</time></li>


### PR DESCRIPTION
## Summary

Four small landing fixes decided with the owner on 20260903, after the second pass over the live site.

- **Positioning line**: `I maintain production Rails systems. These days agents write much of the code, and I review every change before it goes out.` The link now points at `/writing/#systems`, not rubyonrails.org. `og:description` mirrors it. No slogan, no colon gloss, no "proof."
- **InstaPay hook** carries the claim instead of the first sentence of the meta description, which read as a contradiction of the title.
- **Door line** ends on the time-zone sentence instead of interrupting the ask. Mailto href byte-identical. Two test strings updated to match.
- **Stub pages** (162-word deep dive, 75-word comparison page) held out of the writing index and Atom feed until they are written. Pages stay published and stay in the sitemap through `PROOF_SLUGS`. Catalog 60 → 58, feed 58 entries.

## Verification

At `452fe4dd`, from the worktree:

```
python3 scripts/test_writing_layout.py        → Ran 9 tests, OK
python3 scripts/test_site_discoverability.py  → Ran 8 tests, OK
grep -c '<entry>' writing/atom.xml            → 58
git diff master...HEAD | grep '^+' | grep -c '—' → 0
```

Pipeline run `20260903-landing-small-fixes`. Preview URL from Cloudflare Pages will be checked in the review comment.

Related: #16, #17 untouched. Stub fill is tracked in PARA W22.41 / W42.78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
