### PR TITLE
landing: apply Ruby on Rails consistency to modernization card

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,8 +54,8 @@
       <h3>What I Do</h3>
 
       <div class="card">
-        <h4>Rails Modernization &amp; Reliability</h4>
-        <p>Upgrade aging Rails codebases without breaking production. Most recent: modernized a 1M+ line Rails application to 91% test coverage with 3,797 passing tests and an 8-check pre-commit hook. A fixed-price <a href="https://162381607157.gumroad.com/l/rails-readiness-read">written readiness read</a> is available.</p>
+        <h4>Ruby on Rails Modernization &amp; Reliability</h4>
+        <p>Upgrade aging <a href="https://rubyonrails.org/">Ruby on Rails</a> codebases without breaking production. Most recent: modernized a 1M+ line Ruby on Rails application to 91% test coverage with 3,797 passing tests and an 8-check pre-commit hook. A fixed-price <a href="https://162381607157.gumroad.com/l/rails-readiness-read">written readiness read</a> is available.</p>
       </div>
 
       <div class="card">

--- a/scripts/test_site_discoverability.py
+++ b/scripts/test_site_discoverability.py
@@ -169,7 +169,7 @@ class SiteDiscoverabilityTests(unittest.TestCase):
         self.assertNotIn("3 MCP servers", html)
         self.assertNotIn("6+ providers", html)
         self.assertNotIn("BS Computer Science", html)
-        self.assertIn("<h4>Rails Modernization", html)
+        self.assertIn("<h4>Ruby on Rails Modernization", html)
         self.assertIn("<h4>Payment System Integration", html)
         self.assertIn("<h4>Agents in the Work", html)
         header = re.search(r'<p class="header-links">.*?</p>', html, re.S).group(0)


### PR DESCRIPTION
## Summary
- Update card heading on landing page to `Ruby on Rails Modernization & Reliability`.
- Link first mention of `Ruby on Rails` in card body to `https://rubyonrails.org/`.
- Replace secondary mention of `Rails` with `Ruby on Rails` in card body.
- Update test assertion in `scripts/test_site_discoverability.py` to match new heading.

## Verification
- `python3 -m unittest discover -s scripts` (32/32 passing)