### PR TITLE
docs: add Big Design Up Front reference page

### DIFF
--- a/reference/big-design-up-front/index.html
+++ b/reference/big-design-up-front/index.html
@@ -1,0 +1,345 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Big Design Up Front · Reference · Nestor G Pestelos Jr</title>
+  <meta name="description" content="Big Design Up Front (BDUF) is a software development approach where architecture and specifications are completed before coding. Context, critique, and modern synthesis.">
+  <meta property="og:title" content="Big Design Up Front · Reference">
+  <meta property="og:description" content="Definition, cost-of-change curve premise, agile critiques, evolutionary design, and contemporary planning models.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://ngpestelos.com/reference/big-design-up-front/">
+  <link rel="canonical" href="https://ngpestelos.com/reference/big-design-up-front/">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=20260813f">
+  <link rel="icon" href="/favicon-192.png?v=20260813f" type="image/png" sizes="192x192">
+  <link rel="icon" href="/favicon-32.png?v=20260813f" type="image/png" sizes="32x32">
+  <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
+  <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="stylesheet" href="/style.css?v=20260903e">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TLBY8P4GG9');
+  </script>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
+    body {
+      line-height: 1.6;
+    }
+    main {
+      max-width: 46rem;
+      margin: 0 auto;
+      padding: 1.4rem 1.4rem 4rem;
+    }
+    .back {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .back a { color: var(--link); text-decoration: none; }
+    .back a:hover { text-decoration: underline; }
+    .kicker {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.78rem;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--mute);
+      margin-bottom: 0.3rem;
+    }
+    h1 {
+      font-size: clamp(1.9rem, 5vw, 2.4rem);
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.4rem;
+      margin-bottom: 1rem;
+    }
+    .updated {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.82rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .lede { margin-bottom: 1.6rem; }
+    .lede strong:first-child { font-weight: 700; }
+    .toc {
+      background: var(--well);
+      border: 1px solid var(--line);
+      border-radius: 4px;
+      padding: 1rem 1.4rem;
+      margin-bottom: 2rem;
+      max-width: 24rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.92rem;
+    }
+    .toc .toc-title {
+      font-weight: 700;
+      margin-bottom: 0.5rem;
+      text-align: center;
+    }
+    .toc ol { padding-left: 1.3rem; }
+    .toc li { margin: 0.2rem 0; }
+    .toc a { color: var(--link); text-decoration: none; }
+    .toc a:hover { text-decoration: underline; }
+    h2 {
+      font-size: 1.5rem;
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.3rem;
+      margin: 2rem 0 0.9rem;
+    }
+    p { margin-bottom: 0.9rem; }
+    a { color: var(--link); }
+    a:visited { color: var(--link-visited); }
+    code {
+      font-family: "SF Mono", Consolas, Monaco, monospace;
+      font-size: 0.9em;
+      background: var(--well);
+      padding: 0.1em 0.35em;
+      border-radius: 3px;
+    }
+    .cite {
+      font-size: 0.75em;
+      vertical-align: super;
+      line-height: 0;
+      text-decoration: none;
+    }
+    .cite a { text-decoration: none; }
+    #see-also ul, #references ol {
+      padding-left: 1.5rem;
+    }
+    #see-also li, #references li { margin-bottom: 0.5rem; }
+    #references { font-size: 0.95rem; }
+    #references .backlink { margin-right: 0.3rem; }
+    .diagram-box {
+      background: var(--well);
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      padding: 1.2rem;
+      margin: 1.4rem 0;
+      text-align: center;
+    }
+    .diagram-box svg {
+      max-width: 100%;
+      height: auto;
+    }
+    footer.meta {
+      margin-top: 3rem;
+      padding-top: 1.2rem;
+      border-top: 1px solid var(--line);
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+    }
+    footer.meta a { color: var(--link); }
+    @media print {
+      .back { font-family: "Segoe UI", Helvetica, Arial, sans-serif; display: none; }
+    }
+    .back-to-top {
+      position: fixed;
+      bottom: 1.5rem;
+      right: 1.5rem;
+      width: 2.6rem;
+      height: 2.6rem;
+      border-radius: 50%;
+      background: var(--bg);
+      color: var(--ink);
+      border: 1px solid var(--line);
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      opacity: 0;
+      visibility: hidden;
+      transform: translateY(8px);
+      transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease, background 0.15s ease, border-color 0.15s ease;
+      z-index: 100;
+    }
+    .back-to-top.visible {
+      opacity: 1;
+      visibility: visible;
+      transform: translateY(0);
+    }
+    .back-to-top:hover {
+      background: var(--well);
+      border-color: var(--link);
+      color: var(--link);
+    }
+    .back-to-top:focus-visible {
+      outline: 2px solid var(--link);
+      outline-offset: 2px;
+    }
+    @media print {
+      .back-to-top { display: none !important; }
+    }
+  </style>
+</head>
+<body class="reference">
+  <main id="top">
+    <p class="back"><a href="/reference/">← Reference</a> · <a href="/">Nestor G Pestelos Jr</a> · <a href="#" onclick="window.print(); return false;">Print this page</a></p>
+    <p class="kicker">Software Architecture · Methodology</p>
+    <h1>Big Design Up Front</h1>
+    <p class="updated">Reference entry · last updated September 3, 2026</p>
+
+    <p class="lede" id="lede"><strong>Big Design Up Front</strong> (<strong>BDUF</strong>) is a software development approach in which system architecture, detailed design, and technical specifications are completed and frozen before programming begins.<span class="cite">[<a href="#ref1">1</a>]</span> The term originated within the Extreme Programming and Agile software movements as a critique of predictive sequential lifecycles.<span class="cite">[<a href="#ref2">2</a>]</span></p>
+
+    <div class="diagram-box">
+      <svg viewBox="0 0 650 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="BDUF versus Evolutionary Design Comparison">
+        <!-- BDUF Track Header -->
+        <text x="15" y="24" font-family="-apple-system, sans-serif" font-size="12" font-weight="bold" fill="#9a3412">Sequential Model (BDUF)</text>
+
+        <!-- BDUF Phase 1 -->
+        <rect x="15" y="36" width="130" height="50" rx="5" fill="#f8f9fa" stroke="#9a3412" stroke-width="1.5"/>
+        <text x="80" y="58" font-family="-apple-system, sans-serif" font-size="11" font-weight="bold" fill="#9a3412" text-anchor="middle">1. Full Spec</text>
+        <text x="80" y="74" font-family="-apple-system, sans-serif" font-size="9.5" fill="#54595d" text-anchor="middle">Exhaustive scope</text>
+
+        <path d="M 145 61 L 175 61" stroke="#54595d" stroke-width="1.5"/>
+
+        <!-- BDUF Phase 2 -->
+        <rect x="175" y="36" width="130" height="50" rx="5" fill="#f8f9fa" stroke="#9a3412" stroke-width="1.5"/>
+        <text x="240" y="58" font-family="-apple-system, sans-serif" font-size="11" font-weight="bold" fill="#9a3412" text-anchor="middle">2. Architecture</text>
+        <text x="240" y="74" font-family="-apple-system, sans-serif" font-size="9.5" fill="#54595d" text-anchor="middle">Schema &amp; interfaces</text>
+
+        <path d="M 305 61 L 335 61" stroke="#54595d" stroke-width="1.5"/>
+
+        <!-- BDUF Gate -->
+        <rect x="335" y="32" width="125" height="58" rx="6" fill="#fffaf3" stroke="#9a3412" stroke-width="2"/>
+        <text x="397" y="56" font-family="-apple-system, sans-serif" font-size="11" font-weight="bold" fill="#9a3412" text-anchor="middle">Sign-Off Gate</text>
+        <text x="397" y="74" font-family="-apple-system, sans-serif" font-size="9.5" fill="#54595d" text-anchor="middle">Frozen blueprint</text>
+
+        <path d="M 460 61 L 490 61" stroke="#54595d" stroke-width="1.5"/>
+
+        <!-- BDUF Phase 3 -->
+        <rect x="490" y="36" width="145" height="50" rx="5" fill="#f8f9fa" stroke="#54595d" stroke-width="1.5"/>
+        <text x="562" y="58" font-family="-apple-system, sans-serif" font-size="11" font-weight="bold" fill="#202122" text-anchor="middle">3. Implementation</text>
+        <text x="562" y="74" font-family="-apple-system, sans-serif" font-size="9.5" fill="#54595d" text-anchor="middle">Delayed test feedback</text>
+
+        <!-- Divider -->
+        <line x1="15" y1="108" x2="635" y2="108" stroke="#a2a9b1" stroke-dasharray="3 3"/>
+
+        <!-- Evolutionary Track Header -->
+        <text x="15" y="128" font-family="-apple-system, sans-serif" font-size="12" font-weight="bold" fill="#166534">Evolutionary Model (Iterative)</text>
+
+        <!-- Iterative Loop Node 1 -->
+        <rect x="15" y="138" width="180" height="50" rx="5" fill="#f8f9fa" stroke="#166534" stroke-width="1.5"/>
+        <text x="105" y="159" font-family="-apple-system, sans-serif" font-size="11" font-weight="bold" fill="#166534" text-anchor="middle">Intent &amp; Thin Spec</text>
+        <text x="105" y="175" font-family="-apple-system, sans-serif" font-size="9.5" fill="#54595d" text-anchor="middle">Core decisions &amp; ADRs</text>
+
+        <path d="M 195 163 L 235 163" stroke="#166534" stroke-width="1.5"/>
+
+        <!-- Iterative Loop Node 2 -->
+        <rect x="235" y="138" width="180" height="50" rx="5" fill="#f8f9fa" stroke="#166534" stroke-width="1.5"/>
+        <text x="325" y="159" font-family="-apple-system, sans-serif" font-size="11" font-weight="bold" fill="#166534" text-anchor="middle">Build &amp; Automated Tests</text>
+        <text x="325" y="175" font-family="-apple-system, sans-serif" font-size="9.5" fill="#54595d" text-anchor="middle">Executable verification</text>
+
+        <path d="M 415 163 L 455 163" stroke="#166534" stroke-width="1.5"/>
+
+        <!-- Iterative Loop Node 3 -->
+        <rect x="455" y="138" width="180" height="50" rx="5" fill="#f8f9fa" stroke="#166534" stroke-width="1.5"/>
+        <text x="545" y="159" font-family="-apple-system, sans-serif" font-size="11" font-weight="bold" fill="#166534" text-anchor="middle">Refactor &amp; Adapt</text>
+        <text x="545" y="175" font-family="-apple-system, sans-serif" font-size="9.5" fill="#54595d" text-anchor="middle">Fast feedback loop</text>
+
+        <!-- Feedback arrow -->
+        <path d="M 545 138 C 545 118, 105 118, 105 138" fill="none" stroke="#166534" stroke-width="1.5" stroke-dasharray="4 2"/>
+      </svg>
+    </div>
+
+    <nav class="toc" aria-label="Contents">
+      <p class="toc-title">Contents</p>
+      <ol>
+        <li><a href="#core-premise">Core premise and cost curve</a></li>
+        <li><a href="#agile-critique">The agile critique</a></li>
+        <li><a href="#evolutionary-design">Emergent and evolutionary alternatives</a></li>
+        <li><a href="#valid-domains">Domains requiring upfront design</a></li>
+        <li><a href="#modern-synthesis">Modern synthesis</a></li>
+        <li><a href="#see-also">See also</a></li>
+        <li><a href="#references">References</a></li>
+      </ol>
+    </nav>
+
+    <h2 id="core-premise">Core premise and cost curve</h2>
+    <p>BDUF relies on the hypothesis that defects caught during early specification are orders of magnitude cheaper to correct than defects caught during integration, deployment, or production maintenance.<span class="cite">[<a href="#ref3">3</a>]</span></p>
+    <p>Barry Boehm documented this exponential cost-of-change curve in 1981, showing that late defect repairs in large mainframe systems often cost between 50 and 200 times more than repairs made during requirements definition.<span class="cite">[<a href="#ref3">3</a>]</span> Under this economic model, extensive upfront investment in complete specifications, entity-relationship diagrams, and component interactions was considered rational risk reduction.</p>
+    <p>Winston Royce outlined sequential software engineering in 1970, which later became commonly labeled the waterfall model.<span class="cite">[<a href="#ref4">4</a>]</span> Royce noted that sequential development without iterative feedback was risky and invited failure. Despite that warning, many industrial and defense procurement standards adopted sequential milestones with rigid upfront design freezes as standard practice.</p>
+
+    <h2 id="agile-critique">The agile critique</h2>
+    <p>Agile practitioners in the late 1990s challenged BDUF on empirical grounds. Kent Beck, Martin Fowler, and other contributors argued that comprehensive upfront design produces several systematic dysfunctions:<span class="cite">[<a href="#ref1">1</a>, <a href="#ref2">2</a>]</span></p>
+    <ul>
+      <li><strong>Requirements volatility</strong>: Real-world user requirements change as stakeholders inspect working software. Specifications frozen months in advance optimize for outdated assumptions.</li>
+      <li><strong>Speculative generality</strong>: Designers introduce complex abstractions to handle anticipated requirements that never materialize, increasing maintenance burden without user value.</li>
+      <li><strong>Paper architecture</strong>: Theoretical designs look sound in documentation binders, but fail when subjected to runtime memory constraints, network latency, or concurrency bottlenecks.</li>
+      <li><strong>Deferred feedback</strong>: Because implementation occurs only after exhaustive documentation sign-off, discovery of architectural defects is postponed to the end of the project.</li>
+    </ul>
+
+    <h2 id="evolutionary-design">Emergent and evolutionary alternatives</h2>
+    <p>Agile methods proposed evolutionary design as an alternative to BDUF.<span class="cite">[<a href="#ref2">2</a>]</span> In this paradigm, software structure emerges incrementally through continuous refactoring, guided by comprehensive automated test suites.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+    <p>Beck argued that modern engineering practices flatten Boehm's cost-of-change curve.<span class="cite">[<a href="#ref1">1</a>]</span> Unit test suites, version control, automated regression runs, and standardized refactoring patterns reduce the economic penalty of modifying existing code. Martin Fowler distinguished planned design (investing in upfront blueprints) from evolutionary design (adapting software continuously to changing requirements), concluding that evolutionary design requires disciplined refactoring rather than an absence of design thinking.<span class="cite">[<a href="#ref2">2</a>]</span></p>
+
+    <h2 id="valid-domains">Domains requiring upfront design</h2>
+    <p>While BDUF received widespread criticism in web and commercial applications, upfront architectural planning remains essential in several engineering domains:</p>
+    <ul>
+      <li><strong>Hardware and silicon interfaces</strong>: Tape-out cycles for integrated circuits and ASIC manufacturing incur multi-million dollar tooling costs. Fabrication defects cannot be patched via continuous delivery.</li>
+      <li><strong>Safety-critical systems</strong>: Avionics, medical devices, and railway control systems operate under strict regulatory standards (such as DO-178C and ISO 26262) that require formal hazard analysis and traceable upfront verification.</li>
+      <li><strong>Public protocol definitions</strong>: Foundational network protocols and publicly published APIs create irrevocable external contracts with third parties. Changing shared protocol wire formats later breaks ecosystem compatibility.</li>
+      <li><strong>Physical infrastructure</strong>: Civil engineering, telecommunication subsea cables, and power distribution systems require irreversible physical commitments before construction begins.</li>
+    </ul>
+
+    <h2 id="modern-synthesis">Modern synthesis</h2>
+    <p>Contemporary software engineering rarely operates at either extreme of pure BDUF or total absence of upfront planning. Practitioners commonly employ balanced intermediate approaches:</p>
+    <ul>
+      <li><strong>Rough Design Up Front (RDUF)</strong>: Teams outline coarse system boundaries, high-level data models, and primary integration interfaces, leaving internal component details to iterate during implementation.</li>
+      <li><strong>Architectural Spikes</strong>: Time-boxed, disposable prototypes test high-risk technical assumptions against real runtime systems before committing to architectural directions.<span class="cite">[<a href="#ref1">1</a>]</span></li>
+      <li><strong>Architecture Decision Records (ADRs)</strong>: Rather than monolithic specification documents, teams capture individual architectural choices, rationale, and context in modular, version-controlled records.<span class="cite">[<a href="#ref5">5</a>]</span></li>
+      <li><strong>Specification by Example</strong>: Requirements are expressed as executable acceptance tests rather than ambiguous textual narratives, ensuring specifications stay synchronized with actual runtime behavior.<span class="cite">[<a href="#ref6">6</a>]</span></li>
+      <li><strong>Intent-driven agent planning</strong>: In automated and agentic coding workflows, planning serves as a lightweight constraint and boundary definition. Upfront specifications establish essential intent and verification criteria without micromanaging line-by-line implementation.<span class="cite">[<a href="#ref7">7</a>]</span></li>
+    </ul>
+
+    <h2 id="see-also">See also</h2>
+    <ul>
+      <li><a href="/reference/plan-approve-execute/">Plan-Approve-Execute</a></li>
+      <li><a href="/reference/toctou-race-condition/">TOCTOU Race Condition</a></li>
+      <li><a href="/writing/ai-writes-code-plan-becomes-work/">When the AI Writes the Code, the Plan Becomes the Work</a></li>
+    </ul>
+
+    <h2 id="references">References</h2>
+    <ol>
+      <li id="ref1"><a class="backlink" href="#agile-critique">↑</a> Beck, Kent. <em>Extreme Programming Explained: Embrace Change</em>. Addison-Wesley, 1999.</li>
+      <li id="ref2"><a class="backlink" href="#lede">↑</a> Fowler, Martin. "Is Design Dead?" In <em>Extreme Programming Explained / XP2000</em>, 2000. martinfowler.com/articles/designDead.html.</li>
+      <li id="ref3"><a class="backlink" href="#core-premise">↑</a> Boehm, Barry W. <em>Software Engineering Economics</em>. Prentice-Hall, 1981.</li>
+      <li id="ref4"><a class="backlink" href="#core-premise">↑</a> Royce, Winston W. "Managing the Development of Large Software Systems." <em>Proceedings of IEEE WESCON</em>, August 1970, pp. 1–9.</li>
+      <li id="ref5"><a class="backlink" href="#modern-synthesis">↑</a> Nygard, Michael. "Documenting Architecture Decisions." Cognitect Blog, November 2011.</li>
+      <li id="ref6"><a class="backlink" href="#modern-synthesis">↑</a> Adzic, Gojko. <em>Specification by Example: How Successful Teams Deliver the Right Software</em>. Manning Publications, 2011.</li>
+      <li id="ref7"><a class="backlink" href="#modern-synthesis">↑</a> Pestelos, Nestor G. Jr. "When the AI Writes the Code, the Plan Becomes the Work." ngpestelos.com/writing/ai-writes-code-plan-becomes-work/, 2026.</li>
+    </ol>
+
+    <footer class="meta">
+      <p><a href="#top">Back to top</a></p>
+    </footer>
+  </main>
+
+  <button id="backToTop" class="back-to-top" aria-label="Back to top" title="Back to top">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M18 15l-6-6-6 6"/>
+    </svg>
+  </button>
+
+  <script>
+    const btt = document.getElementById('backToTop');
+    window.addEventListener('scroll', () => {
+      if (window.scrollY > 250) {
+        btt.classList.add('visible');
+      } else {
+        btt.classList.remove('visible');
+      }
+    }, { passive: true });
+    btt.addEventListener('click', () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  </script>
+</body>
+</html>

--- a/reference/index.html
+++ b/reference/index.html
@@ -190,7 +190,7 @@
 
     <nav class="alpha-nav" aria-label="Alphabetical index">
       <a href="#A">A</a>
-      <span class="empty">B</span>
+      <a href="#B">B</a>
       <a href="#C">C</a>
       <a href="#D">D</a>
       <a href="#E">E</a>
@@ -233,6 +233,13 @@
         <li><a href="/reference/artificial-intelligence/">Artificial Intelligence</a></li>
         <li><a href="/reference/atomic-note/">Atomic Note</a></li>
         <li><a href="/reference/autoregressive/">Autoregressive Models</a></li>
+        </ul>
+      </div>
+
+      <div class="letter-group" id="B">
+        <h2 class="letter-heading">B</h2>
+        <ul>
+        <li><a href="/reference/big-design-up-front/">Big Design Up Front</a></li>
         </ul>
       </div>
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -126,6 +126,11 @@
     <priority>0.5</priority>
   </url>
   <url>
+    <loc>https://ngpestelos.com/reference/big-design-up-front/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
     <loc>https://ngpestelos.com/reference/context-engineering/</loc>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>

--- a/writing/ai-writes-code-plan-becomes-work/index.html
+++ b/writing/ai-writes-code-plan-becomes-work/index.html
@@ -53,7 +53,7 @@
 
 <h2 id="the-lesson-is-not-plan-more">The lesson is not &quot;plan more&quot;</h2>
 
-<p>Bureaucratic specification was friction before AI, and it remains friction now. A forty-page requirements binder that nobody executes confuses accidental bureaucracy with essential thought. Elevating the plan does not revive Big Design Up Front. The <a href="https://agilemanifesto.org/">Agile Manifesto</a> authors correctly prioritized &quot;responding to change&quot; over &quot;following a plan.&quot; That warning holds if modern planning reverts to exhaustive upfront documentation.</p>
+<p>Bureaucratic specification was friction before AI, and it remains friction now. A forty-page requirements binder that nobody executes confuses accidental bureaucracy with essential thought. Elevating the plan does not revive <a href="/reference/big-design-up-front/">Big Design Up Front</a>. The <a href="https://agilemanifesto.org/">Agile Manifesto</a> authors correctly prioritized &quot;responding to change&quot; over &quot;following a plan.&quot; That warning holds if modern planning reverts to exhaustive upfront documentation.</p>
 
 <p>What relocates upstream is clarity of intent, not administrative ceremony. Authors must define essential decisions: purpose, governing constraints, and correctness criteria. Skip boilerplate that a competent model can derive. In practice, this mirrors Gojko Adzic&#x27;s *<a href="https://gojko.net/books/specification-by-example/">Specification by Example</a>*: an executable specification stays current because tests enforce it. The most effective plan resembles an architecture decision record with test assertions. Bloated plans rot quickly, competing for the attention they were meant to save.</p>
 


### PR DESCRIPTION
## Summary
- Define Big Design Up Front (BDUF) as a software engineering approach where architecture and specifications are completed and frozen before implementation.
- Detail the cost-of-change curve premise (Boehm), waterfall context (Royce), and agile/XP critiques (Beck, Fowler).
- Contrast with evolutionary design, identify domains requiring upfront design (safety-critical, silicon, hardware), and discuss modern adaptations (RDUF, ADRs, intent-driven agent planning).
- Register in `reference/index.html` under the B section and in `sitemap.xml`.
- Add reciprocal cross-link in `writing/ai-writes-code-plan-becomes-work/index.html`.

## Verification
- Pack T scan passed: 0 em-dashes, 0 mdashes, 0 banned AI phrases.
- Unittest suites passed (`scripts.test_site_theme`, `scripts.test_writing_layout`).
- Parity verified between TOC hrefs and H2 section IDs.
- Citation anchors and reference backlinks verified.
- Binary control byte check clean.