### PR TITLE
Add JSON-LD and middot titles on reference pages

### DIFF
--- a/reference/acceleration-whiplash/index.html
+++ b/reference/acceleration-whiplash/index.html
@@ -176,6 +176,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Acceleration Whiplash","description":"Acceleration whiplash occurs when AI code generation throughput overwhelms human review and verification gates, degrading overall software delivery quality.","url":"https://ngpestelos.com/reference/acceleration-whiplash/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/adversarial-agent-review/index.html
+++ b/reference/adversarial-agent-review/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Adversarial Review — Reference — Nestor G Pestelos Jr</title>
+  <title>Adversarial Review (AI Agents) · Reference · Nestor G Pestelos Jr</title>
   <meta name="description" content="Adversarial review is a verification pattern in AI agent systems in which an agent's output is checked by a separate process instructed to find fault with it, not confirm it. Covers independence, refutation framing, verify-before-criticize, multi-reviewer voting, and termination.">
-  <meta property="og:title" content="Adversarial Review — Reference">
+  <meta property="og:title" content="Adversarial Review (AI Agents) · Reference">
   <meta property="og:description" content="A verification pattern for AI agent systems in which an agent's output is checked by a process instructed to refute it, not confirm it.">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://ngpestelos.com/reference/adversarial-agent-review/">
@@ -172,12 +172,15 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Adversarial Review (AI Agents)","description":"Adversarial review is a verification pattern in AI agent systems in which an agent's output is checked by a separate process instructed to find fault with it, not confirm it. Covers independence, refutation framing, verify-before-criticize, multi-reviewer voting, and termination.","url":"https://ngpestelos.com/reference/adversarial-agent-review/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">
     <p class="back"><a href="/reference/">← Reference</a> · <a href="/">Nestor G Pestelos Jr</a> · <a href="#" onclick="window.print(); return false;">Print this page</a></p>
     <p class="kicker">Artificial Intelligence</p>
-    <h1>Adversarial Review</h1>
+    <h1>Adversarial Review (AI Agents)</h1>
     <p class="updated">Reference entry &middot; last updated August 24, 2026</p>
 
     <p class="lede"><strong>Adversarial review</strong> is a verification pattern for AI agent systems in which an agent's output is checked by a separate process instructed to find fault with it, not confirm it.<span class="cite">[<a href="#ref1">1</a>]</span> The reviewing process runs independently of the process that produced the output, and the output only counts as checked once an attempt to refute it has failed. This entry covers the mechanism as applied to AI agents: why single-pass self-review tends toward agreement, the five design elements that make an adversarial pass find real problems instead of manufacturing complaints, and where the pattern is used in agent research and in software delivery.</p>

--- a/reference/agent-harness/index.html
+++ b/reference/agent-harness/index.html
@@ -179,6 +179,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Agent Harness","description":"An agent harness is the complete software infrastructure and runtime environment that wraps, controls, observes, and assists a foundation model in autonomous execution.","url":"https://ngpestelos.com/reference/agent-harness/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/agent-substrate/index.html
+++ b/reference/agent-substrate/index.html
@@ -169,6 +169,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Agent Substrate","description":"Agent substrate is the durable, operator-owned, model-independent representation of the system or domain on which agent harnesses operate.","url":"https://ngpestelos.com/reference/agent-substrate/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/agentic-loops/index.html
+++ b/reference/agentic-loops/index.html
@@ -179,6 +179,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Agentic Loops","description":"An agentic loop is an autonomous execution cycle that drives an AI agent toward a target goal through continuous observation, action, and verification.","url":"https://ngpestelos.com/reference/agentic-loops/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">
@@ -296,6 +299,7 @@
       <li><a href="/reference/fail-closed/">Fail-closed</a></li>
       <li><a href="/reference/plan-approve-execute/">Plan-Approve-Execute</a></li>
       <li><a href="/reference/ooda-loop/">OODA Loop</a></li>
+      <li><a href="/reference/acceleration-whiplash/">Acceleration whiplash</a></li>
       <li><a href="/eli5/agentic-loops/">Agentic Loops (ELI5 explainer)</a></li>
     </ul>
 

--- a/reference/agents/index.html
+++ b/reference/agents/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Agents — Reference — Nestor G Pestelos Jr</title>
+  <title>Agents · Reference · Nestor G Pestelos Jr</title>
   <meta name="description" content="A citable ground-truth reference on Autonomous Agents: MDP formulation, perception-action-reflection loops, tool calling protocols, memory tiers, and multi-agent orchestration.">
-  <meta property="og:title" content="Agents — Reference">
+  <meta property="og:title" content="Agents · Reference">
   <meta property="og:description" content="A citable ground-truth reference on Autonomous AI Agents: MDP formulation, perception-action-reflection loops, tool calling protocols, memory tiers, and multi-agent orchestration.">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://ngpestelos.com/reference/agents/">
@@ -243,6 +243,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Agents","description":"A citable ground-truth reference on Autonomous Agents: MDP formulation, perception-action-reflection loops, tool calling protocols, memory tiers, and multi-agent orchestration.","url":"https://ngpestelos.com/reference/agents/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main>

--- a/reference/ai-agent-observability/index.html
+++ b/reference/ai-agent-observability/index.html
@@ -51,6 +51,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"AI Agent Observability","description":"AI agent observability connects requests, model calls, retrieval, tools, policy decisions, outcomes, and human overrides without treating private chain-of-thought as telemetry.","url":"https://ngpestelos.com/reference/ai-agent-observability/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference"><main id="top">
   <p class="back"><a href="/reference/">← Reference</a> · <a href="/">Nestor G Pestelos Jr</a> · <a href="#" onclick="window.print(); return false;">Print this page</a></p><p class="kicker">Artificial Intelligence · Operations</p><h1>AI Agent Observability</h1><p class="updated">Reference entry · last updated August 25, 2026</p>

--- a/reference/amdahls-law/index.html
+++ b/reference/amdahls-law/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Amdahl's Law · Reference · Nestor G Pestelos Jr</title>
+  <title>Amdahl's Law for Parallel AI Agents · Reference · Nestor G Pestelos Jr</title>
   <meta name="description" content="Amdahl's Law establishes the mathematical limit on speedup and throughput when parallelizing workloads, bounded strictly by the serial fraction.">
-  <meta property="og:title" content="Amdahl's Law · Reference">
+  <meta property="og:title" content="Amdahl's Law for Parallel AI Agents · Reference">
   <meta property="og:description" content="Mathematical formulation, serial bottlenecks, multi-core systems, and parallel AI agent fleet scaling.">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://ngpestelos.com/reference/amdahls-law/">
@@ -186,12 +186,15 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Amdahl's Law for Parallel AI Agents","description":"Amdahl's Law establishes the mathematical limit on speedup and throughput when parallelizing workloads, bounded strictly by the serial fraction.","url":"https://ngpestelos.com/reference/amdahls-law/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">
     <p class="back"><a href="/reference/">← Reference</a> · <a href="/">Nestor G Pestelos Jr</a></p>
     <p class="kicker">Computer Architecture · Parallel Computing</p>
-    <h1>Amdahl's Law</h1>
+    <h1>Amdahl's Law for Parallel AI Agents</h1>
     <p class="updated">Reference entry · last updated August 26, 2026</p>
 
     <p class="lede"><strong>Amdahl's Law</strong> is a mathematical formula that calculates the theoretical maximum speedup achievable by a system when improving or parallelizing a specific fraction of its total workload.<span class="cite">[<a href="#ref1">1</a>]</span> Formulated by computer architect Gene Amdahl in 1967, the law demonstrates that overall performance speedup is strictly bounded by the serial, non-parallelizable portion of the task, regardless of how many parallel processing units are added.<span class="cite">[<a href="#ref2">2</a>]</span></p>

--- a/reference/andy-matuschak/index.html
+++ b/reference/andy-matuschak/index.html
@@ -175,6 +175,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Andy Matuschak","description":"Andy Matuschak is an American software engineer, interface designer, and researcher who pioneered evergreen notes, sliding pane interfaces, and mnemonic media.","url":"https://ngpestelos.com/reference/andy-matuschak/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/artificial-intelligence/index.html
+++ b/reference/artificial-intelligence/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Artificial Intelligence — Reference — Nestor G Pestelos Jr</title>
+  <title>Artificial Intelligence · Reference · Nestor G Pestelos Jr</title>
   <meta name="description" content="A citable ground-truth reference on Artificial Intelligence (AI): rational agent theory, classical vs. statistical paradigms, hierarchy of intelligence, and safety.">
-  <meta property="og:title" content="Artificial Intelligence — Reference">
+  <meta property="og:title" content="Artificial Intelligence · Reference">
   <meta property="og:description" content="A citable ground-truth reference on Artificial Intelligence (AI): rational agent theory, classical vs. statistical paradigms, hierarchy of intelligence, and safety.">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://ngpestelos.com/reference/artificial-intelligence/">
@@ -217,6 +217,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Artificial Intelligence","description":"A citable ground-truth reference on Artificial Intelligence (AI): rational agent theory, classical vs. statistical paradigms, hierarchy of intelligence, and safety.","url":"https://ngpestelos.com/reference/artificial-intelligence/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main>

--- a/reference/atomic-note/index.html
+++ b/reference/atomic-note/index.html
@@ -175,6 +175,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Atomic Note","description":"An atomic note is a self-contained unit of knowledge that captures exactly one idea, concept, or insight with clear provenance and associative links.","url":"https://ngpestelos.com/reference/atomic-note/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/autoregressive/index.html
+++ b/reference/autoregressive/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Autoregressive Models — Reference — Nestor G Pestelos Jr</title>
+  <title>Autoregressive Models · Reference · Nestor G Pestelos Jr</title>
   <meta name="description" content="A citable ground-truth reference on autoregressive models: probabilistic sequence factorization, causal masking, generation bottlenecks, and KV caching in LLMs.">
-  <meta property="og:title" content="Autoregressive Models — Reference">
+  <meta property="og:title" content="Autoregressive Models · Reference">
   <meta property="og:description" content="A citable ground-truth reference on autoregressive models: probabilistic sequence factorization, causal masking, generation bottlenecks, and KV caching in LLMs.">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://ngpestelos.com/reference/autoregressive/">
@@ -224,6 +224,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Autoregressive Models","description":"A citable ground-truth reference on autoregressive models: probabilistic sequence factorization, causal masking, generation bottlenecks, and KV caching in LLMs.","url":"https://ngpestelos.com/reference/autoregressive/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main>

--- a/reference/big-design-up-front/index.html
+++ b/reference/big-design-up-front/index.html
@@ -178,6 +178,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Big Design Up Front","description":"Big Design Up Front (BDUF) is a software development approach where architecture and specifications are completed before coding. Context, critique, and modern synthesis.","url":"https://ngpestelos.com/reference/big-design-up-front/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/bm25/index.html
+++ b/reference/bm25/index.html
@@ -209,6 +209,9 @@
       .back, .back-to-top, .print { display: none; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"BM25 (Best Matching 25)","description":"A citable ground-truth reference on the BM25 (Best Matching 25) ranking algorithm: mathematical formulation, TF saturation, length normalization, variants, and hybrid retrieval.","url":"https://ngpestelos.com/reference/bm25/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body>
   <main>

--- a/reference/context-engineering/index.html
+++ b/reference/context-engineering/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Context Engineering — Reference — Nestor G Pestelos Jr</title>
+  <title>Context Engineering · Reference · Nestor G Pestelos Jr</title>
   <meta name="description" content="A citable ground-truth reference on Context Engineering: token budgeting, memory tiers, Lost in the Middle mechanics, prompt caching, and structured context pipelines.">
-  <meta property="og:title" content="Context Engineering — Reference">
+  <meta property="og:title" content="Context Engineering · Reference">
   <meta property="og:description" content="A citable ground-truth reference on Context Engineering: token budgeting, memory tiers, Lost in the Middle mechanics, prompt caching, and structured context pipelines.">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://ngpestelos.com/reference/context-engineering/">
@@ -232,6 +232,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Context Engineering","description":"A citable ground-truth reference on Context Engineering: token budgeting, memory tiers, Lost in the Middle mechanics, prompt caching, and structured context pipelines.","url":"https://ngpestelos.com/reference/context-engineering/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main>

--- a/reference/context-window/index.html
+++ b/reference/context-window/index.html
@@ -187,6 +187,9 @@
       .back, .back-to-top { display: none; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Context Windows","description":"A citable ground-truth reference on context windows in large language models: quadratic attention complexity, KV cache scaling, RoPE position interpolation, and the Lost in the Middle phenomenon.","url":"https://ngpestelos.com/reference/context-window/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body>
   <main>

--- a/reference/continuous-batching/index.html
+++ b/reference/continuous-batching/index.html
@@ -186,6 +186,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Continuous Batching","description":"Continuous batching is an LLM serving technique that schedules requests dynamically at the token iteration level, eliminating head-of-line blocking and padding waste.","url":"https://ngpestelos.com/reference/continuous-batching/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/deep-neural-networks/index.html
+++ b/reference/deep-neural-networks/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Deep Neural Networks — Reference — Nestor G Pestelos Jr</title>
+  <title>Deep Neural Networks · Reference · Nestor G Pestelos Jr</title>
   <meta name="description" content="A citable ground-truth reference on Deep Neural Networks (DNNs): multi-layer architectures, non-linear activations, backpropagation, and representation learning.">
-  <meta property="og:title" content="Deep Neural Networks — Reference">
+  <meta property="og:title" content="Deep Neural Networks · Reference">
   <meta property="og:description" content="A citable ground-truth reference on Deep Neural Networks (DNNs): multi-layer architectures, non-linear activations, backpropagation, and representation learning.">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://ngpestelos.com/reference/deep-neural-networks/">
@@ -224,6 +224,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Deep Neural Networks","description":"A citable ground-truth reference on Deep Neural Networks (DNNs): multi-layer architectures, non-linear activations, backpropagation, and representation learning.","url":"https://ngpestelos.com/reference/deep-neural-networks/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main>

--- a/reference/eastern-han/index.html
+++ b/reference/eastern-han/index.html
@@ -166,6 +166,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Eastern Han","description":"Eastern Han (25-220) is the second half of the Han dynasty, capital Luoyang, restored by Liu Xiu (Emperor Guangwu) after Wang Mang. It ends when Cao Pi takes the throne in 220.","url":"https://ngpestelos.com/reference/eastern-han/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/embeddings/index.html
+++ b/reference/embeddings/index.html
@@ -187,6 +187,9 @@
       .back, .back-to-top { display: none; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Embeddings and Vector Representations","description":"A citable ground-truth reference on vector embeddings in artificial intelligence: geometric representations, distance metrics, contextual models, anisotropy, and dense retrieval architectures.","url":"https://ngpestelos.com/reference/embeddings/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body>
   <main>

--- a/reference/epistemology/index.html
+++ b/reference/epistemology/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Epistemology — Reference — Nestor G Pestelos Jr</title>
+  <title>Epistemology · Reference · Nestor G Pestelos Jr</title>
   <meta name="description" content="Epistemology is the branch of philosophy concerned with the nature, sources, and limits of knowledge. This entry covers five practical checks for telling a checked belief from a wanted one.">
-  <meta property="og:title" content="Epistemology — Reference">
+  <meta property="og:title" content="Epistemology · Reference">
   <meta property="og:description" content="The branch of philosophy concerned with the nature, sources, and limits of knowledge. Five practical checks for telling a checked belief from a wanted one.">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://ngpestelos.com/reference/epistemology/">
@@ -172,6 +172,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Epistemology","description":"Epistemology is the branch of philosophy concerned with the nature, sources, and limits of knowledge. This entry covers five practical checks for telling a checked belief from a wanted one.","url":"https://ngpestelos.com/reference/epistemology/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/evergreen-notes/index.html
+++ b/reference/evergreen-notes/index.html
@@ -175,6 +175,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Evergreen Notes","description":"Evergreen notes are concept-oriented, atomic digital notes structured to be continually edited, accumulated, and interconnected over time.","url":"https://ngpestelos.com/reference/evergreen-notes/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/exponential-backoff/index.html
+++ b/reference/exponential-backoff/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Exponential Backoff — Reference — Nestor G Pestelos Jr</title>
+  <title>Exponential Backoff · Reference · Nestor G Pestelos Jr</title>
   <meta name="description" content="Exponential backoff is a retry strategy in which each successive wait after a failed operation grows exponentially, up to a capped maximum, instead of retrying immediately or at a fixed interval. Origin, the synchronization problem, and jitter.">
-  <meta property="og:title" content="Exponential Backoff — Reference">
+  <meta property="og:title" content="Exponential Backoff · Reference">
   <meta property="og:description" content="A retry strategy where each wait after a failure grows exponentially, up to a cap. Origin, the synchronization problem, and jitter.">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://ngpestelos.com/reference/exponential-backoff/">
@@ -197,6 +197,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Exponential Backoff","description":"Exponential backoff is a retry strategy in which each successive wait after a failed operation grows exponentially, up to a capped maximum, instead of retrying immediately or at a fixed interval. Origin, the synchronization problem, and jitter.","url":"https://ngpestelos.com/reference/exponential-backoff/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/exponential-decay/index.html
+++ b/reference/exponential-decay/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Exponential Decay — Reference — Nestor G Pestelos Jr</title>
+  <title>Exponential Decay · Reference · Nestor G Pestelos Jr</title>
   <meta name="description" content="Exponential decay is a pattern in which a quantity's rate of decrease is proportional to its current size, so the quantity loses a constant percentage of itself each period. Half-life, carbon-14 dating, drug elimination, and Newton's Law of Cooling.">
-  <meta property="og:title" content="Exponential Decay — Reference">
+  <meta property="og:title" content="Exponential Decay · Reference">
   <meta property="og:description" content="A quantity whose decrease rate is proportional to its current size. Half-life, carbon-14 dating, drug elimination, and Newton's Law of Cooling.">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://ngpestelos.com/reference/exponential-decay/">
@@ -210,6 +210,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Exponential Decay","description":"Exponential decay is a pattern in which a quantity's rate of decrease is proportional to its current size, so the quantity loses a constant percentage of itself each period. Half-life, carbon-14 dating, drug elimination, and Newton's Law of Cooling.","url":"https://ngpestelos.com/reference/exponential-decay/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/exponential-growth/index.html
+++ b/reference/exponential-growth/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Exponential Growth — Reference — Nestor G Pestelos Jr</title>
+  <title>Exponential Growth · Reference · Nestor G Pestelos Jr</title>
   <meta name="description" content="Exponential growth is a pattern in which a quantity's rate of increase is proportional to its current size, so the quantity grows by a constant percentage each period rather than by a constant amount. Doubling time, why intuition fails, and why unbounded exponential growth is rare in practice.">
-  <meta property="og:title" content="Exponential Growth — Reference">
+  <meta property="og:title" content="Exponential Growth · Reference">
   <meta property="og:description" content="A quantity whose growth rate is proportional to its current size. Doubling time, why intuition fails, real examples, and why it always runs into limits.">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://ngpestelos.com/reference/exponential-growth/">
@@ -210,6 +210,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Exponential Growth","description":"Exponential growth is a pattern in which a quantity's rate of increase is proportional to its current size, so the quantity grows by a constant percentage each period rather than by a constant amount. Doubling time, why intuition fails, and why unbounded exponential growth is rare in practice.","url":"https://ngpestelos.com/reference/exponential-growth/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/fail-closed/index.html
+++ b/reference/fail-closed/index.html
@@ -173,6 +173,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Fail-Closed","description":"Fail-closed is a failure mode that withholds an action when the system cannot tell that the action is permitted or safe. Relation to fail-secure, Saltzer fail-safe defaults, and last-known-good.","url":"https://ngpestelos.com/reference/fail-closed/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/fine-tuning/index.html
+++ b/reference/fine-tuning/index.html
@@ -187,6 +187,9 @@
       .back, .back-to-top { display: none; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Fine-Tuning","description":"A citable ground-truth reference on fine-tuning and model alignment: Supervised Fine-Tuning (SFT), Parameter-Efficient Fine-Tuning (LoRA, QLoRA), Reinforcement Learning from Human Feedback (RLHF), and Direct Preference Optimization (DPO).","url":"https://ngpestelos.com/reference/fine-tuning/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body>
   <main>

--- a/reference/firewall-llm/index.html
+++ b/reference/firewall-llm/index.html
@@ -179,6 +179,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Firewall LLM","description":"A firewall LLM is a specialized security mechanism that filters malicious intent, prompt injections, and data leaks before and after foundation model execution.","url":"https://ngpestelos.com/reference/firewall-llm/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/frontier-models/index.html
+++ b/reference/frontier-models/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Frontier Models, Architectures, and Tokens — Reference — Nestor G Pestelos Jr</title>
+  <title>Frontier Models, Architectures, and Tokens · Reference · Nestor G Pestelos Jr</title>
   <meta name="description" content="A citable ground-truth reference on frontier artificial intelligence models, structural model architectures (dense, Mixture-of-Experts, hybrid reasoning), and tokenization mechanics.">
-  <meta property="og:title" content="Frontier Models, Architectures, and Tokens — Reference">
+  <meta property="og:title" content="Frontier Models, Architectures, and Tokens · Reference">
   <meta property="og:description" content="A citable ground-truth reference on frontier AI models, structural model architectures (dense, Mixture-of-Experts, hybrid reasoning), and tokenization mechanics.">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://ngpestelos.com/reference/frontier-models/">
@@ -212,6 +212,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Frontier Models, Architectures, and Tokens","description":"A citable ground-truth reference on frontier artificial intelligence models, structural model architectures (dense, Mixture-of-Experts, hybrid reasoning), and tokenization mechanics.","url":"https://ngpestelos.com/reference/frontier-models/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main>

--- a/reference/hanlons-razor/index.html
+++ b/reference/hanlons-razor/index.html
@@ -166,6 +166,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Hanlon's Razor","description":"Hanlon's Razor is a defeasible rule of thumb for checking unsupported claims about hostile intent.","url":"https://ngpestelos.com/reference/hanlons-razor/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/how-to-take-smart-notes/index.html
+++ b/reference/how-to-take-smart-notes/index.html
@@ -175,6 +175,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"How to Take Smart Notes","description":"How to Take Smart Notes is a 2017 book by Sönke Ahrens that details Niklas Luhmann's Zettelkasten note-taking system for academic and non-fiction writing.","url":"https://ngpestelos.com/reference/how-to-take-smart-notes/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/index.html
+++ b/reference/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Reference — Nestor G Pestelos Jr</title>
+  <title>Reference · Nestor G Pestelos Jr</title>
   <meta name="description" content="Citable ground-truth pages by Nestor G Pestelos Jr. Dense, sourced, meant to be pointed at.">
-  <meta property="og:title" content="Reference — Nestor G Pestelos Jr">
+  <meta property="og:title" content="Reference · Nestor G Pestelos Jr">
   <meta property="og:description" content="Citable ground-truth pages. Dense, sourced, meant to be pointed at.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://ngpestelos.com/reference/">
@@ -179,6 +179,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTermSet","name":"Reference","url":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main>

--- a/reference/kitbashing/index.html
+++ b/reference/kitbashing/index.html
@@ -173,6 +173,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Kitbashing","description":"Kitbashing is building a new model, prop, or digital asset from parts taken out of existing commercial kits rather than sculpting each piece from raw material. Origin in scale modeling, the Star Wars/ILM greeble history, and its later use in digital 3D and as a metaphor for creative recombination.","url":"https://ngpestelos.com/reference/kitbashing/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/large-language-models/index.html
+++ b/reference/large-language-models/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Large Language Models — Reference — Nestor G Pestelos Jr</title>
+  <title>Large Language Models · Reference · Nestor G Pestelos Jr</title>
   <meta name="description" content="A citable ground-truth reference on Large Language Models (LLMs): transformer architecture, tokenization, context engineering, RAG, gateways, and evaluation.">
-  <meta property="og:title" content="Large Language Models — Reference">
+  <meta property="og:title" content="Large Language Models · Reference">
   <meta property="og:description" content="A citable ground-truth reference on Large Language Models (LLMs): transformer architecture, tokenization, context engineering, RAG, gateways, and evaluation.">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://ngpestelos.com/reference/large-language-models/">
@@ -232,6 +232,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Large Language Models","description":"A citable ground-truth reference on Large Language Models (LLMs): transformer architecture, tokenization, context engineering, RAG, gateways, and evaluation.","url":"https://ngpestelos.com/reference/large-language-models/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main>

--- a/reference/linking-your-thinking/index.html
+++ b/reference/linking-your-thinking/index.html
@@ -175,6 +175,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Linking Your Thinking","description":"Linking Your Thinking (LYT) is a personal knowledge management system developed by Nick Milo that organizes notes through fluid associative linking and curated hub notes.","url":"https://ngpestelos.com/reference/linking-your-thinking/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/llm-evaluations/index.html
+++ b/reference/llm-evaluations/index.html
@@ -63,6 +63,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"LLM Evaluations","description":"LLM evaluations are repeatable tests of model or agent behavior against explicit success criteria. Tasks, trials, graders, outcomes, regression suites, and production monitoring.","url":"https://ngpestelos.com/reference/llm-evaluations/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/llm-gateway/index.html
+++ b/reference/llm-gateway/index.html
@@ -179,6 +179,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"LLM Gateway","description":"An LLM gateway is a specialized reverse proxy that brokers, standardizes, secures, and observes traffic between client applications and large language model providers.","url":"https://ngpestelos.com/reference/llm-gateway/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/llm-mutation-testing/index.html
+++ b/reference/llm-mutation-testing/index.html
@@ -179,6 +179,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"LLM Mutation Testing","description":"LLM mutation testing is an evaluation methodology that injects synthetic errors and contextual perturbations into evaluation datasets to measure judge sensitivity and retrieval robustness.","url":"https://ngpestelos.com/reference/llm-mutation-testing/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/lupang-hinirang/index.html
+++ b/reference/lupang-hinirang/index.html
@@ -216,6 +216,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Lupang Hinirang","description":"Lupang Hinirang is the national anthem of the Philippines: Julián Felipe's wordless 1898 march, José Palma's 1899 Spanish poem, three Tagalog rewrites, and the 1998 law that fixed its lyrics, tempo, and use in Filipino only.","url":"https://ngpestelos.com/reference/lupang-hinirang/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/machine-learning/index.html
+++ b/reference/machine-learning/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Machine Learning — Reference — Nestor G Pestelos Jr</title>
+  <title>Machine Learning · Reference · Nestor G Pestelos Jr</title>
   <meta name="description" content="A citable ground-truth reference on Machine Learning (ML): empirical risk minimization, supervised/unsupervised/RL paradigms, and bias-variance tradeoff.">
-  <meta property="og:title" content="Machine Learning — Reference">
+  <meta property="og:title" content="Machine Learning · Reference">
   <meta property="og:description" content="A citable ground-truth reference on Machine Learning (ML): empirical risk minimization, supervised/unsupervised/RL paradigms, and bias-variance tradeoff.">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://ngpestelos.com/reference/machine-learning/">
@@ -224,6 +224,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Machine Learning","description":"A citable ground-truth reference on Machine Learning (ML): empirical risk minimization, supervised/unsupervised/RL paradigms, and bias-variance tradeoff.","url":"https://ngpestelos.com/reference/machine-learning/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main>

--- a/reference/map-of-content/index.html
+++ b/reference/map-of-content/index.html
@@ -175,6 +175,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Map of Content","description":"A Map of Content (MOC) is a curated hub note that organizes associative links to atomic notes around a central theme, concept, or thesis.","url":"https://ngpestelos.com/reference/map-of-content/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/memex/index.html
+++ b/reference/memex/index.html
@@ -175,6 +175,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Memex","description":"The Memex is a hypothetical electromechanical device conceptualized by Vannevar Bush in 1945 that pioneered associative indexing and hypertext trails.","url":"https://ngpestelos.com/reference/memex/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/model-context-protocol/index.html
+++ b/reference/model-context-protocol/index.html
@@ -200,6 +200,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Model Context Protocol","description":"The Model Context Protocol (MCP) is an open-source standard for connecting AI systems with external tools, contextual data sources, and execution environments.","url":"https://ngpestelos.com/reference/model-context-protocol/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/model-router/index.html
+++ b/reference/model-router/index.html
@@ -179,6 +179,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Model Router","description":"A model router is an architectural component that dynamically classifies queries and dispatches them to the optimal model tier based on complexity, latency, and cost.","url":"https://ngpestelos.com/reference/model-router/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/model-transfer/index.html
+++ b/reference/model-transfer/index.html
@@ -185,6 +185,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Model Transfer","description":"Model transfer (transfer learning) is a machine learning technique where knowledge gained while solving a source task is reused to improve performance on a target task.","url":"https://ngpestelos.com/reference/model-transfer/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/natural-language-processing/index.html
+++ b/reference/natural-language-processing/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Natural Language Processing — Reference — Nestor G Pestelos Jr</title>
+  <title>Natural Language Processing · Reference · Nestor G Pestelos Jr</title>
   <meta name="description" content="A citable ground-truth reference on Natural Language Processing (NLP): tokenization, embeddings, syntax parsing, sequence-to-sequence models, and transformer language modeling.">
-  <meta property="og:title" content="Natural Language Processing — Reference">
+  <meta property="og:title" content="Natural Language Processing · Reference">
   <meta property="og:description" content="A citable ground-truth reference on Natural Language Processing (NLP): tokenization, embeddings, syntax parsing, sequence-to-sequence models, and transformer language modeling.">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://ngpestelos.com/reference/natural-language-processing/">
@@ -224,6 +224,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Natural Language Processing","description":"A citable ground-truth reference on Natural Language Processing (NLP): tokenization, embeddings, syntax parsing, sequence-to-sequence models, and transformer language modeling.","url":"https://ngpestelos.com/reference/natural-language-processing/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main>

--- a/reference/neural-networks/index.html
+++ b/reference/neural-networks/index.html
@@ -219,6 +219,9 @@
       .back, .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Neural Networks","description":"A citable ground-truth reference on Neural Networks: artificial neurons, activation functions, multilayer perceptrons, backpropagation, and architectures.","url":"https://ngpestelos.com/reference/neural-networks/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/nick-milo/index.html
+++ b/reference/nick-milo/index.html
@@ -175,6 +175,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Nick Milo","description":"Nick Milo is an educator, writer, and creator of the Linking Your Thinking (LYT) framework and Map of Content (MOC) methodology in personal knowledge management.","url":"https://ngpestelos.com/reference/nick-milo/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/niklas-luhmann/index.html
+++ b/reference/niklas-luhmann/index.html
@@ -175,6 +175,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Niklas Luhmann","description":"Niklas Luhmann was a German sociologist and systems theorist known for his social systems theory and the pioneering Zettelkasten note-taking methodology.","url":"https://ngpestelos.com/reference/niklas-luhmann/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/online-payments/index.html
+++ b/reference/online-payments/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Online Payments — Reference — Nestor G Pestelos Jr</title>
+  <title>Online Payments · Reference · Nestor G Pestelos Jr</title>
   <meta name="description" content="A citable ground-truth reference for online payments: card lifecycle, 4-party mechanics, CNP liability, PCI DSS, ActiveMerchant, and US/PH payment rails.">
-  <meta property="og:title" content="Online Payments — Reference">
+  <meta property="og:title" content="Online Payments · Reference">
   <meta property="og:description" content="A citable ground-truth reference for online payments: card lifecycle, 4-party mechanics, CNP liability, PCI DSS, ActiveMerchant, and US/PH payment rails.">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://ngpestelos.com/reference/online-payments/">
@@ -274,6 +274,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Online Payments","description":"A citable ground-truth reference for online payments: card lifecycle, 4-party mechanics, CNP liability, PCI DSS, ActiveMerchant, and US/PH payment rails.","url":"https://ngpestelos.com/reference/online-payments/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main>

--- a/reference/ooda-loop/index.html
+++ b/reference/ooda-loop/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>OODA Loop — Reference — Nestor G Pestelos Jr</title>
+  <title>OODA Loop · Reference · Nestor G Pestelos Jr</title>
   <meta name="description" content="A citable ground-truth reference on John Boyd's OODA Loop: non-linear cybernetic feedback, Orientation as Schwerpunkt, Destruction and Creation, Implicit Guidance and Control, and agent dynamics.">
-  <meta property="og:title" content="OODA Loop — Reference">
+  <meta property="og:title" content="OODA Loop · Reference">
   <meta property="og:description" content="A citable ground-truth reference on John Boyd's OODA Loop: non-linear cybernetic feedback, Orientation as Schwerpunkt, Destruction and Creation, Implicit Guidance and Control, and agent dynamics.">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://ngpestelos.com/reference/ooda-loop/">
@@ -243,6 +243,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"OODA Loop","description":"A citable ground-truth reference on John Boyd's OODA Loop: non-linear cybernetic feedback, Orientation as Schwerpunkt, Destruction and Creation, Implicit Guidance and Control, and agent dynamics.","url":"https://ngpestelos.com/reference/ooda-loop/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main>

--- a/reference/plan-approve-execute/index.html
+++ b/reference/plan-approve-execute/index.html
@@ -179,6 +179,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Plan-Approve-Execute","description":"Plan-approve-execute is an architectural pattern for autonomous software agents that separates plan generation from gated, authorized tool execution.","url":"https://ngpestelos.com/reference/plan-approve-execute/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/pre-training/index.html
+++ b/reference/pre-training/index.html
@@ -187,6 +187,9 @@
       .back, .back-to-top { display: none; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Pre-Training","description":"A citable ground-truth reference on pre-training in artificial intelligence: self-supervised objectives, compute scaling laws, dataset curation pipelines, and distributed training systems.","url":"https://ngpestelos.com/reference/pre-training/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body>
   <main>

--- a/reference/prompt-caching/index.html
+++ b/reference/prompt-caching/index.html
@@ -176,6 +176,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Prompt Caching","description":"Prompt caching preserves pre-computed Key-Value (KV) cache activations for shared token prefixes, reducing LLM prefill latency and token pricing.","url":"https://ngpestelos.com/reference/prompt-caching/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/prompt-engineering/index.html
+++ b/reference/prompt-engineering/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Prompt Engineering — Reference — Nestor G Pestelos Jr</title>
+  <title>Prompt Engineering · Reference · Nestor G Pestelos Jr</title>
   <meta name="description" content="A citable ground-truth reference on Prompt Engineering: autoregressive conditioning, in-context learning, reasoning scaffolding (CoT, ToT, ReAct), structured outputs, and prompt security.">
-  <meta property="og:title" content="Prompt Engineering — Reference">
+  <meta property="og:title" content="Prompt Engineering · Reference">
   <meta property="og:description" content="A citable ground-truth reference on Prompt Engineering: autoregressive conditioning, in-context learning, reasoning scaffolding (CoT, ToT, ReAct), structured outputs, and prompt security.">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://ngpestelos.com/reference/prompt-engineering/">
@@ -243,6 +243,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Prompt Engineering","description":"A citable ground-truth reference on Prompt Engineering: autoregressive conditioning, in-context learning, reasoning scaffolding (CoT, ToT, ReAct), structured outputs, and prompt security.","url":"https://ngpestelos.com/reference/prompt-engineering/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main>

--- a/reference/prompt/index.html
+++ b/reference/prompt/index.html
@@ -187,6 +187,9 @@
       .back, .back-to-top { display: none; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Prompts in Artificial Intelligence","description":"A citable ground-truth reference on prompts in generative AI: autoregressive prefix conditioning, role delineation schemas, prefill latency mechanics, and prompt injection vulnerabilities.","url":"https://ngpestelos.com/reference/prompt/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body>
   <main>

--- a/reference/reasoning/index.html
+++ b/reference/reasoning/index.html
@@ -187,6 +187,9 @@
       .back, .back-to-top { display: none; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Reasoning in Large Language Models","description":"A citable ground-truth reference on reasoning in large language models: test-time compute scaling, Chain-of-Thought formalisms, Process Reward Models, and inference-time search architectures.","url":"https://ngpestelos.com/reference/reasoning/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body>
   <main>

--- a/reference/recursion/index.html
+++ b/reference/recursion/index.html
@@ -195,6 +195,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Recursion","description":"Recursion is a computational method where a function calls itself to solve smaller subproblems. Covers call stacks, tail-call optimization, recurrence relations, and algorithmic complexity.","url":"https://ngpestelos.com/reference/recursion/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/reinforcement-learning/index.html
+++ b/reference/reinforcement-learning/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Reinforcement Learning — Reference — Nestor G Pestelos Jr</title>
+  <title>Reinforcement Learning · Reference · Nestor G Pestelos Jr</title>
   <meta name="description" content="A citable ground-truth reference on Reinforcement Learning (RL): Markov Decision Processes, Bellman optimality equations, policy gradients, Actor-Critic methods, PPO, DPO, and GRPO.">
-  <meta property="og:title" content="Reinforcement Learning — Reference">
+  <meta property="og:title" content="Reinforcement Learning · Reference">
   <meta property="og:description" content="A citable ground-truth reference on Reinforcement Learning (RL): Markov Decision Processes, Bellman optimality equations, policy gradients, Actor-Critic methods, PPO, DPO, and GRPO.">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://ngpestelos.com/reference/reinforcement-learning/">
@@ -257,6 +257,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Reinforcement Learning","description":"A citable ground-truth reference on Reinforcement Learning (RL): Markov Decision Processes, Bellman optimality equations, policy gradients, Actor-Critic methods, PPO, DPO, and GRPO.","url":"https://ngpestelos.com/reference/reinforcement-learning/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/retrieval-augmented-generation/index.html
+++ b/reference/retrieval-augmented-generation/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Retrieval-Augmented Generation — Reference — Nestor G Pestelos Jr</title>
+  <title>Retrieval-Augmented Generation · Reference · Nestor G Pestelos Jr</title>
   <meta name="description" content="Retrieval-Augmented Generation (RAG) is an AI architecture that grounds a language model's output in documents retrieved at query time. Pipeline, failure modes, and variants, cited.">
-  <meta property="og:title" content="Retrieval-Augmented Generation — Reference">
+  <meta property="og:title" content="Retrieval-Augmented Generation · Reference">
   <meta property="og:description" content="An AI architecture that grounds a language model's output in documents retrieved at query time. Pipeline, failure modes, and variants, cited.">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://ngpestelos.com/reference/retrieval-augmented-generation/">
@@ -190,6 +190,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Retrieval-Augmented Generation","description":"Retrieval-Augmented Generation (RAG) is an AI architecture that grounds a language model's output in documents retrieved at query time. Pipeline, failure modes, and variants, cited.","url":"https://ngpestelos.com/reference/retrieval-augmented-generation/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/reward-hacking/index.html
+++ b/reference/reward-hacking/index.html
@@ -142,6 +142,9 @@
       cursor: pointer;
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Reward Hacking","description":"Reward hacking is when an agent maximizes a formal reward in a way that does not match the designer's intended outcome. Definition, CoastRunners, Skalse unhackability, specification gaming.","url":"https://ngpestelos.com/reference/reward-hacking/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/romance-of-the-three-kingdoms/index.html
+++ b/reference/romance-of-the-three-kingdoms/index.html
@@ -166,6 +166,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Romance of the Three Kingdoms","description":"Romance of the Three Kingdoms (Sanguo yanyi) is a Ming historical novel traditionally attributed to Luo Guanzhong. Relation to Chen Shou's Sanguozhi, the Mao 120-chapter text, and later English translations.","url":"https://ngpestelos.com/reference/romance-of-the-three-kingdoms/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/rule-britannia/index.html
+++ b/reference/rule-britannia/index.html
@@ -180,6 +180,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Rule, Britannia!","description":"Rule, Britannia! is a British patriotic song from James Thomson's 1740 poem, set to music by Thomas Arne for the masque Alfred. Its origin, its role at the Last Night of the Proms, and the 2020 BBC controversy over its imperial and slave-trade associations.","url":"https://ngpestelos.com/reference/rule-britannia/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/semantic-caching/index.html
+++ b/reference/semantic-caching/index.html
@@ -179,6 +179,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Semantic Caching","description":"Semantic caching is a data-caching technique that matches incoming queries to stored results based on vector embedding similarity rather than exact string equality.","url":"https://ngpestelos.com/reference/semantic-caching/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/softmax/index.html
+++ b/reference/softmax/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Softmax Function — Reference — Nestor G Pestelos Jr</title>
+  <title>Softmax Function · Reference · Nestor G Pestelos Jr</title>
   <meta name="description" content="A citable ground-truth reference on the Softmax activation function: mathematical formulation, numerical stability tricks, temperature scaling, self-attention, and derivatives.">
-  <meta property="og:title" content="Softmax Function — Reference">
+  <meta property="og:title" content="Softmax Function · Reference">
   <meta property="og:description" content="A citable ground-truth reference on the Softmax activation function: mathematical formulation, numerical stability tricks, temperature scaling, self-attention, and derivatives.">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://ngpestelos.com/reference/softmax/">
@@ -212,6 +212,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Softmax Function","description":"A citable ground-truth reference on the Softmax activation function: mathematical formulation, numerical stability tricks, temperature scaling, self-attention, and derivatives.","url":"https://ngpestelos.com/reference/softmax/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main>

--- a/reference/sonke-ahrens/index.html
+++ b/reference/sonke-ahrens/index.html
@@ -175,6 +175,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Sönke Ahrens","description":"Sönke Ahrens is a German education researcher and author best known for popularizing Niklas Luhmann's Zettelkasten method through How to Take Smart Notes.","url":"https://ngpestelos.com/reference/sonke-ahrens/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/spaced-repetition/index.html
+++ b/reference/spaced-repetition/index.html
@@ -185,6 +185,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Spaced Repetition","description":"Spaced repetition is an evidence-based learning technique that reviews material at increasing intervals to counteract the psychological forgetting curve.","url":"https://ngpestelos.com/reference/spaced-repetition/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/steelmanning/index.html
+++ b/reference/steelmanning/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Steelmanning — Reference — Nestor G Pestelos Jr</title>
+  <title>Steelmanning · Reference · Nestor G Pestelos Jr</title>
   <meta name="description" content="Steelmanning is the practice of constructing the strongest possible version of an argument, typically one held by an opponent, before evaluating or responding to it. Covers its origin, its debt to the principle of charity, the manual and LLM-assisted methods, and the iron man fallacy it can produce when misapplied.">
-  <meta property="og:title" content="Steelmanning — Reference">
+  <meta property="og:title" content="Steelmanning · Reference">
   <meta property="og:description" content="The practice of constructing the strongest version of an opposing argument before responding to it. Origin, method, and the fallacy it produces when misapplied.">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://ngpestelos.com/reference/steelmanning/">
@@ -172,6 +172,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Steelmanning","description":"Steelmanning is the practice of constructing the strongest possible version of an argument, typically one held by an opponent, before evaluating or responding to it. Covers its origin, its debt to the principle of charity, the manual and LLM-assisted methods, and the iron man fallacy it can produce when misapplied.","url":"https://ngpestelos.com/reference/steelmanning/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/sycophancy/index.html
+++ b/reference/sycophancy/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Sycophancy — Reference — Nestor G Pestelos Jr</title>
+  <title>Sycophancy · Reference · Nestor G Pestelos Jr</title>
   <meta name="description" content="Sycophancy is a language model's tendency to tell a user what it appears to want to hear rather than what is accurate. Covers its source in human-feedback training, how it is measured, where it has been shown to generalize into worse behavior, and mitigations tried.">
-  <meta property="og:title" content="Sycophancy — Reference">
+  <meta property="og:title" content="Sycophancy · Reference">
   <meta property="og:description" content="A language model's tendency to tell a user what it appears to want to hear rather than what is accurate, and why it happens.">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://ngpestelos.com/reference/sycophancy/">
@@ -166,6 +166,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Sycophancy","description":"Sycophancy is a language model's tendency to tell a user what it appears to want to hear rather than what is accurate. Covers its source in human-feedback training, how it is measured, where it has been shown to generalize into worse behavior, and mitigations tried.","url":"https://ngpestelos.com/reference/sycophancy/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/theory-of-constraints/index.html
+++ b/reference/theory-of-constraints/index.html
@@ -195,6 +195,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Theory of Constraints","description":"The Theory of Constraints is a systems management philosophy stating that total system throughput is bounded strictly by its single primary constraint.","url":"https://ngpestelos.com/reference/theory-of-constraints/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/throughput/index.html
+++ b/reference/throughput/index.html
@@ -191,6 +191,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Throughput","description":"Throughput is the rate at which a system processes, produces, or delivers discrete units of output over time. Mathematical principles, Little's Law, queuing dynamics, scaling laws, and LLM inference.","url":"https://ngpestelos.com/reference/throughput/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/time-to-first-token/index.html
+++ b/reference/time-to-first-token/index.html
@@ -186,6 +186,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Time to First Token","description":"Time to First Token (TTFT) is the duration between sending a prompt to a language model and receiving its first generated token. Metrics, prefill vs decode, and latency optimizations.","url":"https://ngpestelos.com/reference/time-to-first-token/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/toctou-race-condition/index.html
+++ b/reference/toctou-race-condition/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>TOCTOU Race Condition — Reference — Nestor G Pestelos Jr</title>
+  <title>TOCTOU Race Condition · Reference · Nestor G Pestelos Jr</title>
   <meta name="description" content="A TOCTOU (time-of-check to time-of-use) race condition is a software bug where a program checks a resource's state, then acts on it, but the resource changes in the gap between the two. This entry covers the general shape, a classic example, and what does not qualify as one.">
-  <meta property="og:title" content="TOCTOU Race Condition — Reference">
+  <meta property="og:title" content="TOCTOU Race Condition · Reference">
   <meta property="og:description" content="A software bug where a program checks a resource's state, then acts on it, but the resource changes in the gap between the two. The general shape, a classic example, and what does not qualify.">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://ngpestelos.com/reference/toctou-race-condition/">
@@ -179,6 +179,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"TOCTOU Race Condition","description":"A TOCTOU (time-of-check to time-of-use) race condition is a software bug where a program checks a resource's state, then acts on it, but the resource changes in the gap between the two. This entry covers the general shape, a classic example, and what does not qualify as one.","url":"https://ngpestelos.com/reference/toctou-race-condition/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/tokens/index.html
+++ b/reference/tokens/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Tokens and Tokenization — Reference — Nestor G Pestelos Jr</title>
+  <title>Tokens and Tokenization · Reference · Nestor G Pestelos Jr</title>
   <meta name="description" content="A citable ground-truth reference on tokens in artificial intelligence: tokenization algorithms (BPE, WordPiece, Unigram), token lifecycle, KV cache scaling, and prompt caching economics.">
-  <meta property="og:title" content="Tokens and Tokenization — Reference">
+  <meta property="og:title" content="Tokens and Tokenization · Reference">
   <meta property="og:description" content="A citable ground-truth reference on tokens in AI: tokenization algorithms (BPE, WordPiece, Unigram), token lifecycle, KV cache scaling, and prompt caching economics.">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://ngpestelos.com/reference/tokens/">
@@ -212,6 +212,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Tokens and Tokenization","description":"A citable ground-truth reference on tokens in artificial intelligence: tokenization algorithms (BPE, WordPiece, Unigram), token lifecycle, KV cache scaling, and prompt caching economics.","url":"https://ngpestelos.com/reference/tokens/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main>

--- a/reference/url-urn-uri/index.html
+++ b/reference/url-urn-uri/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>URL vs URN vs URI — Reference — Nestor G Pestelos Jr</title>
+  <title>URL vs URN vs URI · Reference · Nestor G Pestelos Jr</title>
   <meta name="description" content="A URI (Uniform Resource Identifier) is the general class of resource identifier; a URL (Uniform Resource Locator) is a URI that locates a resource, and a URN (Uniform Resource Name) is a persistent, location-independent name. This entry clarifies the relationship from the defining RFCs.">
-  <meta property="og:title" content="URL vs URN vs URI — Reference">
+  <meta property="og:title" content="URL vs URN vs URI · Reference">
   <meta property="og:description" content="URI is the general class of resource identifier; URL locates a resource; URN names it persistently. The relationship between the three, from the defining RFCs.">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://ngpestelos.com/reference/url-urn-uri/">
@@ -198,6 +198,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"URL vs URN vs URI","description":"A URI (Uniform Resource Identifier) is the general class of resource identifier; a URL (Uniform Resource Locator) is a URI that locates a resource, and a URN (Uniform Resource Name) is a persistent, location-independent name. This entry clarifies the relationship from the defining RFCs.","url":"https://ngpestelos.com/reference/url-urn-uri/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/vannevar-bush/index.html
+++ b/reference/vannevar-bush/index.html
@@ -175,6 +175,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Vannevar Bush","description":"Vannevar Bush was an American engineer and science administrator who directed the OSRD during WWII and conceptualized the Memex, an early precursor to hypertext.","url":"https://ngpestelos.com/reference/vannevar-bush/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/vector-search/index.html
+++ b/reference/vector-search/index.html
@@ -187,6 +187,9 @@
       .back, .back-to-top { display: none; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Vector Search","description":"A citable ground-truth reference on vector search and dense retrieval: Approximate Nearest Neighbor (ANN) indexing, HNSW graphs, Product Quantization, and hybrid lexical-dense search.","url":"https://ngpestelos.com/reference/vector-search/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body>
   <main>

--- a/reference/zettelkasten/index.html
+++ b/reference/zettelkasten/index.html
@@ -175,6 +175,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Zettelkasten","description":"Zettelkasten is a decentralized card-index knowledge management methodology based on autonomous, atomic notes linked in a dynamic network.","url":"https://ngpestelos.com/reference/zettelkasten/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/reference/zhuge-liang/index.html
+++ b/reference/zhuge-liang/index.html
@@ -168,6 +168,9 @@
       .back-to-top { display: none !important; }
     }
   </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Zhuge Liang","description":"Zhuge Liang (Kongming, 181-234) was chancellor of Shu Han. Chen Shou's Sanguozhi biography versus the later Romance of the Three Kingdoms portrait.","url":"https://ngpestelos.com/reference/zhuge-liang/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
 </head>
 <body class="reference">
   <main id="top">

--- a/scripts/test_site_discoverability.py
+++ b/scripts/test_site_discoverability.py
@@ -22,6 +22,7 @@ ATOM = ROOT / "writing" / "atom.xml"
 PRIVACY = ROOT / "privacy.html"
 DEEP_DIVE = ROOT / "writing" / "legacy-rails-upgrade-with-agents" / "index.html"
 COMPARISON = ROOT / "writing" / "upgrade-or-rewrite" / "index.html"
+REF = ROOT / "reference"
 
 PAYMENTS = {
     "instapay-is-not-ach",
@@ -262,6 +263,45 @@ class SiteDiscoverabilityTests(unittest.TestCase):
         self.assertIn("8-check", deep)
         self.assertIn("1,116,726", deep)
         self.assertNotIn("ROI", comparison)
+
+
+class ReferenceSeoTests(unittest.TestCase):
+    def test_reference_titles_use_middot_not_emdash(self):
+        for path in sorted(REF.rglob("index.html")):
+            raw = path.read_bytes()
+            m = re.search(rb"<title>(.*?)</title>", raw, re.I | re.S)
+            self.assertIsNotNone(m, path)
+            title = m.group(1).decode("utf-8")
+            with self.subTest(path=str(path.relative_to(ROOT))):
+                self.assertNotIn("—", title)
+                self.assertNotIn("&mdash;", title)
+
+    def test_reference_entries_have_definedterm_jsonld(self):
+        for path in sorted(REF.glob("*/index.html")):
+            html = path.read_text(encoding="utf-8")
+            with self.subTest(slug=path.parent.name):
+                self.assertIn("application/ld+json", html)
+                self.assertIn('"@type":"DefinedTerm"', html)
+
+    def test_reference_index_has_jsonld(self):
+        html = (REF / "index.html").read_text(encoding="utf-8")
+        self.assertIn("application/ld+json", html)
+
+    def test_adversarial_review_title_scopes_ai_agents(self):
+        raw = (REF / "adversarial-agent-review" / "index.html").read_bytes()
+        title = re.search(rb"<title>(.*?)</title>", raw, re.I | re.S).group(1).decode("utf-8")
+        h1 = (REF / "adversarial-agent-review" / "index.html").read_text(encoding="utf-8")
+        self.assertIn("AI Agents", title)
+        self.assertIn("Adversarial Review (AI Agents)", h1)
+        self.assertNotIn("—", title)
+
+    def test_amdahls_title_targets_parallel_agents(self):
+        raw = (REF / "amdahls-law" / "index.html").read_bytes()
+        title = re.search(rb"<title>(.*?)</title>", raw, re.I | re.S).group(1).decode("utf-8")
+        html = (REF / "amdahls-law" / "index.html").read_text(encoding="utf-8")
+        self.assertIn("Parallel AI Agents", title)
+        self.assertIn("Amdahl's Law for Parallel AI Agents", html)
+        self.assertNotIn("—", title)
 
 
 if __name__ == "__main__":

--- a/writing/the-bugs-that-hide-between-your-agents/index.html
+++ b/writing/the-bugs-that-hide-between-your-agents/index.html
@@ -24,6 +24,9 @@
     gtag('js', new Date());
     gtag('config', 'G-TLBY8P4GG9');
   </script>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"Article","headline":"The Bugs That Hide Between Your Agents","description":"A two-day adversarial review of my agent infrastructure found bugs that file-scoped review could not see: contract drift, fake success, dead states, and untrusted text reaching write authority.","url":"https://ngpestelos.com/writing/the-bugs-that-hide-between-your-agents/","author":{"@type":"Person","name":"Nestor G Pestelos Jr"},"datePublished":"2026-07-08"}
+  </script>
 </head>
 <body>
   <main class="article">


### PR DESCRIPTION
Site half of https://github.com/ngpestelos/src/issues/163

- 78 reference entries emit Schema.org `DefinedTerm` JSON-LD
- Listing page emits `DefinedTermSet`
- `<title>` under `reference/` uses middots (0 em-dashes)
- Retitles: `Adversarial Review (AI Agents)`, `Amdahl's Law for Parallel AI Agents`
- Cross-link: `/reference/agentic-loops/` → `/reference/acceleration-whiplash/`
- Unittest: `ReferenceSeoTests` in `scripts/test_site_discoverability.py`

Also restored missing Article JSON-LD on `writing/the-bugs-that-hide-between-your-agents/` so the existing essay discoverability test stays green.

Skill-body rules ship on `ngpestelos/src` (sibling PR).
