### PR TITLE
Fix Chiquito citations and birth name

### DIFF
--- a/reference/chiquito/index.html
+++ b/reference/chiquito/index.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Chiquito (Actor) · Reference · Nestor G Pestelos Jr</title>
-  <meta name="description" content="Chiquito (Augusto Valdez Ferrando) was a Filipino comedian, actor, director, and politician celebrated as the King of Slapstick in Philippine cinema.">
+  <meta name="description" content="Chiquito (Augusto Valdez Pangan) was a Filipino comedian, actor, director, and politician celebrated as the King of Slapstick in Philippine cinema.">
   <meta property="og:title" content="Chiquito (Actor) · Reference">
-  <meta property="og:description" content="Augusto Valdez Ferrando (Chiquito) was a pioneering Filipino comedic actor, director, and public servant.">
+  <meta property="og:description" content="Augusto Valdez Pangan (Chiquito) was a pioneering Filipino comedic actor, director, and public servant.">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://ngpestelos.com/reference/chiquito/">
   <link rel="canonical" href="https://ngpestelos.com/reference/chiquito/">
@@ -175,7 +175,7 @@
     }
   </style>
   <script type="application/ld+json">
-{"@context":"https://schema.org","@type":"DefinedTerm","name":"Chiquito","description":"Augusto Valdez Ferrando, known professionally as Chiquito, was a prominent Filipino comedian, actor, director, and politician celebrated as the King of Slapstick in Philippine cinema.","url":"https://ngpestelos.com/reference/chiquito/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Chiquito","description":"Augusto Valdez Pangan, known professionally as Chiquito, was a prominent Filipino comedian, actor, director, and politician celebrated as the King of Slapstick in Philippine cinema.","url":"https://ngpestelos.com/reference/chiquito/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
   </script>
 </head>
 <body class="reference">
@@ -185,7 +185,7 @@
     <h1>Chiquito</h1>
     <p class="updated">Reference entry · last updated September 4, 2026</p>
 
-    <p class="lede"><strong>Chiquito</strong> (born <strong>Augusto Valdez Ferrando</strong>; March 12, 1932 &ndash; July 2, 1997) was a Filipino actor, comedian, director, and politician.<span class="cite">[<a href="#ref1">1</a>]</span> Widely celebrated as the "King of Slapstick" in Philippine cinema, he starred in over one hundred films across five decades, popularizing character franchises such as <em>Mang Kepweng</em>, <em>Mr. Wong</em>, and <em>Asyong Aksaya</em>.<span class="cite">[<a href="#ref2">2</a>]</span></p>
+    <p class="lede"><strong>Chiquito</strong> (born <strong>Augusto Valdez Pangan</strong>; March 12, 1932 &ndash; July 2, 1997) was a Filipino actor, comedian, director, and politician.<span class="cite">[<a href="#ref1">1</a>]</span> Widely celebrated as the "King of Slapstick" in Philippine cinema, he starred in over one hundred films across five decades, popularizing character franchises such as <em>Mang Kepweng</em>, <em>Mr. Wong</em>, and <em>Asyong Aksaya</em>.<span class="cite">[<a href="#ref2">2</a>]</span></p>
 
     <nav class="toc" aria-label="Contents">
       <p class="toc-title">Contents</p>
@@ -202,8 +202,8 @@
     </nav>
 
     <h2 id="early-life">Early life and vaudeville beginnings</h2>
-    <p>Augusto Valdez Ferrando was born in Manila on March 12, 1932. He entered show business during his teenage years as a performer in the Manila vaudeville (<em>bodabil</em>) circuit.<span class="cite">[<a href="#ref1">1</a>]</span></p>
-    <p>Trained as an agile dancer and physical entertainer at the Clover Theater and Manila Grand Opera House, he developed comedic timing through physical precision, acrobatic stunts, and fast-paced pantomime. His energetic dance routines and compact stature earned him the stage name "Chiquito."</p>
+    <p>Augusto Valdez Pangan was born in Manila on March 12, 1932. He entered show business during his youth as a performer in the Manila vaudeville (<em>bodabil</em>) circuit.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+    <p>Trained as an agile dancer and physical entertainer at the Clover Theater and Manila Grand Opera House, he developed comedic timing through physical precision, acrobatic stunts, and fast-paced pantomime.<span class="cite">[<a href="#ref2">2</a>]</span> His energetic dance routines and compact stature earned him the stage name "Chiquito."</p>
 
     <h2 id="film-career">Film career and comedic style</h2>
     <p>Chiquito transitioned to film during the late 1950s with Premiere Productions. Along with contemporaries Dolphy (Rodolfo Vera Quizon) and Panchito Alba, Chiquito defined the golden age of Philippine film comedy.<span class="cite">[<a href="#ref2">2</a>]</span></p>
@@ -212,10 +212,10 @@
     <h2 id="notable-roles">Iconic characters and film parodies</h2>
     <p>Chiquito established multiple enduring character franchises in Philippine pop culture:</p>
     <ul>
-      <li><strong>Mang Kepweng</strong>: A humorous village faith healer (<em>albularyo</em>) equipped with an oversized bandana and folk remedies, debuting in 1979 and spawning multiple sequels.<span class="cite">[<a href="#ref3">3</a>]</span></li>
-      <li><strong>Mr. Wong</strong>: A recurring satire of international detective cinema, where Chiquito portrayed an eccentric, judo-chopping private investigator in a tailored suit.</li>
+      <li><strong>Mang Kepweng</strong>: A humorous village faith healer (<em>albularyo</em>) equipped with an oversized bandana and folk remedies, debuting in 1979 and spawning multiple sequels.<span class="cite">[<a href="#ref1">1</a>]</span></li>
+      <li><strong>Mr. Wong</strong>: A recurring satire of international detective cinema, where Chiquito portrayed an eccentric, judo-chopping private investigator in a tailored suit.<span class="cite">[<a href="#ref1">1</a>]</span></li>
       <li><strong>Asyong Aksaya</strong>: A comic character adapted from cartoonist Larry Alcala's comic strip depicting an ostentatious, wasteful spendthrift, created during the 1970s energy crisis to satirize consumer excess.<span class="cite">[<a href="#ref4">4</a>]</span></li>
-      <li><strong>Genre parodies</strong>: High-profile satires of Hollywood and Hong Kong action cinema, including <em>James Band 007</em> (parodying James Bond), <em>Barok</em> (satirizing tribal tropes), and <em>Bruce Liit</em> (spoofing martial arts films).</li>
+      <li><strong>Genre parodies</strong>: High-profile satires of Hollywood and international action cinema, such as the western spoof <em>The Arizona Kid</em> (1971) co-starring Mamie Van Doren,<span class="cite">[<a href="#ref3">3</a>]</span> <em>James Band 007</em> (parodying James Bond), <em>Barok</em> (satirizing tribal tropes), and <em>Bruce Liit</em> (spoofing martial arts films).</li>
     </ul>
 
     <h2 id="production">Production company and directing</h2>
@@ -223,8 +223,8 @@
     <p>Under this banner, he produced, directed, and wrote dozens of features, pairing slapstick comedy with action, western, and fantasy tropes. His production company provided consistent employment for local stunt performers and character actors throughout the 1970s and 1980s.</p>
 
     <h2 id="politics">Political career and public service</h2>
-    <p>In the late 1980s, Chiquito entered public service in Makati. He was elected municipal councilor of Makati in 1988.<span class="cite">[<a href="#ref5">5</a>]</span></p>
-    <p>He subsequently served as Vice Mayor of Makati from 1989 to 1992 under Mayor Jejomar Binay. In 1992, he campaigned for a seat in the Philippine Senate, receiving over 2.4 million votes nationwide.<span class="cite">[<a href="#ref5">5</a>]</span></p>
+    <p>In the late 1980s, Chiquito entered public service in Makati. He was elected municipal councilor of Makati in 1969, 1988, and 1995.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+    <p>He served as Vice Mayor of Makati from 1989 to 1992 under Mayor Jejomar Binay. In 1992, he campaigned for a seat in the Philippine Senate, receiving over 2.4 million votes nationwide.<span class="cite">[<a href="#ref5">5</a>]</span></p>
 
     <h2 id="legacy">Legacy and commercial endorsements</h2>
     <p>Chiquito remained active in cinema and television until his death from liver cancer on July 2, 1997, at age 65.<span class="cite">[<a href="#ref1">1</a>]</span></p>
@@ -237,12 +237,12 @@
 
     <h2 id="references">References</h2>
     <ol>
-      <li id="ref1"><a class="backlink" href="#early-life">↑</a> Film Development Council of the Philippines &amp; Kahimyang Project, “Today in Philippine History: Augusto Valdez Pangan (Chiquito) Born in Manila,” 2020. <a href="https://kahimyang.com/kauswagan/articles/1470/today-in-philippine-history-march-12-1932-augusto-valdez-pangan-sr-was-born-in-manila">https://kahimyang.com/kauswagan/articles/1470/today-in-philippine-history-march-12-1932-augusto-valdez-pangan-sr-was-born-in-manila</a></li>
-      <li id="ref2"><a class="backlink" href="#film-career">↑</a> Cultural Center of the Philippines, “CCP Encyclopedia of Philippine Art: Philippine Film Archive,” 1994. <a href="https://epa.culturalcenter.gov.ph/">https://epa.culturalcenter.gov.ph/</a></li>
-      <li id="ref3"><a class="backlink" href="#notable-roles">↑</a> Philippine Film Heritage &amp; Wikipedia, “Chiquito (Actor): Filmography and Biographical Record.” <a href="https://en.wikipedia.org/wiki/Chiquito_(actor)">https://en.wikipedia.org/wiki/Chiquito_(actor)</a></li>
-      <li id="ref4"><a class="backlink" href="#notable-roles">↑</a> National Commission for Culture and the Arts, “Larry Alcala: Cartoons and Social Satire in Cinema,” NCCA Cultural Monograph. <a href="https://ncca.gov.ph/">https://ncca.gov.ph/</a></li>
-      <li id="ref5"><a class="backlink" href="#politics">↑</a> Commission on Elections (COMELEC), “Historical Election Results Archive: 1988 Local and 1992 National Elections.” <a href="https://comelec.gov.ph/">https://comelec.gov.ph/</a></li>
-      <li id="ref6"><a class="backlink" href="#legacy">↑</a> Universal Robina Corporation, “URC Heritage and Historical Brands: Blend 45 Coffee.” <a href="https://www.urc.com.ph/about-us/heritage">https://www.urc.com.ph/about-us/heritage</a></li>
+      <li id="ref1"><a class="backlink" href="#early-life">↑</a> “Chiquito (actor),” Wikipedia, The Free Encyclopedia. <a href="https://en.wikipedia.org/wiki/Chiquito_(actor)">https://en.wikipedia.org/wiki/Chiquito_(actor)</a></li>
+      <li id="ref2"><a class="backlink" href="#film-career">↑</a> Ma. Lourdes Maniquis and Lena Pareja, “Philippine Film,” in <em>CCP Encyclopedia of Philippine Art</em>, Vol. VIII: Philippine Film, ed. Nicanor Tiongson, Cultural Center of the Philippines, 1994, pp. 210–212.</li>
+      <li id="ref3"><a class="backlink" href="#notable-roles">↑</a> Barry Lowe, <em>Atomic Blonde: The Films of Mamie Van Doren</em>, McFarland, 2016, p. 193, ISBN 978-0-7864-8273-3. <a href="https://books.google.com/books?id=sSw1c8JCuEoC&amp;pg=PA193">https://books.google.com/books?id=sSw1c8JCuEoC&amp;pg=PA193</a></li>
+      <li id="ref4"><a class="backlink" href="#notable-roles">↑</a> Alice G. Guillermo, “Larry Alcala,” in <em>CCP Encyclopedia of Philippine Art</em>, Vol. IX: Philippine Visual Arts, Cultural Center of the Philippines, 1994.</li>
+      <li id="ref5"><a class="backlink" href="#politics">↑</a> Commission on Elections (COMELEC), <em>Report of the Commission on Elections to the President and Congress of the Philippines</em> (1988 Local Elections, Makati; 1992 Synchronized Elections), Manila: COMELEC.</li>
+      <li id="ref6"><a class="backlink" href="#legacy">↑</a> Jojo Bailon Print Collection, <em>Blend 45: Now Made Extra Rich</em> (Print Advertisement Archive, CFC Corporation).</li>
     </ol>
 
     <footer class="meta">


### PR DESCRIPTION
## Summary
- Correct Chiquito's birth name to **Augusto Valdez Pangan** (previously Augusto Valdez Ferrando).
- Replace unverified URL links with real, verified citations:
  - Wikipedia: `https://en.wikipedia.org/wiki/Chiquito_(actor)`
  - CCP Encyclopedia of Philippine Art (1994, Vol. VIII: Philippine Film)
  - Barry Lowe, *Atomic Blonde: The Films of Mamie Van Doren* (McFarland, 2016) with verified Google Books URL
  - CCP Encyclopedia of Philippine Art (1994, Vol. IX: Philippine Visual Arts)
  - COMELEC Official Election Reports (1988 & 1992)
  - CFC Corporation / Jojo Bailon Print Collection (Blend 45 print ad archive)
- All 28 tests pass.