### PR TITLE
Add Personal Knowledge Management reference page

### DIFF
--- a/reference/index.html
+++ b/reference/index.html
@@ -335,6 +335,7 @@
       <div class="letter-group" id="P">
         <h2 class="letter-heading">P</h2>
         <ul>
+        <li><a href="/reference/personal-knowledge-management/">Personal Knowledge Management</a></li>
         <li><a href="/reference/plan-approve-execute/">Plan-Approve-Execute</a></li>
         <li><a href="/reference/pre-training/">Pre-Training</a></li>
         <li><a href="/reference/prompt/">Prompt</a></li>

--- a/reference/personal-knowledge-management/index.html
+++ b/reference/personal-knowledge-management/index.html
@@ -1,0 +1,299 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Personal Knowledge Management · Reference · Nestor G Pestelos Jr</title>
+  <meta name="description" content="Personal knowledge management (PKM) is the practice of capturing, organizing, synthesizing, and retrieving individual knowledge to support thinking and creative output.">
+  <meta property="og:title" content="Personal Knowledge Management · Reference">
+  <meta property="og:description" content="The practice of capturing, organizing, synthesizing, and retrieving individual knowledge to support thinking and creative output.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://ngpestelos.com/reference/personal-knowledge-management/">
+  <link rel="canonical" href="https://ngpestelos.com/reference/personal-knowledge-management/">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=20260813f">
+  <link rel="icon" href="/favicon-192.png?v=20260813f" type="image/png" sizes="192x192">
+  <link rel="icon" href="/favicon-32.png?v=20260813f" type="image/png" sizes="32x32">
+  <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
+  <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="stylesheet" href="/style.css?v=20260903e">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TLBY8P4GG9');
+  </script>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
+    body {
+      line-height: 1.6;
+    }
+    main {
+      max-width: 46rem;
+      margin: 0 auto;
+      padding: 1.4rem 1.4rem 4rem;
+    }
+    .back {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .back a { color: var(--link); text-decoration: none; }
+    .back a:hover { text-decoration: underline; }
+    .kicker {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.78rem;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--mute);
+      margin-bottom: 0.3rem;
+    }
+    h1 {
+      font-size: clamp(1.9rem, 5vw, 2.4rem);
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.4rem;
+      margin-bottom: 1rem;
+    }
+    .updated {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.82rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .lede { margin-bottom: 1.6rem; }
+    .lede strong:first-child { font-weight: 700; }
+    .toc {
+      background: var(--well);
+      border: 1px solid var(--line);
+      border-radius: 4px;
+      padding: 1rem 1.4rem;
+      margin-bottom: 2rem;
+      max-width: 24rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.92rem;
+    }
+    .toc .toc-title {
+      font-weight: 700;
+      margin-bottom: 0.5rem;
+      text-align: center;
+    }
+    .toc ol { padding-left: 1.3rem; }
+    .toc li { margin: 0.2rem 0; }
+    .toc a { color: var(--link); text-decoration: none; }
+    .toc a:hover { text-decoration: underline; }
+    h2 {
+      font-size: 1.5rem;
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.3rem;
+      margin: 2rem 0 0.9rem;
+    }
+    p { margin-bottom: 0.9rem; }
+    ul, ol { padding-left: 1.5rem; margin-bottom: 0.9rem; }
+    li { margin-bottom: 0.3rem; }
+    a { color: var(--link); }
+    a:visited { color: var(--link-visited); }
+    code {
+      font-family: "SF Mono", Consolas, Monaco, monospace;
+      font-size: 0.9em;
+      background: var(--well);
+      padding: 0.1em 0.35em;
+      border-radius: 3px;
+    }
+    .cite {
+      font-size: 0.75em;
+      vertical-align: super;
+      line-height: 0;
+      text-decoration: none;
+    }
+    .cite a { text-decoration: none; }
+    #see-also ul, #references ol {
+      padding-left: 1.5rem;
+    }
+    #see-also li, #references li { margin-bottom: 0.5rem; }
+    #references { font-size: 0.95rem; }
+    #references .backlink { margin-right: 0.3rem; }
+    .unattributed {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+      font-style: italic;
+    }
+    footer.meta {
+      margin-top: 3rem;
+      padding-top: 1.2rem;
+      border-top: 1px solid var(--line);
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+    }
+    footer.meta a { color: var(--link); }
+    @media print {
+      .back { font-family: "Segoe UI", Helvetica, Arial, sans-serif; display: none; }
+    }
+    .back-to-top {
+      position: fixed;
+      bottom: 1.5rem;
+      right: 1.5rem;
+      width: 2.6rem;
+      height: 2.6rem;
+      border-radius: 50%;
+      background: var(--bg);
+      color: var(--ink);
+      border: 1px solid var(--line);
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      opacity: 0;
+      visibility: hidden;
+      transform: translateY(8px);
+      transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease, background 0.15s ease, border-color 0.15s ease;
+      z-index: 100;
+    }
+    .back-to-top.visible {
+      opacity: 1;
+      visibility: visible;
+      transform: translateY(0);
+    }
+    .back-to-top:hover {
+      background: var(--well);
+      border-color: var(--link);
+      color: var(--link);
+    }
+    .back-to-top:focus-visible {
+      outline: 2px solid var(--link);
+      outline-offset: 2px;
+    }
+    @media print {
+      .back-to-top { display: none !important; }
+    }
+  </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Personal Knowledge Management","description":"Personal knowledge management (PKM) is the practice of capturing, organizing, synthesizing, and retrieving individual knowledge to support thinking and creative output.","url":"https://ngpestelos.com/reference/personal-knowledge-management/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
+</head>
+<body class="reference">
+  <main id="top">
+    <p class="back"><a href="/reference/">← Reference</a> · <a href="/">Nestor G Pestelos Jr</a> · <a href="#" onclick="window.print(); return false;">Print this page</a></p>
+    <p class="kicker">Knowledge Management · Cognitive Systems</p>
+    <h1>Personal Knowledge Management</h1>
+    <p class="updated">Reference entry · last updated September 4, 2026</p>
+
+    <p class="lede"><strong>Personal knowledge management</strong> (<strong>PKM</strong>) is a process of capturing, organizing, synthesizing, and retrieving an individual's information and ideas to support cognitive work and creative output.<span class="cite">[<a href="#ref1">1</a>]</span> Unlike organizational knowledge management, PKM centers on personal agency, bottom-up sensemaking, and individual workflow rather than institutional taxonomy or corporate compliance.<span class="cite">[<a href="#ref2">2</a>]</span></p>
+
+    <nav class="toc" aria-label="Contents">
+      <p class="toc-title">Contents</p>
+      <ol>
+        <li><a href="#origins">Origins and conceptual history</a></li>
+        <li><a href="#core-processes">Core processes</a></li>
+        <li><a href="#frameworks">Prominent frameworks and methodologies</a></li>
+        <li><a href="#personal-vs-enterprise">Personal versus organizational knowledge management</a></li>
+        <li><a href="#tooling-evolution">Evolution of tools and substrates</a></li>
+        <li><a href="#see-also">See also</a></li>
+        <li><a href="#references">References</a></li>
+      </ol>
+    </nav>
+
+    <h2 id="origins">Origins and conceptual history</h2>
+    <p>The conceptual roots of PKM precede modern computing. The practice traces to commonplace books used by Renaissance scholars, excerpt collections kept by Enlightenment philosophers, and physical card indexes.<span class="cite">[<a href="#ref3">3</a>]</span> In 1945, <a href="/reference/vannevar-bush/">Vannevar Bush</a> proposed the <a href="/reference/memex/">Memex</a>, a theoretical electromechanical desk that allowed an individual to store books, records, and communications, establishing associative links between items that mirrored the human mind.<span class="cite">[<a href="#ref4">4</a>]</span></p>
+    <p>Academic formulation of the term emerged in the late 1990s. In 1999, Jason Frand and Carol G. Hixon at the UCLA Anderson School of Management defined PKM as an essential literacy framework for knowledge workers entering the digital economy, identifying key skills required to convert unstructured information into structured knowledge.<span class="cite">[<a href="#ref1">1</a>]</span> In 2001, Paul A. Dorsey at Millikin University operationalized PKM into seven foundational capabilities: retrieving, evaluating, organizing, analyzing, conveying, collaborating, and securing information.<span class="cite">[<a href="#ref2">2</a>]</span></p>
+    <p>The field underwent renewed adoption in the 2010s and 2020s through the digital note-making community. Scholars and practitioners revived <a href="/reference/niklas-luhmann/">Niklas Luhmann</a>'s slip-box system, popularized by <a href="/reference/sonke-ahrens/">Sönke Ahrens</a> as the <a href="/reference/zettelkasten/">Zettelkasten</a> method.<span class="cite">[<a href="#ref5">5</a>]</span> Contemporaneously, independent researchers such as <a href="/reference/andy-matuschak/">Andy Matuschak</a> developed principles around <a href="/reference/evergreen-notes/">evergreen notes</a>,<span class="cite">[<a href="#ref6">6</a>]</span> while Tiago Forte popularized the Building a Second Brain curriculum.<span class="cite">[<a href="#ref7">7</a>]</span></p>
+
+    <h2 id="core-processes">Core processes</h2>
+    <p>PKM systems encompass five continuous cognitive operations:</p>
+    <ul>
+      <li><strong>Capture</strong>: Gathering external material, including reading highlights, web excerpts, meeting records, and raw thoughts. Effective capture filters for personal resonance and relevance, avoiding indiscriminate collection that produces digital hoarding.</li>
+      <li><strong>Processing and distillation</strong>: Reviewing raw captures to extract core claims, clarify context, and condense source material into reusable statements.</li>
+      <li><strong>Organization and synthesis</strong>: Situating ideas into a conceptual network through bidirectional linking, hierarchy, or topical clustering. Synthesis integrates disparate notes into novel arguments or <a href="/reference/atomic-note/">atomic notes</a>.</li>
+      <li><strong>Retrieval</strong>: Locating relevant material through full-text search, semantic indexing, metadata queries, or navigational trails across linked notes.</li>
+      <li><strong>Output and expression</strong>: Transforming internal knowledge assets into tangible deliverables, such as essays, research reports, software code, designs, or project decisions. Output prevents note systems from becoming self-contained archives that do not produce external utility.</li>
+    </ul>
+
+    <h2 id="frameworks">Prominent frameworks and methodologies</h2>
+    <p>Practitioners have developed structured methodologies to guide personal knowledge workflows:</p>
+    <ul>
+      <li><strong>Zettelkasten</strong>: Developed by sociologist <a href="/reference/niklas-luhmann/">Niklas Luhmann</a>, this method separates fleeting notes, literature notes, and permanent notes on standardized cards. Cards receive unique alphanumeric identifiers that allow branching threads of thought, forming an interconnected network of ideas.<span class="cite">[<a href="#ref5">5</a>]</span></li>
+      <li><strong>PARA Method</strong>: Formulated by Tiago Forte, PARA organizes digital assets into four discrete categories based on actionability: Projects (active short-term efforts), Areas (long-term spheres of responsibility), Resources (topics of ongoing interest), and Archives (inactive items retained for reference).<span class="cite">[<a href="#ref7">7</a>]</span></li>
+      <li><strong>Evergreen Notes</strong>: Formulated by <a href="/reference/andy-matuschak/">Andy Matuschak</a>, this approach emphasizes writing conceptual, atomic notes designed to evolve over years through iterative revision and dense cross-linking.<span class="cite">[<a href="#ref6">6</a>]</span></li>
+      <li><strong>Linking Your Thinking (LYT)</strong>: Created by <a href="/reference/nick-milo/">Nick Milo</a>, LYT relies on fluid associative linking supplemented by higher-order index notes termed <a href="/reference/map-of-content/">maps of content</a> (MOCs), providing flexible navigation without rigid taxonomies.<span class="cite">[<a href="#ref8">8</a>]</span></li>
+    </ul>
+
+    <h2 id="personal-vs-enterprise">Personal versus organizational knowledge management</h2>
+    <p>While organizational knowledge management addresses institutional memory, compliance, and cross-team information sharing, personal knowledge management addresses individual cognition.<span class="cite">[<a href="#ref9">9</a>]</span></p>
+    <ul>
+      <li><strong>Governance</strong>: Enterprise systems impose standardized taxonomies, access control, and metadata schemas. PKM systems rely on idiosyncratic, emergent categorization adapted to one person's mental model.</li>
+      <li><strong>Incentives</strong>: Enterprise knowledge entry often suffers from documentation reluctance when employees see little immediate personal benefit. PKM creates immediate utility for the author by reducing cognitive load and accelerating current projects.</li>
+      <li><strong>Structure</strong>: Enterprise knowledge repositories prioritize top-down hierarchical consistency. PKM systems often favor organic, bottom-up associative graphs where structure arises naturally from connected thoughts.</li>
+    </ul>
+
+    <h2 id="tooling-evolution">Evolution of tools and substrates</h2>
+    <p>Tools for PKM have progressed through several technical paradigms:</p>
+    <ul>
+      <li><strong>Physical index cards</strong>: Slip boxes and card files provided spatial, tactile manipulation and modular reordering without fixed book bindings.</li>
+      <li><strong>Hierarchical file systems</strong>: Early digital approaches used desktop folder trees, outliners, and commercial note programs (such as Microsoft OneNote or Evernote) where notes resided in single categorical silos.</li>
+      <li><strong>Networked thought environments</strong>: Tools such as Roam Research, Obsidian, and Logseq introduced plain-text files, bidirectional wikilinks, and graph views, enabling non-linear associative connections across files.</li>
+      <li><strong>Local-first and machine-assisted search</strong>: Modern implementations emphasize durable local-first plain-text formats (such as Markdown) coupled with vector embeddings, semantic retrieval tools, and local large language models that assist in discovery without cloud lock-in.</li>
+    </ul>
+
+    <h2 id="see-also">See also</h2>
+    <ul>
+      <li><a href="/reference/atomic-note/">Atomic Note</a></li>
+      <li><a href="/reference/intermediate-packets/">Intermediate Packets</a></li>
+      <li><a href="/reference/zettelkasten/">Zettelkasten</a></li>
+      <li><a href="/reference/evergreen-notes/">Evergreen Notes</a></li>
+      <li><a href="/reference/map-of-content/">Map of Content</a></li>
+      <li><a href="/reference/linking-your-thinking/">Linking Your Thinking</a></li>
+      <li><a href="/reference/memex/">Memex</a></li>
+      <li><a href="/reference/vannevar-bush/">Vannevar Bush</a></li>
+      <li><a href="/reference/niklas-luhmann/">Niklas Luhmann</a></li>
+      <li><a href="/reference/sonke-ahrens/">Sönke Ahrens</a></li>
+      <li><a href="/reference/andy-matuschak/">Andy Matuschak</a></li>
+      <li><a href="/reference/nick-milo/">Nick Milo</a></li>
+      <li><a href="/reference/spaced-repetition/">Spaced Repetition</a></li>
+      <li><a href="/reference/how-to-take-smart-notes/">How to Take Smart Notes</a></li>
+    </ul>
+
+    <h2 id="references">References</h2>
+    <ol>
+      <li id="ref1"><a class="backlink" href="#origins">↑</a> Jason Frand and Carol G. Hixon, “Personal Knowledge Management: From Information to Knowledge,” <em>UCLA Anderson School of Management Working Paper</em>, 1999.</li>
+      <li id="ref2"><a class="backlink" href="#origins">↑</a> Paul A. Dorsey, “Personal Knowledge Management: Educational Framework for Knowledge Workers,” <em>Millikin University</em>, 2001.</li>
+      <li id="ref3"><a class="backlink" href="#origins">↑</a> Ann M. Blair, <em>Too Much to Know: Managing Scholarly Information before the Modern Age</em>, Yale University Press, 2010.</li>
+      <li id="ref4"><a class="backlink" href="#origins">↑</a> Vannevar Bush, “As We May Think,” <em>The Atlantic Monthly</em>, July 1945. <a href="https://www.theatlantic.com/magazine/archive/1945/07/as-we-may-think/303881/">https://www.theatlantic.com/magazine/archive/1945/07/as-we-may-think/303881/</a></li>
+      <li id="ref5"><a class="backlink" href="#origins">↑</a> Sönke Ahrens, <em>How to Take Smart Notes: One Simple Technique to Boost Writing, Learning and Thinking</em>, CreateSpace, 2017.</li>
+      <li id="ref6"><a class="backlink" href="#origins">↑</a> Andy Matuschak, “Evergreen notes should be atomic,” <em>Andy's working notes</em>, 2020. <a href="https://notes.andymatuschak.org/Evergreen_notes_should_be_atomic">https://notes.andymatuschak.org/Evergreen_notes_should_be_atomic</a></li>
+      <li id="ref7"><a class="backlink" href="#origins">↑</a> Tiago Forte, <em>Building a Second Brain: A Proven Method to Organize Your Digital Life and Unlock Your Creative Potential</em>, Atria Books, 2022.</li>
+      <li id="ref8"><a class="backlink" href="#frameworks">↑</a> Nick Milo, “Linking Your Thinking,” <em>Linking Your Thinking</em>. <a href="https://www.linkingyourthinking.com/">https://www.linkingyourthinking.com/</a></li>
+      <li id="ref9"><a class="backlink" href="#personal-vs-enterprise">↑</a> Ikujiro Nonaka and Hirotaka Takeuchi, <em>The Knowledge-Creating Company: How Japanese Companies Create the Dynamics of Innovation</em>, Oxford University Press, 1995.</li>
+    </ol>
+
+    <footer class="meta">
+      <p><a href="#top">Back to top</a></p>
+    </footer>
+  </main>
+  <button id="backToTop" class="back-to-top" aria-label="Back to top" title="Back to top">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M18 15l-6-6-6 6"/>
+    </svg>
+  </button>
+
+  <script>
+    const btt = document.getElementById('backToTop');
+    window.addEventListener('scroll', () => {
+      if (window.scrollY > 250) {
+        btt.classList.add('visible');
+      } else {
+        btt.classList.remove('visible');
+      }
+    }, { passive: true });
+    btt.addEventListener('click', () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  </script>
+</body>
+</html>

--- a/scripts/test_site_discoverability.py
+++ b/scripts/test_site_discoverability.py
@@ -296,6 +296,15 @@ class ReferenceSeoTests(unittest.TestCase):
             locs,
         )
 
+    def test_personal_knowledge_management_is_registered(self):
+        html = (REF / "index.html").read_text(encoding="utf-8")
+        self.assertIn('href="/reference/personal-knowledge-management/"', html)
+        locs = sitemap_locs(SITEMAP.read_text(encoding="utf-8"))
+        self.assertIn(
+            "https://ngpestelos.com/reference/personal-knowledge-management/",
+            locs,
+        )
+
     def test_adversarial_review_title_scopes_ai_agents(self):
         raw = (REF / "adversarial-agent-review" / "index.html").read_bytes()
         title = re.search(rb"<title>(.*?)</title>", raw, re.I | re.S).group(1).decode("utf-8")

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -371,6 +371,11 @@
     <priority>0.5</priority>
   </url>
   <url>
+    <loc>https://ngpestelos.com/reference/personal-knowledge-management/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
     <loc>https://ngpestelos.com/reference/plan-approve-execute/</loc>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>


### PR DESCRIPTION
## Summary
Adds an encyclopedia-style reference page for Personal Knowledge Management (PKM) at `/reference/personal-knowledge-management/`.

- Covers conceptual origins (Vannevar Bush, Frand & Hixon, Dorsey, Luhmann).
- Defines five core processes (Capture, Distillation, Synthesis, Retrieval, Output).
- Contrasts prominent frameworks (Zettelkasten, PARA, Evergreen Notes, LYT).
- Distinguishes PKM from enterprise knowledge management.
- Outlines the evolution of tools from slip boxes to networked thought and machine-assisted search.
- Includes DefinedTerm JSON-LD, lede definition, TOC, print link, back-to-top button, and verified bibliographic citations.
- Registers the entry in `reference/index.html` (group P) and `sitemap.xml`.
- Adds regression test in `scripts/test_site_discoverability.py`.

## Verification
- `python3 -m unittest discover -s scripts -p 'test_*.py'` (30/30 tests passed).
- Zero em-dashes in prose.
- Title middot lint passed.