### PR TITLE
Align 8 reference pages with site theme tokens

### DIFF
--- a/reference/bm25/index.html
+++ b/reference/bm25/index.html
@@ -35,22 +35,9 @@
       ]
     });"></script>
   <style>
-    :root {
-      --bg: #ffffff;
-      --well: #f8f9fa;
-      --box-bg: #f8f9fa;
-      --ink: #202122;
-      --mute: #54595d;
-      --line: #a2a9b1;
-      --link: #0645ad;
-      --link-visited: #795cb2;
-    }
     * { box-sizing: border-box; margin: 0; padding: 0; }
     html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
     body {
-      background: var(--bg);
-      color: var(--ink);
-      font-family: Georgia, "Times New Roman", serif;
       line-height: 1.6;
     }
     main {
@@ -213,7 +200,7 @@
 {"@context":"https://schema.org","@type":"DefinedTerm","name":"BM25 (Best Matching 25)","description":"A citable ground-truth reference on the BM25 (Best Matching 25) ranking algorithm: mathematical formulation, TF saturation, length normalization, variants, and hybrid retrieval.","url":"https://ngpestelos.com/reference/bm25/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
   </script>
 </head>
-<body>
+<body class="reference">
   <main>
     <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/reference/">Reference</a><span class="print"> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a></span></p>
     <div class="kicker">Information Retrieval &middot; Ranking Functions</div>

--- a/reference/context-window/index.html
+++ b/reference/context-window/index.html
@@ -35,22 +35,9 @@
       ]
     });"></script>
   <style>
-    :root {
-      --bg: #ffffff;
-      --well: #f8f9fa;
-      --box-bg: #f8f9fa;
-      --ink: #202122;
-      --mute: #54595d;
-      --line: #a2a9b1;
-      --link: #0645ad;
-      --link-visited: #795cb2;
-    }
     * { box-sizing: border-box; margin: 0; padding: 0; }
     html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
     body {
-      background: var(--bg);
-      color: var(--ink);
-      font-family: Georgia, "Times New Roman", serif;
       line-height: 1.6;
     }
     main {
@@ -191,7 +178,7 @@
 {"@context":"https://schema.org","@type":"DefinedTerm","name":"Context Windows","description":"A citable ground-truth reference on context windows in large language models: quadratic attention complexity, KV cache scaling, RoPE position interpolation, and the Lost in the Middle phenomenon.","url":"https://ngpestelos.com/reference/context-window/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
   </script>
 </head>
-<body>
+<body class="reference">
   <main>
     <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/reference/">Reference</a> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a></p>
     <div class="kicker">Reference Guide</div>

--- a/reference/embeddings/index.html
+++ b/reference/embeddings/index.html
@@ -35,22 +35,9 @@
       ]
     });"></script>
   <style>
-    :root {
-      --bg: #ffffff;
-      --well: #f8f9fa;
-      --box-bg: #f8f9fa;
-      --ink: #202122;
-      --mute: #54595d;
-      --line: #a2a9b1;
-      --link: #0645ad;
-      --link-visited: #795cb2;
-    }
     * { box-sizing: border-box; margin: 0; padding: 0; }
     html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
     body {
-      background: var(--bg);
-      color: var(--ink);
-      font-family: Georgia, "Times New Roman", serif;
       line-height: 1.6;
     }
     main {
@@ -191,7 +178,7 @@
 {"@context":"https://schema.org","@type":"DefinedTerm","name":"Embeddings and Vector Representations","description":"A citable ground-truth reference on vector embeddings in artificial intelligence: geometric representations, distance metrics, contextual models, anisotropy, and dense retrieval architectures.","url":"https://ngpestelos.com/reference/embeddings/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
   </script>
 </head>
-<body>
+<body class="reference">
   <main>
     <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/reference/">Reference</a> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a></p>
     <div class="kicker">Reference Guide</div>

--- a/reference/fine-tuning/index.html
+++ b/reference/fine-tuning/index.html
@@ -35,22 +35,9 @@
       ]
     });"></script>
   <style>
-    :root {
-      --bg: #ffffff;
-      --well: #f8f9fa;
-      --box-bg: #f8f9fa;
-      --ink: #202122;
-      --mute: #54595d;
-      --line: #a2a9b1;
-      --link: #0645ad;
-      --link-visited: #795cb2;
-    }
     * { box-sizing: border-box; margin: 0; padding: 0; }
     html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
     body {
-      background: var(--bg);
-      color: var(--ink);
-      font-family: Georgia, "Times New Roman", serif;
       line-height: 1.6;
     }
     main {
@@ -191,7 +178,7 @@
 {"@context":"https://schema.org","@type":"DefinedTerm","name":"Fine-Tuning","description":"A citable ground-truth reference on fine-tuning and model alignment: Supervised Fine-Tuning (SFT), Parameter-Efficient Fine-Tuning (LoRA, QLoRA), Reinforcement Learning from Human Feedback (RLHF), and Direct Preference Optimization (DPO).","url":"https://ngpestelos.com/reference/fine-tuning/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
   </script>
 </head>
-<body>
+<body class="reference">
   <main>
     <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/reference/">Reference</a> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a></p>
     <div class="kicker">Reference Guide</div>

--- a/reference/pre-training/index.html
+++ b/reference/pre-training/index.html
@@ -35,22 +35,9 @@
       ]
     });"></script>
   <style>
-    :root {
-      --bg: #ffffff;
-      --well: #f8f9fa;
-      --box-bg: #f8f9fa;
-      --ink: #202122;
-      --mute: #54595d;
-      --line: #a2a9b1;
-      --link: #0645ad;
-      --link-visited: #795cb2;
-    }
     * { box-sizing: border-box; margin: 0; padding: 0; }
     html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
     body {
-      background: var(--bg);
-      color: var(--ink);
-      font-family: Georgia, "Times New Roman", serif;
       line-height: 1.6;
     }
     main {
@@ -191,7 +178,7 @@
 {"@context":"https://schema.org","@type":"DefinedTerm","name":"Pre-Training","description":"A citable ground-truth reference on pre-training in artificial intelligence: self-supervised objectives, compute scaling laws, dataset curation pipelines, and distributed training systems.","url":"https://ngpestelos.com/reference/pre-training/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
   </script>
 </head>
-<body>
+<body class="reference">
   <main>
     <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/reference/">Reference</a> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a></p>
     <div class="kicker">Reference Guide</div>

--- a/reference/prompt/index.html
+++ b/reference/prompt/index.html
@@ -35,22 +35,9 @@
       ]
     });"></script>
   <style>
-    :root {
-      --bg: #ffffff;
-      --well: #f8f9fa;
-      --box-bg: #f8f9fa;
-      --ink: #202122;
-      --mute: #54595d;
-      --line: #a2a9b1;
-      --link: #0645ad;
-      --link-visited: #795cb2;
-    }
     * { box-sizing: border-box; margin: 0; padding: 0; }
     html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
     body {
-      background: var(--bg);
-      color: var(--ink);
-      font-family: Georgia, "Times New Roman", serif;
       line-height: 1.6;
     }
     main {
@@ -191,7 +178,7 @@
 {"@context":"https://schema.org","@type":"DefinedTerm","name":"Prompts in Artificial Intelligence","description":"A citable ground-truth reference on prompts in generative AI: autoregressive prefix conditioning, role delineation schemas, prefill latency mechanics, and prompt injection vulnerabilities.","url":"https://ngpestelos.com/reference/prompt/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
   </script>
 </head>
-<body>
+<body class="reference">
   <main>
     <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/reference/">Reference</a> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a></p>
     <div class="kicker">Reference Guide</div>

--- a/reference/reasoning/index.html
+++ b/reference/reasoning/index.html
@@ -35,22 +35,9 @@
       ]
     });"></script>
   <style>
-    :root {
-      --bg: #ffffff;
-      --well: #f8f9fa;
-      --box-bg: #f8f9fa;
-      --ink: #202122;
-      --mute: #54595d;
-      --line: #a2a9b1;
-      --link: #0645ad;
-      --link-visited: #795cb2;
-    }
     * { box-sizing: border-box; margin: 0; padding: 0; }
     html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
     body {
-      background: var(--bg);
-      color: var(--ink);
-      font-family: Georgia, "Times New Roman", serif;
       line-height: 1.6;
     }
     main {
@@ -191,7 +178,7 @@
 {"@context":"https://schema.org","@type":"DefinedTerm","name":"Reasoning in Large Language Models","description":"A citable ground-truth reference on reasoning in large language models: test-time compute scaling, Chain-of-Thought formalisms, Process Reward Models, and inference-time search architectures.","url":"https://ngpestelos.com/reference/reasoning/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
   </script>
 </head>
-<body>
+<body class="reference">
   <main>
     <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/reference/">Reference</a> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a></p>
     <div class="kicker">Reference Guide</div>

--- a/reference/vector-search/index.html
+++ b/reference/vector-search/index.html
@@ -35,22 +35,9 @@
       ]
     });"></script>
   <style>
-    :root {
-      --bg: #ffffff;
-      --well: #f8f9fa;
-      --box-bg: #f8f9fa;
-      --ink: #202122;
-      --mute: #54595d;
-      --line: #a2a9b1;
-      --link: #0645ad;
-      --link-visited: #795cb2;
-    }
     * { box-sizing: border-box; margin: 0; padding: 0; }
     html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
     body {
-      background: var(--bg);
-      color: var(--ink);
-      font-family: Georgia, "Times New Roman", serif;
       line-height: 1.6;
     }
     main {
@@ -191,7 +178,7 @@
 {"@context":"https://schema.org","@type":"DefinedTerm","name":"Vector Search","description":"A citable ground-truth reference on vector search and dense retrieval: Approximate Nearest Neighbor (ANN) indexing, HNSW graphs, Product Quantization, and hybrid lexical-dense search.","url":"https://ngpestelos.com/reference/vector-search/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
   </script>
 </head>
-<body>
+<body class="reference">
   <main>
     <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/reference/">Reference</a> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a></p>
     <div class="kicker">Reference Guide</div>

--- a/scripts/test_site_theme.py
+++ b/scripts/test_site_theme.py
@@ -76,15 +76,20 @@ class SiteThemeTests(unittest.TestCase):
                     rf"(?m)^\s*{re.escape(selector)}\s*\{{",
                 )
 
-        for rel in ("reference/index.html", "reference/agents/index.html"):
-            html = text(rel)
-            self.assertIn(CSS_VER, html)
-            self.assertRegex(html, r"<body[^>]*class=\"[^\"]*\breference\b")
-            self.assertNotIn("#0645ad", html)
-            self.assertNotIn("#795cb2", html)
-            style = "".join(re.findall(r"<style>(.*?)</style>", html, re.S))
-            self.assertNotRegex(style, r"--bg:\s*#fff")
-            self.assertNotRegex(style, r"font-family:\s*Georgia")
+        ref_pages = ["reference/index.html"] + [
+            str(p.relative_to(ROOT))
+            for p in sorted((ROOT / "reference").glob("*/index.html"))
+        ]
+        for rel in ref_pages:
+            with self.subTest(rel=rel):
+                html = text(rel)
+                self.assertIn(CSS_VER, html)
+                self.assertRegex(html, r"<body[^>]*class=\"[^\"]*\breference\b")
+                self.assertNotIn("#0645ad", html)
+                self.assertNotIn("#795cb2", html)
+                style = "".join(re.findall(r"<style>(.*?)</style>", html, re.S))
+                self.assertNotRegex(style, r"--bg:\s*#fff")
+                self.assertNotRegex(style, r"font-family:\s*Georgia")
 
     def test_ninthgreen_and_trees_untouched(self):
         sample = text("samples/ninthgreen/index.html")


### PR DESCRIPTION
## Summary
Aligns the remaining 8 reference pages (`bm25`, `context-window`, `embeddings`, `fine-tuning`, `pre-training`, `prompt`, `reasoning`, and `vector-search`) with the canonical site styling tokens (`style.css`).

- Removes hardcoded `:root` palette blocks (`--bg: #ffffff`, `--link: #0645ad`, `--link-visited: #795cb2`).
- Removes hardcoded `font-family: Georgia` on `body` (inherits Iowan Old Style / Palatino from `style.css`).
- Adds `class="reference"` to `<body>` to eliminate double-padding stacking with `<main>`.
- Generalizes `scripts/test_site_theme.py` to enforce these invariants across all reference entries under `reference/*/index.html`.

## Verification
- Ran `python3 -m unittest discover -s scripts -p 'test_*.py'`. All tests passed.
- Verified test failure prior to migration and clean pass after migration.