### PR TITLE
reference: add Dead Internet Theory entry

### DIFF
--- a/reference/dead-internet-theory/index.html
+++ b/reference/dead-internet-theory/index.html
@@ -1,0 +1,301 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dead Internet Theory · Reference · Nestor G Pestelos Jr</title>
+  <meta name="description" content="Dead Internet Theory is an internet culture concept and sociological diagnosis asserting that the majority of web traffic, interactions, and content have transitioned from organic human activity to automated bot networks, algorithmic curation, and generative artificial intelligence.">
+  <meta property="og:title" content="Dead Internet Theory · Reference">
+  <meta property="og:description" content="An encyclopedia entry on the Dead Internet Theory, its online forum origins, empirical bot measurements, ad-supported platform incentives, and epistemic implications.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://ngpestelos.com/reference/dead-internet-theory/">
+  <link rel="canonical" href="https://ngpestelos.com/reference/dead-internet-theory/">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=20260813f">
+  <link rel="icon" href="/favicon-192.png?v=20260813f" type="image/png" sizes="192x192">
+  <link rel="icon" href="/favicon-32.png?v=20260813f" type="image/png" sizes="32x32">
+  <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
+  <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="stylesheet" href="/style.css?v=20260903e">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TLBY8P4GG9');
+  </script>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
+    body {
+      line-height: 1.6;
+    }
+    main {
+      max-width: 46rem;
+      margin: 0 auto;
+      padding: 1.4rem 1.4rem 4rem;
+    }
+    .back {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .back a { color: var(--link); text-decoration: none; }
+    .back a:hover { text-decoration: underline; }
+    .kicker {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.78rem;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--mute);
+      margin-bottom: 0.3rem;
+    }
+    h1 {
+      font-size: clamp(1.9rem, 5vw, 2.4rem);
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.4rem;
+      margin-bottom: 1rem;
+    }
+    .updated {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.82rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .lede { margin-bottom: 1.6rem; }
+    .lede strong:first-child { font-weight: 700; }
+    .toc {
+      background: var(--well);
+      border: 1px solid var(--line);
+      border-radius: 4px;
+      padding: 1rem 1.4rem;
+      margin-bottom: 2rem;
+      max-width: 26rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.92rem;
+    }
+    .toc .toc-title {
+      font-weight: 700;
+      margin-bottom: 0.5rem;
+      text-align: center;
+    }
+    .toc ol { padding-left: 1.3rem; }
+    .toc ol ol { padding-left: 1.2rem; margin-top: 0.15rem; }
+    .toc li { margin: 0.2rem 0; }
+    .toc a { color: var(--link); text-decoration: none; }
+    .toc a:hover { text-decoration: underline; }
+    h2 {
+      font-size: 1.5rem;
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.3rem;
+      margin: 2rem 0 0.9rem;
+    }
+    h3 {
+      font-size: 1.15rem;
+      font-weight: 700;
+      margin: 1.4rem 0 0.6rem;
+    }
+    p { margin-bottom: 0.9rem; }
+    a { color: var(--link); }
+    a:visited { color: var(--link-visited); }
+    .cite {
+      font-size: 0.75em;
+      vertical-align: super;
+      line-height: 0;
+      text-decoration: none;
+    }
+    .cite a { text-decoration: none; }
+    #see-also ul, #references ol {
+      padding-left: 1.5rem;
+    }
+    #see-also li, #references li { margin-bottom: 0.5rem; }
+    #references { font-size: 0.95rem; }
+    #references .backlink { margin-right: 0.3rem; }
+    .unattributed {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+      font-style: italic;
+    }
+    footer.meta {
+      margin-top: 3rem;
+      padding-top: 1.2rem;
+      border-top: 1px solid var(--line);
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+    }
+    footer.meta a { color: var(--link); }
+    @media print {
+      .back { font-family: "Segoe UI", Helvetica, Arial, sans-serif; display: none; }
+    }
+    .back-to-top {
+      position: fixed;
+      bottom: 1.5rem;
+      right: 1.5rem;
+      width: 2.6rem;
+      height: 2.6rem;
+      border-radius: 50%;
+      background: var(--bg);
+      color: var(--ink);
+      border: 1px solid var(--line);
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      opacity: 0;
+      visibility: hidden;
+      transform: translateY(8px);
+      transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease, background 0.15s ease, border-color 0.15s ease;
+      z-index: 100;
+    }
+    .back-to-top.visible {
+      opacity: 1;
+      visibility: visible;
+      transform: translateY(0);
+    }
+    .back-to-top:hover {
+      background: var(--well);
+      border-color: var(--link);
+      color: var(--link);
+    }
+    .back-to-top:focus-visible {
+      outline: 2px solid var(--link);
+      outline-offset: 2px;
+    }
+    @media print {
+      .back-to-top { display: none !important; }
+    }
+  </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Dead Internet Theory","description":"Dead Internet Theory is an internet culture concept and sociological diagnosis asserting that the majority of web traffic, interactions, and content have transitioned from organic human activity to automated bot networks, algorithmic curation, and generative artificial intelligence.","url":"https://ngpestelos.com/reference/dead-internet-theory/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
+</head>
+<body class="reference">
+  <main id="top">
+    <p class="back"><a href="/reference/">← Reference</a> · <a href="/">Nestor G Pestelos Jr</a> · <a href="#" onclick="window.print(); return false;">Print this page</a></p>
+    <p class="kicker">Internet Culture &amp; Systems</p>
+    <h1>Dead Internet Theory</h1>
+    <p class="updated">Reference entry &middot; last updated September 5, 2026</p>
+
+    <p class="lede"><strong>Dead Internet Theory</strong> is an internet culture concept and sociological diagnosis asserting that the majority of web traffic, interactions, and content have transitioned from organic human activity to automated bot networks, algorithmic curation, and generative artificial intelligence.<span class="cite">[<a href="#ref1">1</a>]</span> Originating in online discussion forums during the late 2010s as a speculative conspiracy theory, the concept has gained academic and technical attention as measured automated traffic has surpassed human traffic and synthetic media has populated public social feeds.<span class="cite">[<a href="#ref2">2</a>]</span></p>
+
+    <nav class="toc" aria-label="Contents">
+      <p class="toc-title">Contents</p>
+      <ol>
+        <li><a href="#origin-and-history">Origin and history</a></li>
+        <li><a href="#core-claims">Core claims</a>
+          <ol>
+            <li><a href="#empirical-displacement">Empirical displacement</a></li>
+            <li><a href="#conspiratorial-framing">Conspiratorial framing</a></li>
+          </ol>
+        </li>
+        <li><a href="#structural-drivers">Structural drivers</a>
+          <ol>
+            <li><a href="#ad-revenue-incentives">Ad-revenue incentives</a></li>
+            <li><a href="#synthetic-media-economics">Zero marginal cost generation</a></li>
+            <li><a href="#search-engine-degradation">Search engine degradation</a></li>
+          </ol>
+        </li>
+        <li><a href="#sociological-impact">Sociological and epistemic impact</a>
+          <ol>
+            <li><a href="#zombie-publics">Zombie publics</a></li>
+            <li><a href="#trust-erosion">Trust erosion in public commons</a></li>
+          </ol>
+        </li>
+        <li><a href="#technical-countermeasures">Technical countermeasures</a></li>
+        <li><a href="#see-also">See also</a></li>
+        <li><a href="#references">References</a></li>
+      </ol>
+    </nav>
+
+    <h2 id="origin-and-history">Origin and history</h2>
+    <p>Discussions anticipating the concept emerged on imageboards and fringe forums such as 4chan and Wizardchan between 2018 and 2020. The formal label coalesced in January 2021 when a user named "IlluminatiPirate" published a thread titled "Dead Internet Theory: Most Of The Internet Is Fake" on Agora Road's Macintosh Cafe forum.<span class="cite">[<a href="#ref5">5</a>]</span> The post claimed that the organic, chaotic internet of the 2000s died around 2016 or 2017, replaced by an artificial landscape maintained by bot swarms and automated recommendation systems designed to influence cultural and consumer behavior.</p>
+    <p>In August 2021, journalist Kaitlyn Tiffany brought the theory into mainstream discussion in <em>The Atlantic</em>.<span class="cite">[<a href="#ref1">1</a>]</span> Tiffany analyzed the psychological appeal of the claim, noting that while the centralized conspiracy narrative was unevidenced, the underlying feeling of an increasingly artificial, alienating web reflected observable realities of automated engagement and algorithmic consolidation.</p>
+
+    <h2 id="core-claims">Core claims</h2>
+    <p>The theory divides into two distinct assertions: an empirical claim regarding automated traffic, and an unverified conspiratorial explanation for that shift.</p>
+
+    <h3 id="empirical-displacement">Empirical displacement</h3>
+    <p>The observable component claims that non-human actors generate the majority of digital activity. Network security measurements corroborate that automated agents represent a substantial and growing share of global web requests. Annual traffic audits conducted by cybersecurity firm Imperva recorded bot activity exceeding 40% of web traffic throughout the 2010s, with automated requests reaching 49.6% in 2023 and 51% in 2026.<span class="cite">[<a href="#ref3">3</a>]</span> Automated activity includes search index crawlers, automated ad-fraud scripts, scrapers harvesting training corpora for large language models, and conversational comment bots on social networks.</p>
+
+    <h3 id="conspiratorial-framing">Conspiratorial framing</h3>
+    <p>The conspiratorial component attributes this automation to a covert, centralized alliance between state intelligence agencies and major tech corporations designed to pacify citizens and manufacture political consent.<span class="cite">[<a href="#ref1">1</a>]</span> Sociological evaluations treat this coordinated narrative as unfalsifiable folklore. The observed automation arises instead from decentralized market incentives: commercial arbitrage, click fraud, spam monetization, and automated audience inflation.<span class="cite">[<a href="#ref2">2</a>]</span></p>
+
+    <h2 id="structural-drivers">Structural drivers</h2>
+    <p>The expansion of synthetic interaction stems from economic incentives and technical advancements rather than clandestine governance.</p>
+
+    <h3 id="ad-revenue-incentives">Ad-revenue incentives</h3>
+    <p>Online media and social platforms depend on programmatic advertising models that monetize impressions, clicks, and engagement volume. Platforms track raw metric counts rather than verified human intent. Because automated bot networks inflate recorded engagement figures without immediately reducing short-term ad revenue, platforms face weak commercial incentives to deploy aggressive countermeasures that would reduce reported active-user numbers.</p>
+
+    <h3 id="synthetic-media-economics">Zero marginal cost generation</h3>
+    <p>The rapid consumer adoption of generative artificial intelligence and agentic workflows after 2022 reduced the marginal cost of producing text, images, audio, and video to near zero. Autonomous agents can parse conversational context in social media threads and output coherent, context-specific replies without human intervention. Scammers and marketing syndicates deploy swarms of synthetic accounts to build apparent consensus, promote affiliate products, or run social engineering campaigns at computational scale.</p>
+
+    <h3 id="search-engine-degradation">Search engine degradation</h3>
+    <p>Automated content production has impacted web retrieval. Content farms generate search-optimized articles specifically crafted to rank on commercial queries. Major search engines have responded by integrating automated summarization engines (such as AI Overviews), which reduce click-through referrals to independent human publishers and encourage further synthetic content generation to satisfy automated indexing pipelines.<span class="cite">[<a href="#ref2">2</a>]</span></p>
+
+    <h2 id="sociological-impact">Sociological and epistemic impact</h2>
+    <p>The saturation of synthetic activity alters how human participants perceive public digital forums.</p>
+
+    <h3 id="zombie-publics">Zombie publics</h3>
+    <p>Social theorist Venkatesh Rao introduced the concept of "zombie publics" in 2026 to describe institutions, accounts, and discussion spaces that maintain high visible activity despite possessing little authentic interior life.<span class="cite">[<a href="#ref4">4</a>]</span> When visibility decouples from shared human reality, public digital spaces become perpetual circulation engines where automated accounts interact with other automated accounts, generating visible output that no longer creates shared knowledge among human participants.</p>
+
+    <h3 id="trust-erosion">Trust erosion in public commons</h3>
+    <p>As synthetic content becomes indistinguishable from authentic human output, open social platforms experience severe trust decay. Observers cannot verify whether a comment, account, video, or review originates from a living human or an automated agent. This environment drives users away from open public feeds and into gated, private channels, encrypted group chats, and real-time physical gatherings that resist automated synthesis.</p>
+
+    <h2 id="technical-countermeasures">Technical countermeasures</h2>
+    <p>Mitigating automated impersonation involves distinct architectural approaches:</p>
+    <ul>
+      <li><strong>Cryptographic Proof-of-Personhood:</strong> Systems that bind digital credentials to verifiable human biometrics (such as zero-knowledge iris hashes) to confirm unique physical identity without revealing personal data.</li>
+      <li><strong>Hardware-Bound Authentication:</strong> Standards such as FIDO2 and WebAuthn that tie authorization to cryptographic origin keys stored on physical devices, rendering traditional credential harvesting ineffective.</li>
+      <li><strong>Negative Constraints:</strong> Explicit, checkable operational boundaries, such as refusing to utilize CGI in product demonstrations, allowing organizations to maintain credibility in saturated synthetic media environments.</li>
+      <li><strong>Proof of Work and Economic Friction:</strong> Introducing small computational or financial costs per transaction or communication request to break the zero-cost advantage of automated bot swarms.</li>
+    </ul>
+
+    <h2 id="see-also">See also</h2>
+    <ul>
+      <li><a href="/reference/agents/">Reference: Agents</a></li>
+      <li><a href="/reference/adversarial-agent-review/">Reference: Adversarial Review</a></li>
+      <li><a href="/reference/epistemology/">Reference: Epistemology</a></li>
+      <li><a href="/reference/fail-closed/">Reference: Fail-Closed</a></li>
+      <li><a href="/reference/sycophancy/">Reference: Sycophancy</a></li>
+    </ul>
+
+    <h2 id="references">References</h2>
+    <ol>
+      <li id="ref1"><span class="backlink">^</span> Kaitlyn Tiffany, "Maybe You Missed It, but the Internet 'Died' Five Years Ago," <em>The Atlantic</em>, August 31, 2021.</li>
+      <li id="ref2"><span class="backlink">^</span> Prathamesh Muzumdar, "The Dead Internet Theory: A Survey on Artificial Interactions and the Future of Social Media," <em>Asian Journal of Research in Computer Science</em>, 2025.</li>
+      <li id="ref3"><span class="backlink">^</span> Imperva Threat Research, <em>2024 Imperva Bad Bot Report: Cybercrime Confronts Artificial Intelligence</em>, Imperva Inc., 2024.</li>
+      <li id="ref4"><span class="backlink">^</span> Venkatesh Rao, "Dead Forest Theory," <em>Contraptions</em>, July 5, 2026.</li>
+      <li id="ref5"><span class="backlink">^</span> IlluminatiPirate, "Dead Internet Theory: Most Of The Internet Is Fake," <em>Agora Road's Macintosh Cafe</em>, January 5, 2021.</li>
+    </ol>
+
+    <footer class="meta">
+      <p><a href="#top">Back to top</a></p>
+    </footer>
+  </main>
+  <button id="backToTop" class="back-to-top" aria-label="Back to top" title="Back to top">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M18 15l-6-6-6 6"/>
+    </svg>
+  </button>
+
+  <script>
+    const btt = document.getElementById('backToTop');
+    window.addEventListener('scroll', () => {
+      if (window.scrollY > 250) {
+        btt.classList.add('visible');
+      } else {
+        btt.classList.remove('visible');
+      }
+    }, { passive: true });
+    btt.addEventListener('click', () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  </script>
+</body>
+</html>

--- a/reference/index.html
+++ b/reference/index.html
@@ -236,6 +236,7 @@
       <div class="letter-group" id="D">
         <h2 class="letter-heading">D</h2>
         <ul>
+        <li><a href="/reference/dead-internet-theory/">Dead Internet Theory</a></li>
         <li><a href="/reference/deep-neural-networks/">Deep Neural Networks</a></li>
         </ul>
       </div>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -201,6 +201,11 @@
     <priority>0.5</priority>
   </url>
   <url>
+    <loc>https://ngpestelos.com/reference/dead-internet-theory/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
     <loc>https://ngpestelos.com/reference/deep-neural-networks/</loc>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>


### PR DESCRIPTION
Add citable encyclopedia-style reference page for Dead Internet Theory:
- History from 2021 Agora Road forum post to academic study
- Empirical bot measurement vs conspiratorial framing
- Structural economic drivers and platform ad-revenue misalignment
- Sociological concepts (zombie publics, trust decay) and technical mitigations
- Schema.org DefinedTerm JSON-LD metadata
- Updated reference index and sitemap.xml