### PR TITLE
Sort writing buckets by publication date

### DIFF
--- a/scripts/test_site_discoverability.py
+++ b/scripts/test_site_discoverability.py
@@ -44,6 +44,18 @@ def is_snapshot_slug(slug: str) -> bool:
     return bool(SNAPSHOT_SLUG.search(slug))
 
 
+def bucket_datetimes(html: str) -> dict[str, list[str]]:
+    sections = re.findall(
+        r'<section class="bucket" id="([^"]+)">(.*?)</section>',
+        html,
+        re.S,
+    )
+    return {
+        bucket_id: re.findall(r'<time datetime="([^"]+)">', body)
+        for bucket_id, body in sections
+    }
+
+
 class MetaDescriptionParser(HTMLParser):
     def __init__(self):
         super().__init__()
@@ -97,6 +109,17 @@ class SiteDiscoverabilityTests(unittest.TestCase):
                 rf'href="/writing/{re.escape(item["slug"])}/">[^<]*</a>\s*<time datetime="{item["date"]}"',
             )
         self.assertGreaterEqual(len(re.findall(r'<li class="pin">', html)), 13)
+        datetimes = bucket_datetimes(html)
+        self.assertEqual(list(datetimes), ["systems", "payments", "essays"])
+        for bucket_id, dates in datetimes.items():
+            self.assertEqual(dates, sorted(dates, reverse=True), bucket_id)
+        systems = re.search(
+            r'<section class="bucket" id="systems">.*?</section>', html, re.S
+        ).group(0)
+        employee = systems.find("/writing/the-employee-you-cant-stop-managing/")
+        meat = systems.find("/writing/meat-proxy-problem/")
+        source = systems.find("/writing/build-source-of-truth-before-index/")
+        self.assertTrue(0 <= employee < meat < source)
 
     def test_homepage_pins_and_linters(self):
         html = HOME.read_text(encoding="utf-8")

--- a/scripts/writing_catalog.py
+++ b/scripts/writing_catalog.py
@@ -51,13 +51,7 @@ def display_date(iso_date: str) -> str:
 
 def _ordered_bucket(items: list[dict], bucket: str) -> list[dict]:
     bucket_items = [item for item in items if item.get("bucket") == bucket]
-    pins = sorted(
-        [item for item in bucket_items if item.get("pin")],
-        key=lambda item: item["pin"],
-    )
-    rest = [item for item in bucket_items if not item.get("pin")]
-    rest.sort(key=lambda item: item["date"], reverse=True)
-    return pins + rest
+    return sorted(bucket_items, key=lambda item: item["date"], reverse=True)
 
 
 def index_inner_html(items: list[dict]) -> str:

--- a/writing/index.html
+++ b/writing/index.html
@@ -38,14 +38,13 @@
       <section class="bucket" id="systems">
         <h2>Production systems and agents</h2>
         <ul>
-          <li class="pin"><a href="/writing/meat-proxy-problem/">The Meat Proxy Problem</a> <time datetime="2026-08-19">19 Aug 2026</time></li>
           <li class="pin"><a href="/writing/the-employee-you-cant-stop-managing/">The Employee You Can&#x27;t Stop Managing</a> <time datetime="2026-08-21">21 Aug 2026</time></li>
-          <li class="pin"><a href="/writing/ai-writes-code-plan-becomes-work/">When the AI Writes the Code, the Plan Becomes the Work</a> <time datetime="2026-08-11">11 Aug 2026</time></li>
-          <li class="pin"><a href="/writing/nine-security-issues-zero-lines-i-wrote/">Nine Security Issues, Zero Lines I Wrote</a> <time datetime="2026-08-12">12 Aug 2026</time></li>
-          <li class="pin"><a href="/writing/agents-plan-b-destroy-data/">Your Agent&#x27;s Plan B Will Destroy Your Data</a> <time datetime="2026-03-25">25 Mar 2026</time></li>
+          <li class="pin"><a href="/writing/meat-proxy-problem/">The Meat Proxy Problem</a> <time datetime="2026-08-19">19 Aug 2026</time></li>
           <li><a href="/writing/build-source-of-truth-before-index/">Build the Source of Truth Before the Index</a> <time datetime="2026-08-18">18 Aug 2026</time></li>
           <li><a href="/writing/ledger-that-stayed-empty/">The Ledger That Stayed Empty</a> <time datetime="2026-08-14">14 Aug 2026</time></li>
           <li><a href="/writing/scanner-that-feeds-pipeline/">The Scanner That Feeds the Pipeline</a> <time datetime="2026-08-13">13 Aug 2026</time></li>
+          <li class="pin"><a href="/writing/nine-security-issues-zero-lines-i-wrote/">Nine Security Issues, Zero Lines I Wrote</a> <time datetime="2026-08-12">12 Aug 2026</time></li>
+          <li class="pin"><a href="/writing/ai-writes-code-plan-becomes-work/">When the AI Writes the Code, the Plan Becomes the Work</a> <time datetime="2026-08-11">11 Aug 2026</time></li>
           <li><a href="/writing/half-agent-infrastructure-depreciating-asset/">Your Agent Infrastructure Has Two Lifespans</a> <time datetime="2026-08-02">2 Aug 2026</time></li>
           <li><a href="/writing/agent-didnt-get-dumber-chat-got-contaminated/">The Agent Didn&#x27;t Get Dumber. The Chat Got Contaminated</a> <time datetime="2026-07-31">31 Jul 2026</time></li>
           <li><a href="/writing/debt-with-diff-attached/">Debt With a Diff Attached</a> <time datetime="2026-07-24">24 Jul 2026</time></li>
@@ -61,6 +60,7 @@
           <li><a href="/writing/agent-rail-war-red-herring/">The Agent Rail War Is a Red Herring</a> <time datetime="2026-07-08">8 Jul 2026</time></li>
           <li><a href="/writing/the-bugs-that-hide-between-your-agents/">The Bugs That Hide Between Your Agents</a> <time datetime="2026-07-08">8 Jul 2026</time></li>
           <li><a href="/writing/governing-delegation-scope-creep/">Governing Delegation - Using Architecture to Stop AI Scope Creep</a> <time datetime="2026-07-03">3 Jul 2026</time></li>
+          <li class="pin"><a href="/writing/agents-plan-b-destroy-data/">Your Agent&#x27;s Plan B Will Destroy Your Data</a> <time datetime="2026-03-25">25 Mar 2026</time></li>
           <li><a href="/writing/debug-system-not-prompt/">Debug the System Not the Prompt</a> <time datetime="2026-03-24">24 Mar 2026</time></li>
           <li><a href="/writing/basb-claude-code-setup/">Building a Second Brain with Claude Code - The Setup</a> <time datetime="2026-03-19">19 Mar 2026</time></li>
           <li><a href="/writing/enter-key-problem/">The Enter Key Problem</a> <time datetime="2026-03-19">19 Mar 2026</time></li>
@@ -83,19 +83,19 @@
         <ul>
           <li class="pin"><a href="/writing/five-checks-against-motivated-reasoning/">Five Checks Against Motivated Reasoning</a> <time datetime="2026-08-24">24 Aug 2026</time></li>
           <li class="pin"><a href="/writing/what-actually-buys-you-the-power-to-say-no/">What Actually Buys You the Power to Say No</a> <time datetime="2026-08-21">21 Aug 2026</time></li>
-          <li class="pin"><a href="/writing/career-ceiling-i-was-worried-about-already-existed/">The Career Ceiling I Was Worried About Already Existed</a> <time datetime="2026-08-14">14 Aug 2026</time></li>
-          <li class="pin"><a href="/writing/orchestrator-identity/">The Orchestrator Identity</a> <time datetime="2026-07-24">24 Jul 2026</time></li>
-          <li class="pin"><a href="/writing/most-expensive-avoidance-looks-like-prudence/">The Most Expensive Avoidance Looks Exactly Like Prudence</a> <time datetime="2026-07-28">28 Jul 2026</time></li>
           <li><a href="/writing/credit-cures-plagiarism-not-permission/">Credit Cures Plagiarism, Not Permission</a> <time datetime="2026-08-17">17 Aug 2026</time></li>
           <li><a href="/writing/metric-already-happened-upstream/">The Metric You&#x27;re Watching Already Happened Upstream</a> <time datetime="2026-08-15">15 Aug 2026</time></li>
           <li><a href="/writing/positioning-demotes-prediction/">Positioning Doesn&#x27;t Escape Prediction, It Demotes It</a> <time datetime="2026-08-14">14 Aug 2026</time></li>
+          <li class="pin"><a href="/writing/career-ceiling-i-was-worried-about-already-existed/">The Career Ceiling I Was Worried About Already Existed</a> <time datetime="2026-08-14">14 Aug 2026</time></li>
           <li><a href="/writing/triffins-dilemma-escape-doesnt-work/">The Only Concrete Escape From Triffin&#x27;s Dilemma Doesn&#x27;t Work</a> <time datetime="2026-08-14">14 Aug 2026</time></li>
           <li><a href="/writing/agency-dims-as-the-timeframe-collapses/">Agency Dims as the Timeframe Collapses</a> <time datetime="2026-08-11">11 Aug 2026</time></li>
           <li><a href="/writing/same-tunnel-ships-work-drops-room/">The Same Tunnel That Ships the Work Drops the Room</a> <time datetime="2026-07-31">31 Jul 2026</time></li>
           <li><a href="/writing/urgency-conscientiousness-better-marketing/">Urgency Is Just Conscientiousness With Better Marketing</a> <time datetime="2026-07-28">28 Jul 2026</time></li>
+          <li class="pin"><a href="/writing/most-expensive-avoidance-looks-like-prudence/">The Most Expensive Avoidance Looks Exactly Like Prudence</a> <time datetime="2026-07-28">28 Jul 2026</time></li>
           <li><a href="/writing/run-dead-internet-on-purpose/">I Run a Dead Internet on Purpose</a> <time datetime="2026-07-26">26 Jul 2026</time></li>
           <li><a href="/writing/addiction-to-being-right-is-rarer-than-you-think/">The Addiction to Being Right Is Rarer Than You Think</a> <time datetime="2026-07-24">24 Jul 2026</time></li>
           <li><a href="/writing/ai-rerunning-the-nuclear-script/">AI Is Rerunning the Nuclear Script, Not the Part You Think</a> <time datetime="2026-07-24">24 Jul 2026</time></li>
+          <li class="pin"><a href="/writing/orchestrator-identity/">The Orchestrator Identity</a> <time datetime="2026-07-24">24 Jul 2026</time></li>
           <li><a href="/writing/selection-beats-execution-when-games-differ/">Selection Beats Execution Only When the Games Differ</a> <time datetime="2026-07-23">23 Jul 2026</time></li>
           <li><a href="/writing/engineer-the-downside-when-you-cannot-forecast/">Engineer the Downside When You Cannot Forecast the Upside</a> <time datetime="2026-07-23">23 Jul 2026</time></li>
           <li><a href="/writing/anxiety-present-tense-problem/">Anxiety Is a Present-Tense Problem</a> <time datetime="2026-07-21">21 Jul 2026</time></li>


### PR DESCRIPTION
Closes #24

Sort every article inside each `/writing/` bucket by publication date, newest first.

`_ordered_bucket()` used to list pins by pin rank, then the rest by date. Pin rank is homepage curation; it no longer controls the full writing index. `class="pin"` and catalog pin values stay. Equal dates keep catalog order.

## Verify

- Systems: *The Employee You Can't Stop Managing* (21 Aug) before *The Meat Proxy Problem* (19 Aug) before *Build the Source of Truth Before the Index* (18 Aug)
- Homepage, catalog pin fields, and Atom feed unchanged
- `python3 scripts/test_site_discoverability.py && python3 scripts/test_writing_layout.py`
