### PR TITLE
writing: refile agent-rail-war-red-herring under payments

### DIFF
--- a/scripts/test_site_discoverability.py
+++ b/scripts/test_site_discoverability.py
@@ -28,6 +28,7 @@ PAYMENTS = {
     "instapay-is-not-ach",
     "us-and-philippine-payment-rails",
     "payments-glossary",
+    "agent-rail-war-red-herring",
 }
 SNAPSHOT_SLUG = re.compile(r"-\d{8}$")
 ATOM_NS = {"atom": "http://www.w3.org/2005/Atom"}

--- a/scripts/writing-catalog.json
+++ b/scripts/writing-catalog.json
@@ -297,7 +297,7 @@
     "slug": "agent-rail-war-red-herring",
     "title": "The Agent Rail War Is a Red Herring",
     "date": "2026-07-08",
-    "bucket": "systems",
+    "bucket": "payments",
     "pin": null
   },
   {

--- a/writing/index.html
+++ b/writing/index.html
@@ -59,7 +59,6 @@
           <li><a href="/writing/polish-is-free-thinking-isnt/">Polish Is Free. Thinking Isn&#x27;t</a> <time datetime="2026-07-11">11 Jul 2026</time></li>
           <li><a href="/writing/capacity-is-your-lowest-ceiling/">Capacity Is Your Lowest Ceiling</a> <time datetime="2026-07-11">11 Jul 2026</time></li>
           <li><a href="/writing/pattern-capture-auto-activating-skill-library/">Pattern Capture - How I Built an Auto-Activating Skill Library</a> <time datetime="2026-07-10">10 Jul 2026</time></li>
-          <li><a href="/writing/agent-rail-war-red-herring/">The Agent Rail War Is a Red Herring</a> <time datetime="2026-07-08">8 Jul 2026</time></li>
           <li><a href="/writing/the-bugs-that-hide-between-your-agents/">The Bugs That Hide Between Your Agents</a> <time datetime="2026-07-08">8 Jul 2026</time></li>
           <li><a href="/writing/governing-delegation-scope-creep/">Governing Delegation - Using Architecture to Stop AI Scope Creep</a> <time datetime="2026-07-03">3 Jul 2026</time></li>
           <li class="pin"><a href="/writing/agents-plan-b-destroy-data/">Your Agent&#x27;s Plan B Will Destroy Your Data</a> <time datetime="2026-03-25">25 Mar 2026</time></li>
@@ -78,6 +77,7 @@
           <li class="pin"><a href="/writing/instapay-is-not-ach/">InstaPay Is Not ACH</a> <time datetime="2026-08-18">18 Aug 2026</time></li>
           <li class="pin"><a href="/writing/us-and-philippine-payment-rails/">US and Philippine Payment Rails</a> <time datetime="2026-08-18">18 Aug 2026</time></li>
           <li class="pin"><a href="/writing/payments-glossary/">Payments Glossary</a> <time datetime="2026-08-18">18 Aug 2026</time></li>
+          <li><a href="/writing/agent-rail-war-red-herring/">The Agent Rail War Is a Red Herring</a> <time datetime="2026-07-08">8 Jul 2026</time></li>
         </ul>
       </section>
       <section class="bucket" id="essays">


### PR DESCRIPTION
## Summary

- Move "The Agent Rail War Is a Red Herring" from the **Production systems and agents** bucket to **Payments** in `scripts/writing-catalog.json`.
- Regenerate the `#writing` inner of `writing/index.html` from the catalog (the one `<li>` moves sections; nothing else changes).
- Add the slug to the pinned `PAYMENTS` set in `scripts/test_site_discoverability.py` so the bucket is covered by the existing test.

The piece is about card vs stablecoin rails and the trust layer above them. It was filed under systems on the strength of the word "agent".

## Not changed

- `writing/atom.xml` and `sitemap.xml`: bucket is not part of either, so no feed rebuild.
- The article page itself, and homepage pins.

## Test plan

- [x] `python3.11 -m unittest discover -s scripts -p 'test_*.py'` → 32 tests OK at d02f267

🤖 Generated with [Claude Code](https://claude.com/claude-code)
