### PR TITLE
Add Intermediate Packets reference

### DIFF
--- a/reference/atomic-note/index.html
+++ b/reference/atomic-note/index.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Atomic Note · Reference · Nestor G Pestelos Jr</title>
-  <meta name="description" content="An atomic note is a self-contained unit of knowledge that captures exactly one idea, concept, or insight with clear provenance and associative links.">
+  <meta name="description" content="An atomic note centers on one idea. The practice comes from the Zettelkasten lineage and differs from an Intermediate Packet.">
   <meta property="og:title" content="Atomic Note · Reference">
-  <meta property="og:description" content="A self-contained knowledge unit expressing a single concept or insight.">
+  <meta property="og:description" content="A note centered on one idea, with roots in the Zettelkasten tradition.">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://ngpestelos.com/reference/atomic-note/">
   <link rel="canonical" href="https://ngpestelos.com/reference/atomic-note/">
@@ -176,7 +176,7 @@
     }
   </style>
   <script type="application/ld+json">
-{"@context":"https://schema.org","@type":"DefinedTerm","name":"Atomic Note","description":"An atomic note is a self-contained unit of knowledge that captures exactly one idea, concept, or insight with clear provenance and associative links.","url":"https://ngpestelos.com/reference/atomic-note/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Atomic Note","description":"An atomic note centers on one idea. The practice comes from the Zettelkasten lineage and differs from an Intermediate Packet.","url":"https://ngpestelos.com/reference/atomic-note/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
   </script>
 </head>
 <body class="reference">
@@ -184,84 +184,77 @@
     <p class="back"><a href="/reference/">← Reference</a> · <a href="/">Nestor G Pestelos Jr</a> · <a href="#" onclick="window.print(); return false;">Print this page</a></p>
     <p class="kicker">Knowledge Management · Information Architecture</p>
     <h1>Atomic Note</h1>
-    <p class="updated">Reference entry · last updated August 30, 2026</p>
+    <p class="updated">Reference entry · last updated September 4, 2026</p>
 
-    <p class="lede"><strong>Atomic note</strong> is a self-contained unit of knowledge that captures exactly one idea, concept, or insight.<span class="cite">[<a href="#ref1">1</a>]</span> The principle of atomicity requires that the note remains fully comprehensible on its own while serving as a modular building block for larger synthesis, argumentation, and network linkage.<span class="cite">[<a href="#ref2">2</a>]</span></p>
+    <p class="lede"><strong>Atomic note</strong> is a note centered on one idea or knowledge building block.<span class="cite">[<a href="#ref1">1</a>]</span> Atomicity concerns conceptual scope. It does not prescribe a word count, file format, or metadata scheme.<span class="cite">[<a href="#ref2">2</a>]</span></p>
 
     <nav class="toc" aria-label="Contents">
       <p class="toc-title">Contents</p>
       <ol>
         <li><a href="#principle">The atomicity principle</a></li>
-        <li><a href="#origins">Origins in the Zettelkasten method</a></li>
-        <li><a href="#structure">Anatomy and structural constraints</a></li>
-        <li><a href="#combinatorial">Combinatorial utility and synthesis</a></li>
-        <li><a href="#taxonomy">Distinction from other note types</a></li>
+        <li><a href="#origins">Zettelkasten lineage and terminology</a></li>
+        <li><a href="#structure">Implementation choices</a></li>
+        <li><a href="#combinatorial">Linking and reuse</a></li>
+        <li><a href="#taxonomy">Relationship to Intermediate Packets</a></li>
         <li><a href="#see-also">See also</a></li>
         <li><a href="#references">References</a></li>
       </ol>
     </nav>
 
     <h2 id="principle">The atomicity principle</h2>
-    <p>The atomicity principle states that a single note should contain only one discrete idea.<span class="cite">[<a href="#ref1">1</a>]</span> If a text attempts to address two separate arguments, mechanisms, or claims, it must be split into two separate atomic notes and connected via a hypertext link.</p>
-    <p>This constraint delivers three functional advantages:</p>
+    <p>The atomicity principle directs each note toward one idea.<span class="cite">[<a href="#ref1">1</a>]</span> A note can include examples, evidence, and context that serve that idea. The appropriate boundary depends on the intended use, and strict fragmentation can make a note less useful.<span class="cite">[<a href="#ref2">2</a>]</span></p>
     <ul>
-      <li><strong>Precise linkage</strong>: When another document references the note, the link points directly to a specific claim rather than an unindexed long-form document.</li>
-      <li><strong>Modularity</strong>: An atomic note can be recombined into multiple different outlines, maps of content, or essays without dragging along unrelated concepts.</li>
-      <li><strong>Cognitive clarity</strong>: Forcing an insight into a single self-contained note tests whether the author truly understands the core mechanism.</li>
+      <li><strong>Precise links</strong>: A link can point to a specific claim or concept.</li>
+      <li><strong>Reuse</strong>: A focused note can support several projects without carrying unrelated material.</li>
+      <li><strong>Clear scope</strong>: A narrow focus helps expose missing context and mixed arguments.</li>
     </ul>
 
-    <h2 id="origins">Origins in the Zettelkasten method</h2>
-    <p>The atomic note concept derives from the card-index system (<em><a href="/reference/zettelkasten/">Zettelkasten</a></em>) developed by German sociologist <a href="/reference/niklas-luhmann/">Niklas Luhmann</a>.<span class="cite">[<a href="#ref3">3</a>]</span> Luhmann restricted each paper slip (<em>Zettel</em>) to one thought, written on one side of an index card, and assigned each an alphanumeric identifier (such as <code>21/3d7a</code>) to allow infinite branching and cross-referencing.<span class="cite">[<a href="#ref4">4</a>]</span></p>
-    <p>In modern digital knowledge management, researchers and writers adapted Luhmann's physical slip constraints into digital hypertext systems. <a href="/reference/andy-matuschak/">Andy Matuschak</a> popularized the term <em><a href="/reference/evergreen-notes/">evergreen notes</a></em>, emphasizing that digital atomic notes should be concept-oriented, densely linked, and continually revised over time.<span class="cite">[<a href="#ref2">2</a>]</span> <a href="/reference/sonke-ahrens/">Sönke Ahrens</a> formalized the theoretical framework in <a href="/reference/how-to-take-smart-notes/"><em>How to Take Smart Notes</em></a>, contrasting atomic permanent notes with temporary inbox captures.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+    <h2 id="origins">Zettelkasten lineage and terminology</h2>
+    <p>The one-idea-per-note practice belongs to the <a href="/reference/zettelkasten/">Zettelkasten</a> lineage. Contemporary Zettelkasten sources describe atomicity as one knowledge building block per note and treat it as a direction for note-making, not a rigid law.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+    <p>Digital note-makers extended the practice. <a href="/reference/andy-matuschak/">Andy Matuschak</a>, for example, describes <a href="/reference/evergreen-notes/">evergreen notes</a> as atomic when each note is about one thing and preserves the context needed to understand that thing.<span class="cite">[<a href="#ref2">2</a>]</span> These sources do not establish one person as the inventor of the modern English term <em>atomic note</em>.</p>
+    <p>Forte calls reusable units of project work <a href="/reference/intermediate-packets/">Intermediate Packets</a>.<span class="cite">[<a href="#ref3">3</a>]</span> His framework describes work as reusable building blocks, but it does not originate the atomic-note term.</p>
 
-    <h2 id="structure">Anatomy and structural constraints</h2>
-    <p>In contemporary knowledge bases, an atomic note adheres to strict structural standards to maintain automated retrieval and cross-domain synthesis:</p>
+    <h2 id="structure">Implementation choices</h2>
+    <p>An atomic note needs one clear focus. Other structural features depend on the note system:</p>
     <ul>
-      <li><strong>Title as declarative thesis</strong>: The filename expresses a complete, active claim (for example, <code>Deals Under Two Thousand Need No Call.md</code>) rather than a vague topic bucket.</li>
-      <li><strong>Body word budget</strong>: The core body is constrained to a concise limit (often under 300 words) to prevent topic creep.</li>
-      <li><strong>Progressive summary</strong>: Layered summaries (such as an executive summary, key insight quote, and context line) enable rapid scanning.</li>
-      <li><strong>Frontmatter metadata</strong>: Machine-readable YAML headers track creation date, tags, permalink, and related associative links.</li>
-      <li><strong>Provenance and public URL citation</strong>: Visible source citations ground every factual assertion in verified primary documents or accessible URLs.</li>
+      <li>a title that names the idea or states the note's claim;</li>
+      <li>enough context for the note to remain understandable;</li>
+      <li>links to related notes and sources; and</li>
+      <li>metadata that supports retrieval in a particular tool.</li>
     </ul>
+    <p>Word limits, progressive summaries, YAML frontmatter, and public URL citations are system-specific conventions. They can support brevity, retrieval, or provenance, but they are not universal requirements for atomic notes.</p>
 
-    <h2 id="combinatorial">Combinatorial utility and synthesis</h2>
-    <p>Because atomic notes are modular and unburdened by rigid hierarchical folder constraints, they facilitate bottom-up idea emergence. Rather than organizing knowledge top-down before writing, an author gathers related atomic notes into associative clusters, known as maps of content (MOCs), to evaluate emerging theses and draft publications.<span class="cite">[<a href="#ref5">5</a>]</span></p>
+    <h2 id="combinatorial">Linking and reuse</h2>
+    <p>A focused note gives links a precise target. It can be connected across topics and reused in outlines, <a href="/reference/map-of-content/">maps of content</a>, or later writing. Notes that are too broad can blur those links, while notes split too finely can fragment the network.<span class="cite">[<a href="#ref2">2</a>]</span></p>
 
-    <h2 id="taxonomy">Distinction from other note types</h2>
-    <p>Personal knowledge systems categorize information into distinct stages of processing:</p>
+    <h2 id="taxonomy">Relationship to Intermediate Packets</h2>
+    <p>Atomicity classifies a note by conceptual scope. The Intermediate Packet category classifies an artifact by its role in reusable project work. An atomic note can function as an Intermediate Packet when it becomes input to a project.<span class="cite">[<a href="#ref3">3</a>]</span></p>
+    <p>Intermediate Packets have a wider range of forms:</p>
     <ul>
-      <li><strong>Fleeting notes</strong>: Raw, temporary inbox captures, voice memos, or highlights that are processed and subsequently discarded.</li>
-      <li><strong>Literature notes</strong>: Source-centric summaries capturing what an external author said in a specific book or article.</li>
-      <li><strong>Atomic notes (Permanent notes)</strong>: Concept-centric, synthesized units of understanding written in the author's own words with verified source provenance.</li>
-      <li><strong>Maps of content (MOCs)</strong>: Higher-order hub notes that curate, sequence, and evaluate clusters of atomic notes around a specific thesis.</li>
-      <li><strong>Reference documents</strong>: Exhaustive specifications, runbooks, or archive documents exempt from the single-idea brevity limit.</li>
+      <li>meeting notes and research lists;</li>
+      <li>slides, diagrams, drafts, and templates; and</li>
+      <li>completed deliverables that can contribute to later work.</li>
     </ul>
+    <p>A packet can contain several ideas. Its defining property is useful reuse in project work.<span class="cite">[<a href="#ref3">3</a>]</span></p>
 
     <h2 id="see-also">See also</h2>
     <ul>
       <li><a href="/reference/zettelkasten/">Zettelkasten</a></li>
+      <li><a href="/reference/intermediate-packets/">Intermediate Packets</a></li>
       <li><a href="/reference/evergreen-notes/">Evergreen notes</a></li>
       <li><a href="/reference/how-to-take-smart-notes/">How to Take Smart Notes</a></li>
       <li><a href="/reference/andy-matuschak/">Andy Matuschak</a></li>
       <li><a href="/reference/sonke-ahrens/">Sönke Ahrens</a></li>
       <li><a href="/reference/niklas-luhmann/">Niklas Luhmann</a></li>
       <li><a href="/reference/map-of-content/">Map of content</a></li>
-      <li><a href="/reference/memex/">Memex</a></li>
       <li><a href="/reference/linking-your-thinking/">Linking Your Thinking</a></li>
-      <li><a href="/reference/nick-milo/">Nick Milo</a></li>
-      <li><a href="/reference/vannevar-bush/">Vannevar Bush</a></li>
-      <li><a href="/reference/epistemology/">Epistemology</a></li>
-      <li><a href="/reference/context-engineering/">Context engineering</a></li>
-      <li><a href="/reference/adversarial-agent-review/">Adversarial review</a></li>
     </ul>
 
     <h2 id="references">References</h2>
     <ol>
-      <li id="ref1"><a class="backlink" href="#principle">↑</a> Sönke Ahrens, <em>How to Take Smart Notes: One Simple Technique to Boost Writing, Learning and Thinking</em>, CreateSpace, 2017.</li>
-      <li id="ref2"><a class="backlink" href="#principle">↑</a> Andy Matuschak, “Evergreen note titles are like APIs,” 2020. Public notes: <a href="https://notes.andymatuschak.org/Evergreen_notes">https://notes.andymatuschak.org/Evergreen_notes</a></li>
-      <li id="ref3"><a class="backlink" href="#origins">↑</a> Niklas Luhmann, “Kommunikation mit Zettelkästen: Ein Erfahrungsbericht,” in <em>Universität als Milieu: Kleine Schriften</em>, H. Baier, Ed. Bielefeld: Haux, 1992, pp. 53–61.</li>
-      <li id="ref4"><a class="backlink" href="#origins">↑</a> Johannes F. K. Schmidt, “Niklas Luhmann's Card Index: Thinking Tool, Communication Partner, Publication Machine,” in <em>Forgetting Machines: Knowledge Management Evolution in Early Modern Europe</em>, A. Cevolini, Ed. Leiden: Brill, 2016, pp. 289–311.</li>
-      <li id="ref5"><a class="backlink" href="#combinatorial">↑</a> Nick Milo, <em>Linking Your Thinking: Maps of Content</em>, 2020. <a href="https://www.linkingyourthinking.com/">https://www.linkingyourthinking.com/</a></li>
+      <li id="ref1"><a class="backlink" href="#principle">↑</a> Sascha Fast, “Introduction to the Zettelkasten Method,” <em>Zettelkasten Method</em>. <a href="https://zettelkasten.de/introduction/">https://zettelkasten.de/introduction/</a></li>
+      <li id="ref2"><a class="backlink" href="#principle">↑</a> Andy Matuschak, “Evergreen notes should be atomic,” <em>Andy's working notes</em>. <a href="https://notes.andymatuschak.org/Evergreen_notes_should_be_atomic">https://notes.andymatuschak.org/Evergreen_notes_should_be_atomic</a></li>
+      <li id="ref3"><a class="backlink" href="#origins">↑</a> Tiago Forte, <em>Building a Second Brain</em>, Atria Books, 2022, pp. 152–154. <a href="https://www.simonandschuster.com/books/Building-a-Second-Brain/Tiago-Forte/9781982167387">Official publisher page</a>.</li>
     </ol>
 
     <footer class="meta">

--- a/reference/index.html
+++ b/reference/index.html
@@ -174,7 +174,7 @@
       <a href="#F">F</a>
       <a href="#G">G</a>
       <a href="#H">H</a>
-      <span class="empty">I</span>
+      <a href="#I">I</a>
       <span class="empty">J</span>
       <a href="#K">K</a>
       <a href="#L">L</a>
@@ -273,6 +273,13 @@
         <ul>
         <li><a href="/reference/hanlons-razor/">Hanlon's Razor</a></li>
         <li><a href="/reference/how-to-take-smart-notes/">How to Take Smart Notes</a></li>
+        </ul>
+      </div>
+
+      <div class="letter-group" id="I">
+        <h2 class="letter-heading">I</h2>
+        <ul>
+        <li><a href="/reference/intermediate-packets/">Intermediate Packets</a></li>
         </ul>
       </div>
 

--- a/reference/intermediate-packets/index.html
+++ b/reference/intermediate-packets/index.html
@@ -178,7 +178,7 @@
     <h1>Intermediate Packets</h1>
     <p class="updated">Reference entry · last updated September 4, 2026</p>
 
-    <p class="lede"><strong>Intermediate Packet</strong> is a reusable piece of work that can contribute to a current or future project. Tiago Forte introduced the term in his <em>Building a Second Brain</em> system for tangible units such as notes, outlines, drafts, slides, templates, and completed deliverables.<span class="cite">[<a href="#ref3">3</a>]</span></p>
+    <p class="lede"><strong>Intermediate Packet</strong> is a reusable piece of work that can contribute to a current or future project. Tiago Forte introduced the term.<span class="cite">[<a href="#ref1">1</a>]</span> In his <em>Building a Second Brain</em> system, Intermediate Packets include tangible units such as notes, outlines, drafts, slides, templates, and completed deliverables.<span class="cite">[<a href="#ref3">3</a>]</span></p>
 
     <nav class="toc" aria-label="Contents">
       <p class="toc-title">Contents</p>

--- a/reference/intermediate-packets/index.html
+++ b/reference/intermediate-packets/index.html
@@ -178,7 +178,7 @@
     <h1>Intermediate Packets</h1>
     <p class="updated">Reference entry · last updated September 4, 2026</p>
 
-    <p class="lede"><strong>Intermediate Packet</strong> is a reusable piece of work that can contribute to a current or future project. Tiago Forte introduced the term in his <em>Building a Second Brain</em> system for tangible units such as notes, outlines, drafts, slides, templates, and completed deliverables.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+    <p class="lede"><strong>Intermediate Packet</strong> is a reusable piece of work that can contribute to a current or future project. Tiago Forte introduced the term in his <em>Building a Second Brain</em> system for tangible units such as notes, outlines, drafts, slides, templates, and completed deliverables.<span class="cite">[<a href="#ref3">3</a>]</span></p>
 
     <nav class="toc" aria-label="Contents">
       <p class="toc-title">Contents</p>
@@ -232,7 +232,7 @@
     </ul>
     <h2 id="atomic-notes">Relationship to atomic notes</h2>
     <p>An <a href="/reference/atomic-note/">atomic note</a> is classified by conceptual scope. It centers on one idea or knowledge building block.<span class="cite">[<a href="#ref4">4</a>]</span> An Intermediate Packet is classified by reuse in project work. Its size and format depend on the work it supports.</p>
-    <p>The categories overlap when an atomic note becomes input to a project. Meeting notes, slide decks, drafts, templates, and final deliverables may contain several ideas while remaining reusable units of work.<span class="cite">[<a href="#ref1">1</a>]</span> The Zettelkasten atomicity principle and Forte's Intermediate Packet concept address different properties of an artifact.<span class="cite">[<a href="#ref5">5</a>]</span></p>
+    <p>The categories overlap when an atomic note becomes input to a project. Meeting notes, slide decks, drafts, templates, and final deliverables may contain several ideas while remaining reusable units of work.<span class="cite">[<a href="#ref3">3</a>]</span> The Zettelkasten atomicity principle and Forte's Intermediate Packet concept address different properties of an artifact.<span class="cite">[<a href="#ref5">5</a>]</span></p>
 
     <h2 id="see-also">See also</h2>
     <ul>

--- a/reference/intermediate-packets/index.html
+++ b/reference/intermediate-packets/index.html
@@ -1,0 +1,279 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Intermediate Packets · Reference · Nestor G Pestelos Jr</title>
+  <meta name="description" content="Intermediate Packets are reusable pieces of work that can contribute to current or future projects.">
+  <meta property="og:title" content="Intermediate Packets · Reference">
+  <meta property="og:description" content="Reusable pieces of work that can contribute to current or future projects.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://ngpestelos.com/reference/intermediate-packets/">
+  <link rel="canonical" href="https://ngpestelos.com/reference/intermediate-packets/">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=20260813f">
+  <link rel="icon" href="/favicon-192.png?v=20260813f" type="image/png" sizes="192x192">
+  <link rel="icon" href="/favicon-32.png?v=20260813f" type="image/png" sizes="32x32">
+  <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
+  <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="stylesheet" href="/style.css?v=20260903e">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TLBY8P4GG9');
+  </script>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
+    body {
+      line-height: 1.6;
+    }
+    main {
+      max-width: 46rem;
+      margin: 0 auto;
+      padding: 1.4rem 1.4rem 4rem;
+    }
+    .back {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .back a { color: var(--link); text-decoration: none; }
+    .back a:hover { text-decoration: underline; }
+    .kicker {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.78rem;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--mute);
+      margin-bottom: 0.3rem;
+    }
+    h1 {
+      font-size: clamp(1.9rem, 5vw, 2.4rem);
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.4rem;
+      margin-bottom: 1rem;
+    }
+    .updated {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.82rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .lede { margin-bottom: 1.6rem; }
+    .lede strong:first-child { font-weight: 700; }
+    .toc {
+      background: var(--well);
+      border: 1px solid var(--line);
+      border-radius: 4px;
+      padding: 1rem 1.4rem;
+      margin-bottom: 2rem;
+      max-width: 28rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.92rem;
+    }
+    .toc .toc-title {
+      font-weight: 700;
+      margin-bottom: 0.5rem;
+      text-align: center;
+    }
+    .toc ol { padding-left: 1.3rem; }
+    .toc ol ol { margin-bottom: 0; }
+    .toc li { margin: 0.2rem 0; }
+    .toc a { color: var(--link); text-decoration: none; }
+    .toc a:hover { text-decoration: underline; }
+    h2 {
+      font-size: 1.5rem;
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.3rem;
+      margin: 2rem 0 0.9rem;
+    }
+    h3 {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 1.05rem;
+      margin: 1.3rem 0 0.45rem;
+    }
+    p { margin-bottom: 0.9rem; }
+    ul, ol { padding-left: 1.5rem; margin-bottom: 0.9rem; }
+    li { margin-bottom: 0.3rem; }
+    a { color: var(--link); }
+    a:visited { color: var(--link-visited); }
+    .cite {
+      font-size: 0.75em;
+      vertical-align: super;
+      line-height: 0;
+      text-decoration: none;
+    }
+    .cite a { text-decoration: none; }
+    #see-also ul, #references ol {
+      padding-left: 1.5rem;
+    }
+    #see-also li, #references li { margin-bottom: 0.5rem; }
+    #references { font-size: 0.95rem; }
+    #references .backlink { margin-right: 0.3rem; }
+    footer.meta {
+      margin-top: 3rem;
+      padding-top: 1.2rem;
+      border-top: 1px solid var(--line);
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+    }
+    footer.meta a { color: var(--link); }
+    @media print {
+      .back {font-family:"Segoe UI", Helvetica, Arial, sans-serif;display: none;}
+    }
+    .back-to-top {
+      position: fixed;
+      bottom: 1.5rem;
+      right: 1.5rem;
+      width: 2.6rem;
+      height: 2.6rem;
+      border-radius: 50%;
+      background: var(--bg);
+      color: var(--ink);
+      border: 1px solid var(--line);
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      opacity: 0;
+      visibility: hidden;
+      transform: translateY(8px);
+      transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease, background 0.15s ease, border-color 0.15s ease;
+      z-index: 100;
+    }
+    .back-to-top.visible {
+      opacity: 1;
+      visibility: visible;
+      transform: translateY(0);
+    }
+    .back-to-top:hover {
+      background: var(--well);
+      border-color: var(--link);
+      color: var(--link);
+    }
+    .back-to-top:focus-visible {
+      outline: 2px solid var(--link);
+      outline-offset: 2px;
+    }
+    @media print {
+      .back-to-top { display: none !important; }
+    }
+  </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Intermediate Packet","description":"An Intermediate Packet is a reusable piece of work that can contribute to a current or future project.","url":"https://ngpestelos.com/reference/intermediate-packets/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
+</head>
+<body class="reference">
+  <main id="top">
+    <p class="back"><a href="/reference/">← Reference</a> · <a href="/">Nestor G Pestelos Jr</a> · <a href="#" onclick="window.print(); return false;">Print this page</a></p>
+    <p class="kicker">Knowledge Management · Project Work</p>
+    <h1>Intermediate Packets</h1>
+    <p class="updated">Reference entry · last updated September 4, 2026</p>
+
+    <p class="lede"><strong>Intermediate Packet</strong> is a reusable piece of work that can contribute to a current or future project. Tiago Forte introduced the term in his <em>Building a Second Brain</em> system for tangible units such as notes, outlines, drafts, slides, templates, and completed deliverables.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+
+    <nav class="toc" aria-label="Contents">
+      <p class="toc-title">Contents</p>
+      <ol>
+        <li><a href="#origin">Origin and purpose</a></li>
+        <li><a href="#kinds">Five kinds of Intermediate Packets</a>
+          <ol>
+            <li><a href="#distilled-notes">Distilled notes</a></li>
+            <li><a href="#outtakes">Outtakes</a></li>
+            <li><a href="#work-in-process">Work-in-process</a></li>
+            <li><a href="#final-deliverables">Final deliverables</a></li>
+            <li><a href="#documents-by-others">Documents created by others</a></li>
+          </ol>
+        </li>
+        <li><a href="#benefits">Practical benefits</a></li>
+        <li><a href="#atomic-notes">Relationship to atomic notes</a></li>
+        <li><a href="#see-also">See also</a></li>
+        <li><a href="#references">References</a></li>
+      </ol>
+    </nav>
+
+    <h2 id="origin">Origin and purpose</h2>
+    <p>Forte used the term in his February 2017 article “Bending the Curves of Productivity.” He proposed packaging research, notes, brainstorms, examples, outlines, prototypes, drafts, and unused ideas as reusable components.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+    <p>Three months later, Forte described Intermediate Packets as units smaller than deliverables, including digital notes, work-in-progress drafts, outlines, brainstorms, and checklists.<span class="cite">[<a href="#ref2">2</a>]</span> The <em>Building a Second Brain</em> book places these reusable assets in the Express stage of its Capture, Organize, Distill, Express method.<span class="cite">[<a href="#ref3">3</a>]</span></p>
+
+    <h2 id="kinds">Five kinds of Intermediate Packets</h2>
+    <p><em>Building a Second Brain</em> identifies five kinds of packets.<span class="cite">[<a href="#ref3">3</a>]</span></p>
+
+    <h3 id="distilled-notes">Distilled notes</h3>
+    <p>Distilled notes compress books, articles, meetings, or research into material that can be reviewed and applied without rereading the full source.</p>
+
+    <h3 id="outtakes">Outtakes</h3>
+    <p>Outtakes are useful material removed from an earlier project. A cut paragraph, unused diagram, or rejected example can remain available for later work.</p>
+
+    <h3 id="work-in-process">Work-in-process</h3>
+    <p>Work-in-process includes artifacts created while a project develops, such as plans, agendas, graphics, requirement documents, checklists, and drafts.</p>
+
+    <h3 id="final-deliverables">Final deliverables</h3>
+    <p>Completed reports, presentations, templates, and other delivered work can supply parts of later projects.</p>
+
+    <h3 id="documents-by-others">Documents created by others</h3>
+    <p>Documents from colleagues, clients, contractors, and other contributors can serve as packets when permission, attribution, and reuse rights allow it.</p>
+
+    <h2 id="benefits">Practical benefits</h2>
+    <p>Intermediate Packets reduce the amount of project state held in memory. A preserved artifact provides a clear point for resuming work after an interruption.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+    <ul>
+      <li><strong>Short work periods</strong>: A packet can fit the time available.</li>
+      <li><strong>Earlier feedback</strong>: A small draft or prototype can be reviewed before the project is heavily committed.</li>
+      <li><strong>Lower starting cost</strong>: Existing research, outlines, and templates reduce blank-page work.</li>
+      <li><strong>Reuse</strong>: One artifact can contribute to several deliverables or projects.</li>
+    </ul>
+    <h2 id="atomic-notes">Relationship to atomic notes</h2>
+    <p>An <a href="/reference/atomic-note/">atomic note</a> is classified by conceptual scope. It centers on one idea or knowledge building block.<span class="cite">[<a href="#ref4">4</a>]</span> An Intermediate Packet is classified by reuse in project work. Its size and format depend on the work it supports.</p>
+    <p>The categories overlap when an atomic note becomes input to a project. Meeting notes, slide decks, drafts, templates, and final deliverables may contain several ideas while remaining reusable units of work.<span class="cite">[<a href="#ref1">1</a>]</span> The Zettelkasten atomicity principle and Forte's Intermediate Packet concept address different properties of an artifact.<span class="cite">[<a href="#ref5">5</a>]</span></p>
+
+    <h2 id="see-also">See also</h2>
+    <ul>
+      <li><a href="/reference/atomic-note/">Atomic note</a></li>
+      <li><a href="/reference/zettelkasten/">Zettelkasten</a></li>
+      <li><a href="/reference/evergreen-notes/">Evergreen notes</a></li>
+      <li><a href="/reference/map-of-content/">Map of content</a></li>
+      <li><a href="/reference/kitbashing/">Kitbashing</a></li>
+    </ul>
+
+    <h2 id="references">References</h2>
+    <ol>
+      <li id="ref1"><a class="backlink" href="#origin">↑</a> Tiago Forte, “Bending the Curves of Productivity,” <em>Forte Labs</em>, February 1, 2017. <a href="https://fortelabs.com/blog/bending-the-curves-of-productivity/">https://fortelabs.com/blog/bending-the-curves-of-productivity/</a></li>
+      <li id="ref2"><a class="backlink" href="#origin">↑</a> Tiago Forte, “Mood as Extrapolation Engine: Using Emotions to Generate Momentum,” <em>Forte Labs</em>, May 24, 2017. <a href="https://fortelabs.com/blog/mood-as-extrapolation-engine-using-emotions-to-generate-momentum/">https://fortelabs.com/blog/mood-as-extrapolation-engine-using-emotions-to-generate-momentum/</a></li>
+      <li id="ref3"><a class="backlink" href="#origin">↑</a> Tiago Forte, <em>Building a Second Brain</em>, Atria Books, 2022, pp. 152–154. <a href="https://www.simonandschuster.com/books/Building-a-Second-Brain/Tiago-Forte/9781982167387">Official publisher page</a>.</li>
+      <li id="ref4"><a class="backlink" href="#atomic-notes">↑</a> Andy Matuschak, “Evergreen notes should be atomic,” <em>Andy's working notes</em>. <a href="https://notes.andymatuschak.org/Evergreen_notes_should_be_atomic">https://notes.andymatuschak.org/Evergreen_notes_should_be_atomic</a></li>
+      <li id="ref5"><a class="backlink" href="#atomic-notes">↑</a> Sascha Fast, “Introduction to the Zettelkasten Method,” <em>Zettelkasten Method</em>. <a href="https://zettelkasten.de/introduction/">https://zettelkasten.de/introduction/</a></li>
+    </ol>
+
+    <footer class="meta">
+      <p><a href="#top">Back to top</a></p>
+    </footer>
+  </main>
+  <button id="backToTop" class="back-to-top" aria-label="Back to top" title="Back to top">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M18 15l-6-6-6 6"/>
+    </svg>
+  </button>
+
+  <script>
+    const btt = document.getElementById('backToTop');
+    window.addEventListener('scroll', () => {
+      if (window.scrollY > 250) {
+        btt.classList.add('visible');
+      } else {
+        btt.classList.remove('visible');
+      }
+    }, { passive: true });
+    btt.addEventListener('click', () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  </script>
+</body>
+</html>

--- a/scripts/test_site_discoverability.py
+++ b/scripts/test_site_discoverability.py
@@ -287,6 +287,15 @@ class ReferenceSeoTests(unittest.TestCase):
         html = (REF / "index.html").read_text(encoding="utf-8")
         self.assertIn("application/ld+json", html)
 
+    def test_intermediate_packets_is_registered(self):
+        html = (REF / "index.html").read_text(encoding="utf-8")
+        self.assertIn('href="/reference/intermediate-packets/"', html)
+        locs = sitemap_locs(SITEMAP.read_text(encoding="utf-8"))
+        self.assertIn(
+            "https://ngpestelos.com/reference/intermediate-packets/",
+            locs,
+        )
+
     def test_adversarial_review_title_scopes_ai_agents(self):
         raw = (REF / "adversarial-agent-review" / "index.html").read_bytes()
         title = re.search(rb"<title>(.*?)</title>", raw, re.I | re.S).group(1).decode("utf-8")

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -541,6 +541,11 @@
     <priority>0.5</priority>
   </url>
   <url>
+    <loc>https://ngpestelos.com/reference/intermediate-packets/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
     <loc>https://ngpestelos.com/reference/linking-your-thinking/</loc>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>


### PR DESCRIPTION
## Summary
- correct the Atomic Note entry provenance and separate atomicity from local vault conventions
- add a sourced Intermediate Packets reference entry with the five packet types
- register the new page in the reference index and sitemap

## Verification
- `python3 -m unittest discover -s scripts -p 'test_*.py'` (29 tests passed)
- reference title, JSON-LD, TOC, citation, voice, and diff checks passed

## Sources
- Tiago Forte, “Bending the Curves of Productivity” (2017)
- Tiago Forte, “Mood as Extrapolation Engine” (2017)
- Andy Matuschak, “Evergreen notes should be atomic”
- Zettelkasten Method introduction