### PR TITLE
reference: add Culture (Anthropology) entry

### DIFF
--- a/reference/culture/index.html
+++ b/reference/culture/index.html
@@ -1,0 +1,278 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Culture (Anthropology) · Reference · Nestor G Pestelos Jr</title>
+  <meta name="description" content="Culture, in anthropology, is the knowledge, belief, custom and habit that people acquire as members of a society rather than inherit biologically. Tylor, Geertz, UNESCO and cultural-evolution definitions, transmission, subculture and counterculture, organizational culture, culture as an explanation, machine culture.">
+  <meta property="og:title" content="Culture (Anthropology) · Reference">
+  <meta property="og:description" content="Learned, shared, transmitted. Definitions from Tylor to cultural evolution, subculture, organizational culture, machine culture.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://ngpestelos.com/reference/culture/">
+  <link rel="canonical" href="https://ngpestelos.com/reference/culture/">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=20260813f">
+  <link rel="icon" href="/favicon-192.png?v=20260813f" type="image/png" sizes="192x192">
+  <link rel="icon" href="/favicon-32.png?v=20260813f" type="image/png" sizes="32x32">
+  <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
+  <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="stylesheet" href="/style.css?v=20260903e">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TLBY8P4GG9');
+  </script>
+  <style>
+    
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
+    body {
+      line-height: 1.6;
+    }
+    main {
+      max-width: 46rem;
+      margin: 0 auto;
+      padding: 1.4rem 1.4rem 4rem;
+    }
+    .back {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .back a { color: var(--link); text-decoration: none; }
+    .back a:hover { text-decoration: underline; }
+    .kicker {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.78rem;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--mute);
+      margin-bottom: 0.3rem;
+    }
+    h1 {
+      font-size: clamp(1.9rem, 5vw, 2.4rem);
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.4rem;
+      margin-bottom: 1rem;
+    }
+    .updated {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.82rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .lede { margin-bottom: 1.6rem; }
+    .lede strong:first-child { font-weight: 700; }
+    .toc {
+      background: var(--well);
+      border: 1px solid var(--line);
+      border-radius: 4px;
+      padding: 1rem 1.4rem;
+      margin-bottom: 2rem;
+      max-width: 24rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.92rem;
+    }
+    .toc .toc-title {
+      font-weight: 700;
+      margin-bottom: 0.5rem;
+      text-align: center;
+    }
+    .toc ol { padding-left: 1.3rem; }
+    .toc li { margin: 0.2rem 0; }
+    .toc a { color: var(--link); text-decoration: none; }
+    .toc a:hover { text-decoration: underline; }
+    h2 {
+      font-size: 1.5rem;
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.3rem;
+      margin: 2rem 0 0.9rem;
+    }
+    p { margin-bottom: 0.9rem; }
+    a { color: var(--link); }
+    a:visited { color: var(--link-visited); }
+    code {
+      font-family: "SF Mono", Consolas, Monaco, monospace;
+      font-size: 0.9em;
+      background: var(--well);
+      padding: 0.1em 0.35em;
+      border-radius: 3px;
+    }
+    .cite {
+      font-size: 0.75em;
+      vertical-align: super;
+      line-height: 0;
+      text-decoration: none;
+    }
+    .cite a { text-decoration: none; }
+    #see-also ul, #references ol {
+      padding-left: 1.5rem;
+    }
+    #see-also li, #references li { margin-bottom: 0.5rem; }
+    #references { font-size: 0.95rem; }
+    #references .backlink { margin-right: 0.3rem; }
+    .unattributed {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+      font-style: italic;
+    }
+    footer.meta {
+      margin-top: 3rem;
+      padding-top: 1.2rem;
+      border-top: 1px solid var(--line);
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+    }
+    footer.meta a { color: var(--link); }
+    @media print {
+      .back {font-family:"Segoe UI", Helvetica, Arial, sans-serif;display: none;}
+    }
+      .back-to-top {
+      position: fixed;
+      bottom: 1.5rem;
+      right: 1.5rem;
+      width: 2.6rem;
+      height: 2.6rem;
+      border-radius: 50%;
+      background: var(--bg);
+      color: var(--ink);
+      border: 1px solid var(--line);
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      opacity: 0;
+      visibility: hidden;
+      transform: translateY(8px);
+      transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease, background 0.15s ease, border-color 0.15s ease;
+      z-index: 100;
+    }
+    .back-to-top.visible {
+      opacity: 1;
+      visibility: visible;
+      transform: translateY(0);
+    }
+    .back-to-top:hover {
+      background: var(--well);
+      border-color: var(--link);
+      color: var(--link);
+    }
+    .back-to-top:focus-visible {
+      outline: 2px solid var(--link);
+      outline-offset: 2px;
+    }
+    @media print {
+      .back-to-top { display: none !important; }
+    }
+  </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Culture (Anthropology)","description":"Culture, in anthropology, is the knowledge, belief, custom and habit that people acquire as members of a society rather than inherit biologically. Tylor, Geertz, UNESCO and cultural-evolution definitions, transmission, subculture and counterculture, organizational culture, culture as an explanation, machine culture.","url":"https://ngpestelos.com/reference/culture/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
+</head>
+<body class="reference">
+  <main id="top">
+    <p class="back"><a href="/reference/">← Reference</a> · <a href="/">Nestor G Pestelos Jr</a> · <a href="#" onclick="window.print(); return false;">Print this page</a></p>
+    <p class="kicker">Anthropology · Social Science</p>
+    <h1>Culture (Anthropology)</h1>
+    <p class="updated">Reference entry · last updated September 5, 2026</p>
+
+    <p class="lede"><strong>Culture</strong>, in anthropology, is the body of knowledge, belief, custom and habit that people acquire as members of a society, as distinct from what they inherit biologically. Edward Burnett Tylor gave the founding definition in 1871: “that complex whole which includes knowledge, belief, art, morals, law, custom and any other capabilities and habits acquired by man as a member of society.”<span class="cite">[<a href="#ref1">1</a>]</span> Later definitions keep the same three properties. Culture is learned, it is shared by a group, and it passes between people rather than through genes.<span class="cite">[<a href="#ref3">3</a>]</span></p>
+
+    <nav class="toc" aria-label="Contents">
+      <p class="toc-title">Contents</p>
+      <ol>
+        <li><a href="#etymology">Etymology</a></li>
+        <li><a href="#definitions">Definitions</a></li>
+        <li><a href="#transmission">Transmission and cultural evolution</a></li>
+        <li><a href="#subculture">Subculture and counterculture</a></li>
+        <li><a href="#organizational">Organizational culture</a></li>
+        <li><a href="#explanation">Culture as an explanation</a></li>
+        <li><a href="#machine">Machine culture</a></li>
+        <li><a href="#see-also">See also</a></li>
+        <li><a href="#references">References</a></li>
+      </ol>
+    </nav>
+
+    <h2 id="etymology">Etymology</h2>
+    <p>The modern term descends from Latin <em>cultura</em>, cultivation. Cicero used it figuratively in the <em>Tusculanae Disputationes</em>, where he wrote of a cultivation of the soul, <em>cultura animi</em>.<span class="cite">[<a href="#ref4">4</a>]</span> The agricultural sense and the sense of personal refinement both survive in English. The anthropological sense, a whole society's learned way of life, dates from the nineteenth century.</p>
+
+    <h2 id="definitions">Definitions</h2>
+    <p>Tylor's definition opens <em>Primitive Culture</em> (1871). Its scope is deliberately wide: knowledge, belief, art, morals, law and custom together, with a catch-all for any other acquired capability or habit.<span class="cite">[<a href="#ref1">1</a>]</span> The definition places culture on the side of acquisition. Whatever a person learns as a member of society counts.</p>
+    <p>By the middle of the twentieth century the term had multiplied. Alfred Kroeber and Clyde Kluckhohn surveyed the accumulated definitions in <em>Culture: A Critical Review of Concepts and Definitions</em> (1952).<span class="cite">[<a href="#ref11">11</a>]</span></p>
+    <p>Clifford Geertz, in <em>The Interpretation of Cultures</em> (1973), shifted the emphasis from inventory to meaning. “Man is an animal suspended in webs of significance he himself has spun,” he wrote. “I take culture to be those webs, and the analysis of it to be therefore not an experimental science in search of law but an interpretative one in search of meaning.” The method he proposed for reading those webs is thick description.<span class="cite">[<a href="#ref5">5</a>]</span></p>
+    <p>An institutional definition appears in the preamble of the UNESCO Universal Declaration on Cultural Diversity, adopted 2 November 2001: culture “should be regarded as the set of distinctive spiritual, material, intellectual and emotional features of society or a social group, and that it encompasses, in addition to art and literature, lifestyles, ways of living together, value systems, traditions and beliefs.”<span class="cite">[<a href="#ref2">2</a>]</span></p>
+    <p>Cultural evolution researchers use a narrower working definition: culture is socially learned information stored in individuals' brains that is capable of affecting behavior. Social learning here means copying behaviour observed in others or acquiring it by being taught.<span class="cite">[<a href="#ref3">3</a>]</span> Humans acquire culture through enculturation and socialization.<span class="cite">[<a href="#ref4">4</a>]</span></p>
+
+    <h2 id="transmission">Transmission and cultural evolution</h2>
+    <p>Dual inheritance theory, also called gene-culture coevolution, developed from the 1960s through the early 1980s to explain human behaviour as the product of two interacting evolutionary processes, genetic evolution and cultural evolution. Luigi Luca Cavalli-Sforza and Marcus Feldman published foundational dynamic models in 1976. Robert Boyd and Peter Richerson's <em>Culture and the Evolutionary Process</em> (1985) became the field's standard reference.<span class="cite">[<a href="#ref3">3</a>]</span></p>
+    <p>On this account a cultural trait behaves like an inherited trait with a different channel. It varies between individuals, it is transmitted by social learning, and some variants spread while others die out. The same three processes, variation, transmission and selection, are the ones a later literature uses to ask what happens when machines join the population of learners and teachers (see <a href="#machine">Machine culture</a>).</p>
+
+    <h2 id="subculture">Subculture and counterculture</h2>
+    <p>A subculture is a group of people within a cultural society that differentiates itself from the values of the mainstream or dominant culture. Dick Hebdige, in <em>Subculture: The Meaning of Style</em> (1979), argued that members signal membership through a distinctive style: fashions, mannerisms and argot.<span class="cite">[<a href="#ref6">6</a>]</span></p>
+    <p>A counterculture is a culture whose values and norms of behaviour are opposed to those of the current mainstream society, and sometimes diametrically opposed to mainstream cultural mores. John Milton Yinger proposed the term <em>contraculture</em> in a 1960 <em>American Sociological Review</em> article. Theodore Roszak's <em>The Making of a Counter Culture</em> (1969) carried the word into general use.<span class="cite">[<a href="#ref7">7</a>]</span> Subcultures differ from countercultures: a subculture can coexist with the mainstream it marks itself off from, while a counterculture defines itself against it.<span class="cite">[<a href="#ref6">6</a>]</span></p>
+
+    <h2 id="organizational">Organizational culture</h2>
+    <p>The term transfers to firms and other organizations. Organizational culture is the set of shared norms, values and behaviours in an organization. Edgar Schein, in <em>Organizational Culture and Leadership</em> (1992), defined it as a shared pattern of basic assumptions that group members acquire over time as they learn to cope with internal and external problems.<span class="cite">[<a href="#ref8">8</a>]</span> The anthropological properties carry over unchanged: the assumptions are learned on the job, shared across the group, and passed to newcomers.</p>
+
+    <h2 id="explanation">Culture as an explanation</h2>
+    <p>Culture is often invoked to explain why a country, firm or team underperforms. Benjamin R. Punongbayan, writing in <em>BusinessWorld</em> in September 2024 on the claim that Filipino culture is “damaged” and inhibits economic growth, argued that the claim cannot be assessed until the term is fixed. Combining two dictionary senses, he adopted a working definition of Filipino culture as “shared beliefs, attitudes, values, behavior, practices, and goals of the Filipino nation,” with “shared” meaning held by most rather than all, and only then asked which traits could plausibly affect growth.<span class="cite">[<a href="#ref9">9</a>]</span></p>
+    <p>The methodological point generalizes. A culture-based explanation is testable only once it names which shared beliefs or practices do the causal work and what evidence would separate them from institutional or historical causes of the same outcome.</p>
+
+    <h2 id="machine">Machine culture</h2>
+    <p>Brinkmann and fourteen co-authors introduced the term <em>machine culture</em> in a 2023 <em>Nature Human Behaviour</em> perspective for culture mediated or generated by machines. They argue that intelligent machines simultaneously transform the cultural evolutionary processes of variation, transmission and selection: recommender algorithms alter social learning dynamics, chatbots form a new mode of cultural transmission by serving as cultural models, and machines contribute cultural traits directly, from game strategies and visual art to scientific results.<span class="cite">[<a href="#ref10">10</a>]</span> The framework treats machines as participants in the same three processes that dual inheritance theory uses for humans, rather than as a separate phenomenon.</p>
+
+    <h2 id="see-also">See also</h2>
+    <ul>
+      <li><a href="/reference/large-language-models/">Large Language Models</a></li>
+      <li><a href="/reference/artificial-intelligence/">Artificial Intelligence</a></li>
+      <li><a href="/reference/chiquito/">Chiquito (Actor)</a></li>
+    </ul>
+
+    <h2 id="references">References</h2>
+    <ol>
+      <li id="ref1"><a class="backlink" href="#definitions">↑</a> Edward Burnett Tylor, <em>Primitive Culture: Researches into the Development of Mythology, Philosophy, Religion, Language, Art, and Custom</em>, vol. 1, London: John Murray, 1871. Full view of the 1920 Murray printing: <a href="https://archive.org/details/primitiveculture01tylouoft">https://archive.org/details/primitiveculture01tylouoft</a>. Definition as quoted in Wikipedia, “Culture.”</li>
+      <li id="ref2"><a class="backlink" href="#definitions">↑</a> UNESCO, <em>Universal Declaration on Cultural Diversity</em>, adopted 2 November 2001, preamble. <a href="https://www.unesco.org/en/legal-affairs/unesco-universal-declaration-cultural-diversity">https://www.unesco.org/en/legal-affairs/unesco-universal-declaration-cultural-diversity</a></li>
+      <li id="ref3"><a class="backlink" href="#transmission">↑</a> Wikipedia, “Dual inheritance theory.” Definition of the theory, Cavalli-Sforza and Feldman (1976), Boyd and Richerson (1985), and the working definition of culture as socially learned information. <a href="https://en.wikipedia.org/wiki/Dual_inheritance_theory">https://en.wikipedia.org/wiki/Dual_inheritance_theory</a></li>
+      <li id="ref4"><a class="backlink" href="#etymology">↑</a> Wikipedia, “Culture.” Etymology from Cicero's <em>cultura animi</em>; enculturation and socialization. <a href="https://en.wikipedia.org/wiki/Culture">https://en.wikipedia.org/wiki/Culture</a></li>
+      <li id="ref5"><a class="backlink" href="#definitions">↑</a> Wikipedia, “Clifford Geertz,” quoting <em>The Interpretation of Cultures</em> (1973). <a href="https://en.wikipedia.org/wiki/Clifford_Geertz">https://en.wikipedia.org/wiki/Clifford_Geertz</a></li>
+      <li id="ref6"><a class="backlink" href="#subculture">↑</a> Wikipedia, “Subculture.” Definition; Hebdige (1979). <a href="https://en.wikipedia.org/wiki/Subculture">https://en.wikipedia.org/wiki/Subculture</a></li>
+      <li id="ref7"><a class="backlink" href="#subculture">↑</a> Wikipedia, “Counterculture.” Definition; Yinger (1960), Roszak (1969). <a href="https://en.wikipedia.org/wiki/Counterculture">https://en.wikipedia.org/wiki/Counterculture</a></li>
+      <li id="ref8"><a class="backlink" href="#organizational">↑</a> Wikipedia, “Organizational culture.” Definition; Schein, <em>Organizational Culture and Leadership: A Dynamic View</em> (1992). <a href="https://en.wikipedia.org/wiki/Organizational_culture">https://en.wikipedia.org/wiki/Organizational_culture</a></li>
+      <li id="ref9"><a class="backlink" href="#explanation">↑</a> Benjamin R. Punongbayan, “Does Filipino culture hinder economic development?”, <em>BusinessWorld</em>, MAP Insights, 3 September 2024. <a href="https://www.bworldonline.com/opinion/2024/09/03/617541/does-filipino-culture-hinder-economic-development/">https://www.bworldonline.com/opinion/2024/09/03/617541/does-filipino-culture-hinder-economic-development/</a></li>
+      <li id="ref10"><a class="backlink" href="#machine">↑</a> Levin Brinkmann, Fabian Baumann, Jean-François Bonnefon et al., “Machine culture,” <em>Nature Human Behaviour</em>, 2023, doi:10.1038/s41562-023-01742-2. Free full text (preprint): <a href="https://arxiv.org/abs/2311.11388">https://arxiv.org/abs/2311.11388</a></li>
+      <li id="ref11"><a class="backlink" href="#definitions">↑</a> Alfred L. Kroeber and Clyde Kluckhohn, <em>Culture: A Critical Review of Concepts and Definitions</em>, Papers of the Peabody Museum of American Archaeology and Ethnology, vol. 47, no. 1, Cambridge, Massachusetts: Peabody Museum, 1952.</li>
+    </ol>
+
+    <footer class="meta">
+      <p><a href="#top">Back to top</a></p>
+    </footer>
+  </main>
+  <button id="backToTop" class="back-to-top" aria-label="Back to top" title="Back to top">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M18 15l-6-6-6 6"/>
+    </svg>
+  </button>
+
+  <script>
+    const btt = document.getElementById('backToTop');
+    window.addEventListener('scroll', () => {
+      if (window.scrollY > 250) {
+        btt.classList.add('visible');
+      } else {
+        btt.classList.remove('visible');
+      }
+    }, { passive: true });
+    btt.addEventListener('click', () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  </script>
+</body>
+</html>

--- a/reference/index.html
+++ b/reference/index.html
@@ -229,6 +229,7 @@
         <li><a href="/reference/context-engineering/">Context Engineering</a></li>
         <li><a href="/reference/context-window/">Context Windows</a></li>
         <li><a href="/reference/continuous-batching/">Continuous Batching</a></li>
+        <li><a href="/reference/culture/">Culture (Anthropology)</a></li>
         </ul>
       </div>
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -970,4 +970,9 @@
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
+  <url>
+    <loc>https://ngpestelos.com/reference/culture/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
 </urlset>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -972,6 +972,10 @@
   </url>
   <url>
     <loc>https://ngpestelos.com/reference/marginal-price/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
     <loc>https://ngpestelos.com/reference/culture/</loc>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>


### PR DESCRIPTION
## Summary

New reference entry `/reference/culture/`: **Culture (Anthropology)**.

- Etymology (Cicero's *cultura animi*)
- Definitions: Tylor 1871, Kroeber and Kluckhohn 1952 (print citation), Geertz 1973, UNESCO 2001, and the cultural-evolution working definition
- Transmission and cultural evolution (dual inheritance theory; Cavalli-Sforza and Feldman 1976; Boyd and Richerson 1985)
- Subculture and counterculture (Hebdige 1979; Yinger 1960; Roszak 1969)
- Organizational culture (Schein 1992)
- Culture as an explanation (Punongbayan, BusinessWorld, 3 September 2024)
- Machine culture (Brinkmann et al., Nature Human Behaviour 2023, arXiv preprint as free full text)

Title carries the `(Anthropology)` scope because page-one search for the bare term is dictionaries and Wikipedia (public-reference-pages rules 1 and 3). The angle follows the vault's Culture corpus: learned, shared, transmitted behaviour. JSON-LD `DefinedTerm` included. Listing and sitemap updated. See also links to Large Language Models, Artificial Intelligence, Chiquito.

## Verification

- 11 citations. 10 URLs fetched live this session; Kroeber and Kluckhohn 1952 is a print bibliographic citation with no link (no verified open-access copy). Tylor links the full-view 1920 Murray printing on archive.org, not a lending item.
- The BusinessWorld column returned 403 to the fetch tool and 200 to curl with a browser user agent; quotes taken from the curl text.
- Middot title, zero prose em-dashes, zero control bytes, all in-page anchors resolve, de-AI Pack T greps clean.
- `scripts/test_site_discoverability.py`: 17 tests OK on Python 3.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
