### PR TITLE
Use default styles on reference index

### DIFF
--- a/reference/index.html
+++ b/reference/index.html
@@ -33,7 +33,6 @@
       scroll-behavior: smooth;
     }
     .back {
-      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
       font-size: 0.85rem;
       color: var(--mute);
       margin-bottom: 1.4rem;
@@ -46,7 +45,6 @@
       border-radius: 4px;
       padding: 0.6rem 0.8rem;
       margin-bottom: 1.8rem;
-      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
       font-size: 0.92rem;
       display: flex;
       flex-wrap: wrap;
@@ -88,7 +86,6 @@
       margin-bottom: 0;
     }
     .letter-heading {
-      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
       font-size: 1.2rem;
       font-weight: 700;
       color: var(--ink);
@@ -98,7 +95,6 @@
     }
     #reference ul {
       list-style: none;
-      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
     }
     #reference li {
       padding: 0.45rem 0;

--- a/reference/index.html
+++ b/reference/index.html
@@ -32,14 +32,6 @@
       text-size-adjust: 100%;
       scroll-behavior: smooth;
     }
-    body {
-      line-height: 1.6;
-    }
-    main {
-      max-width: 46rem;
-      margin: 0 auto;
-      padding: 1.4rem 1.4rem 4rem;
-    }
     .back {
       font-family: "Segoe UI", Helvetica, Arial, sans-serif;
       font-size: 0.85rem;
@@ -48,20 +40,6 @@
     }
     .back a { color: var(--link); text-decoration: none; }
     .back a:hover { text-decoration: underline; }
-    h1 {
-      font-size: clamp(1.9rem, 5vw, 2.4rem);
-      font-weight: 400;
-      border-bottom: 1px solid var(--line);
-      padding-bottom: 0.4rem;
-      margin-bottom: 1rem;
-    }
-    .next-step {
-      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
-      font-size: 0.98rem;
-      color: var(--mute);
-      max-width: 40ch;
-      margin-bottom: 1.4rem;
-    }
     .alpha-nav {
       background: var(--well);
       border: 1px solid var(--line);

--- a/scripts/test_site_theme.py
+++ b/scripts/test_site_theme.py
@@ -68,6 +68,7 @@ class SiteThemeTests(unittest.TestCase):
 
         index_html = text("reference/index.html")
         index_style = "".join(re.findall(r"<style>(.*?)</style>", index_html, re.S))
+        self.assertNotRegex(index_style, r"font-family\s*:")
         for selector in ("body", "main", "h1", ".next-step"):
             with self.subTest(selector=selector):
                 self.assertNotRegex(

--- a/scripts/test_site_theme.py
+++ b/scripts/test_site_theme.py
@@ -59,6 +59,13 @@ class SiteThemeTests(unittest.TestCase):
             self.assertNotRegex(style, r"body\s*\{[^}]*font-family:\s*\"Segoe UI\"")
 
     def test_reference_uses_landing_tokens(self):
+        css = text("style.css")
+        self.assertNotRegex(css, r"body\.eli5,\s*body\.reference\s*\{")
+        self.assertRegex(
+            css,
+            r"body\.eli5,\s*body\.reference:not\(:has\(#reference\)\)\s*\{\s*padding:\s*0;",
+        )
+
         index_html = text("reference/index.html")
         index_style = "".join(re.findall(r"<style>(.*?)</style>", index_html, re.S))
         for selector in ("body", "main", "h1", ".next-step"):

--- a/scripts/test_site_theme.py
+++ b/scripts/test_site_theme.py
@@ -59,6 +59,15 @@ class SiteThemeTests(unittest.TestCase):
             self.assertNotRegex(style, r"body\s*\{[^}]*font-family:\s*\"Segoe UI\"")
 
     def test_reference_uses_landing_tokens(self):
+        index_html = text("reference/index.html")
+        index_style = "".join(re.findall(r"<style>(.*?)</style>", index_html, re.S))
+        for selector in ("body", "main", "h1", ".next-step"):
+            with self.subTest(selector=selector):
+                self.assertNotRegex(
+                    index_style,
+                    rf"(?m)^\s*{re.escape(selector)}\s*\{{",
+                )
+
         for rel in ("reference/index.html", "reference/agents/index.html"):
             html = text(rel)
             self.assertIn(CSS_VER, html)

--- a/style.css
+++ b/style.css
@@ -510,7 +510,7 @@ body:has(#writing) {
 }
 
 body.eli5,
-body.reference {
+body.reference:not(:has(#reference)) {
   padding: 0;
 }
 
@@ -754,5 +754,4 @@ body:has(main.article) .table-wrap {
     display: none !important;
   }
 }
-
 


### PR DESCRIPTION
## Summary

- let the shared site stylesheet own the reference index layout, heading, and intro
- keep the reference-specific alphabetical navigation and grouping styles
- add regression coverage against page-level shared-style overrides

## Verification

- `python3 -m unittest scripts.test_site_theme scripts.test_site_discoverability` (19 tests passed)