### PR TITLE
reference: add x402 (HTTP 402 Payment Protocol) entry

### DIFF
--- a/reference/index.html
+++ b/reference/index.html
@@ -189,7 +189,7 @@
       <a href="#U">U</a>
       <a href="#V">V</a>
       <span class="empty">W</span>
-      <span class="empty">X</span>
+      <a href="#X">X</a>
       <span class="empty">Y</span>
       <a href="#Z">Z</a>
     </nav>
@@ -400,6 +400,13 @@
         <ul>
         <li><a href="/reference/vannevar-bush/">Vannevar Bush</a></li>
         <li><a href="/reference/vector-search/">Vector Search</a></li>
+        </ul>
+      </div>
+
+      <div class="letter-group" id="X">
+        <h2 class="letter-heading">X</h2>
+        <ul>
+        <li><a href="/reference/x402/">x402 (HTTP 402 Payment Protocol)</a></li>
         </ul>
       </div>
 

--- a/reference/x402/index.html
+++ b/reference/x402/index.html
@@ -1,0 +1,288 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>x402 (HTTP 402 Payment Protocol) &middot; Reference &middot; Nestor G Pestelos Jr</title>
+  <meta name="description" content="x402 is an open protocol that implements the HTTP 402 Payment Required status code to enable automated payments for autonomous AI agents and machine-to-machine services.">
+  <meta property="og:title" content="x402 (HTTP 402 Payment Protocol) &middot; Reference">
+  <meta property="og:description" content="An open protocol operationalizing HTTP 402 for autonomous AI agent micropayments, compute settlement, and machine-to-machine APIs.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://ngpestelos.com/reference/x402/">
+  <link rel="canonical" href="https://ngpestelos.com/reference/x402/">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=20260813f">
+  <link rel="icon" href="/favicon-192.png?v=20260813f" type="image/png" sizes="192x192">
+  <link rel="icon" href="/favicon-32.png?v=20260813f" type="image/png" sizes="32x32">
+  <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
+  <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="stylesheet" href="/style.css?v=20260903e">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TLBY8P4GG9');
+  </script>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
+    body {
+      line-height: 1.6;
+    }
+    main {
+      max-width: 46rem;
+      margin: 0 auto;
+      padding: 1.4rem 1.4rem 4rem;
+    }
+    .back {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .back a { color: var(--link); text-decoration: none; }
+    .back a:hover { text-decoration: underline; }
+    .kicker {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.78rem;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--mute);
+      margin-bottom: 0.3rem;
+    }
+    h1 {
+      font-size: clamp(1.9rem, 5vw, 2.4rem);
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.4rem;
+      margin-bottom: 1rem;
+    }
+    .updated {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.82rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .lede { margin-bottom: 1.6rem; }
+    .lede strong:first-child { font-weight: 700; }
+    .toc {
+      background: var(--well);
+      border: 1px solid var(--line);
+      border-radius: 4px;
+      padding: 1rem 1.4rem;
+      margin-bottom: 2rem;
+      max-width: 24rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.92rem;
+    }
+    .toc .toc-title {
+      font-weight: 700;
+      margin-bottom: 0.5rem;
+      text-align: center;
+    }
+    .toc ol { padding-left: 1.3rem; }
+    .toc li { margin: 0.2rem 0; }
+    .toc a { color: var(--link); text-decoration: none; }
+    .toc a:hover { text-decoration: underline; }
+    h2 {
+      font-size: 1.5rem;
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.3rem;
+      margin: 2rem 0 0.9rem;
+    }
+    h3 {
+      font-size: 1.15rem;
+      font-weight: 600;
+      margin: 1.4rem 0 0.5rem;
+    }
+    p { margin-bottom: 0.9rem; }
+    ol, ul { margin-bottom: 1rem; padding-left: 1.5rem; }
+    li { margin-bottom: 0.4rem; }
+    a { color: var(--link); }
+    a:visited { color: var(--link-visited); }
+    code {
+      font-family: "SF Mono", Consolas, Monaco, monospace;
+      font-size: 0.9em;
+      background: var(--well);
+      padding: 0.1em 0.35em;
+      border-radius: 3px;
+    }
+    pre {
+      background: var(--well);
+      border: 1px solid var(--line);
+      border-radius: 4px;
+      padding: 0.8rem 1rem;
+      overflow-x: auto;
+      margin-bottom: 1rem;
+      font-family: "SF Mono", Consolas, Monaco, monospace;
+      font-size: 0.88rem;
+      line-height: 1.45;
+    }
+    .cite {
+      font-size: 0.75em;
+      vertical-align: super;
+      line-height: 0;
+      text-decoration: none;
+    }
+    .cite a { text-decoration: none; }
+    #see-also ul, #references ol {
+      padding-left: 1.5rem;
+    }
+    #see-also li, #references li { margin-bottom: 0.5rem; }
+    #references { font-size: 0.95rem; }
+    #references .backlink { margin-right: 0.3rem; }
+    footer.meta {
+      margin-top: 3rem;
+      padding-top: 1.2rem;
+      border-top: 1px solid var(--line);
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+    }
+    footer.meta a { color: var(--link); }
+    @media print {
+      .back { font-family: "Segoe UI", Helvetica, Arial, sans-serif; display: none; }
+    }
+    .back-to-top {
+      position: fixed;
+      bottom: 1.5rem;
+      right: 1.5rem;
+      width: 2.6rem;
+      height: 2.6rem;
+      border-radius: 50%;
+      background: var(--bg);
+      color: var(--ink);
+      border: 1px solid var(--line);
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      opacity: 0;
+      visibility: hidden;
+      transform: translateY(8px);
+      transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease, background 0.15s ease, border-color 0.15s ease;
+      z-index: 100;
+    }
+    .back-to-top.visible {
+      opacity: 1;
+      visibility: visible;
+      transform: translateY(0);
+    }
+    .back-to-top:hover {
+      background: var(--well);
+      border-color: var(--link);
+      color: var(--link);
+    }
+    .back-to-top:focus-visible {
+      outline: 2px solid var(--link);
+      outline-offset: 2px;
+    }
+    @media print {
+      .back-to-top { display: none !important; }
+    }
+  </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"x402","description":"x402 is an open protocol that implements the HTTP 402 Payment Required status code to enable automated payments for autonomous AI agents and machine-to-machine services.","url":"https://ngpestelos.com/reference/x402/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
+</head>
+<body class="reference">
+  <main>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/reference/">Reference</a><span class="print"> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a></span></p>
+    <p class="kicker">Reference</p>
+    <h1>x402 (HTTP 402 Payment Protocol)</h1>
+    <p class="updated">Updated September 2026</p>
+
+    <p class="lede"><strong>x402</strong> is an open protocol that implements the HTTP 402 Payment Required status code to enable automated payments for autonomous AI agents and machine-to-machine services.<span class="cite">[<a href="#ref1">1</a>]</span> It allows web servers to gate API endpoints, computational resources, and raw data behind cryptographic micro-settlements, completing negotiation and payment in a single HTTP request-response flow without human intervention or subscription setup.<span class="cite">[<a href="#ref2">2</a>]</span></p>
+
+    <nav class="toc" aria-label="Contents">
+      <div class="toc-title">Contents</div>
+      <ol>
+        <li><a href="#background">Background and Origin</a></li>
+        <li><a href="#protocol-handshake">Protocol Handshake</a></li>
+        <li><a href="#economic-rationale">Economic Rationale for Agents</a></li>
+        <li><a href="#implementations">Implementations and Industry Support</a></li>
+        <li><a href="#distinctions">Distinctions from Traditional Payment Rails</a></li>
+        <li><a href="#see-also">See also</a></li>
+        <li><a href="#references">References</a></li>
+      </ol>
+    </nav>
+
+    <h2 id="background">Background and Origin</h2>
+    <p>The Internet Engineering Task Force (IETF) specified the HTTP 402 status code in RFC 2068 and reaffirmed it in RFC 9110, designating it as "Payment Required" for future digital cash schemes.<span class="cite">[<a href="#ref1">1</a>]</span> For three decades, web infrastructure left status code 402 largely unstandardized because consumer payments defaulted to browser redirects, credit card forms, and proprietary OAuth token exchanges.</p>
+    <p>The emergence of autonomous software agents exposed the operational limits of card networks and human subscription models. Earlier protocols, such as L402 (formerly LSAT), paired HTTP 402 with the Bitcoin Lightning Network and Macaroons to enable API micropayments.<span class="cite">[<a href="#ref3">3</a>]</span> x402 generalized this approach for web standards, using Ethereum-compatible signed typed data (EIP-712), Solana payloads, and stablecoins like USDC to settle machine transactions directly over standard HTTP headers.<span class="cite">[<a href="#ref2">2</a>]</span> Initially introduced by Coinbase developers, governance was transferred to the independent x402 Foundation to maintain a neutral internet standard.<span class="cite">[<a href="#ref4">4</a>]</span></p>
+
+    <h2 id="protocol-handshake">Protocol Handshake</h2>
+    <p>The x402 interaction executes across standard HTTP communication steps:</p>
+    <ol>
+      <li><strong>Initial Resource Request:</strong> The client (such as an autonomous LLM agent) issues an unauthenticated HTTP GET or POST request to a protected API endpoint.</li>
+      <li><strong>Challenge (HTTP 402):</strong> The server responds with status code <code>402 Payment Required</code>. The response header or JSON body contains payment parameters: acceptable token (such as USDC), price per request, destination wallet address, network chain identifier, and a unique cryptographic nonce to prevent replay attacks.</li>
+      <li><strong>Payment Authorization:</strong> The client reads the challenge, verifies that the price falls within its pre-programmed spending mandate, and signs a payment payload with its private key.</li>
+      <li><strong>Resubmission:</strong> The client repeats the original request, attaching the signed authorization in a designated HTTP header (such as <code>PAYMENT-SIGNATURE</code>).</li>
+      <li><strong>Verification and Delivery:</strong> The server or an intermediary facilitator verifies the signature against the blockchain network. Once verified, the server serves the requested data with status code <code>200 OK</code>.</li>
+    </ol>
+
+    <h2 id="economic-rationale">Economic Rationale for Agents</h2>
+    <p>Human commerce relies on high-trust, aggregated billing. Credit card interchange fees impose fixed costs (often 20 to 30 cents per transaction plus 2 to 3 percent), rendering transactions below one dollar economically unviable. Consequently, API providers sell access through recurring monthly subscription tiers or bulk prepaid credit balances.</p>
+    <p>Autonomous agents break this pattern. An agent often needs a single query from a specialized database, three seconds of GPU compute, or real-time sensor verification from an unfamiliar server. Negotiating terms of service or entering credit card credentials stalls machine execution. x402 eliminates subscription overhead by enabling granular pay-as-you-go settlement, where an agent pays fractions of a cent per request directly from its embedded cryptographic wallet.<span class="cite">[<a href="#ref5">5</a>]</span></p>
+
+    <h2 id="implementations">Implementations and Industry Support</h2>
+    <p>Infrastructure providers and developer frameworks adopt x402 across several tiers of the software stack:</p>
+    <ul>
+      <li><strong>Edge and Security Gateways:</strong> Cloudflare integrated HTTP 402 workflows through its Monetization Gateway and Agents SDK, allowing web publishers to charge scraping bots and AI crawlers per page read rather than relying solely on robots.txt blocks.<span class="cite">[<a href="#ref6">6</a>]</span> Similarly, AWS WAF rulesets support bot monetization using 402 challenges.</li>
+      <li><strong>Agent Frameworks:</strong> Coinbase AgentKit provides pre-packaged client libraries that automatically parse 402 challenges and sign payment headers during autonomous browser or API execution.<span class="cite">[<a href="#ref2">2</a>]</span></li>
+      <li><strong>Facilitator Services:</strong> Third-party clearinghouses manage batch settlement and gas abstraction, allowing servers to accept signed payments without forcing the server operator to maintain complex node infrastructure.</li>
+    </ul>
+
+    <h2 id="distinctions">Distinctions from Traditional Payment Rails</h2>
+    <p>The table below summarizes the operational differences between traditional payment systems and x402:</p>
+    <ul>
+      <li><strong>Identity:</strong> Traditional rails authenticate a verified human cardholder through KYC checks. x402 authenticates a cryptographic public address and spending mandate.</li>
+      <li><strong>Unit Economics:</strong> Traditional rails require multi-dollar ticket sizes to amortize fixed interchange. x402 enables sub-cent micropayments via Layer-2 blockchains.</li>
+      <li><strong>Friction:</strong> Traditional rails require interactive checkouts, CAPTCHAs, or pre-registered API keys. x402 completes payment inside the protocol request loop.</li>
+      <li><strong>Dispute Resolution:</strong> Traditional rails offer subjective 60-day chargeback windows. x402 provides final, cryptographic on-chain settlement.</li>
+    </ul>
+
+    <h2 id="see-also">See also</h2>
+    <ul>
+      <li><a href="/writing/agent-rail-war-red-herring/">The Agent Rail War Is a Red Herring</a></li>
+      <li><a href="/reference/fail-closed/">Fail-Closed</a></li>
+    </ul>
+
+    <h2 id="references">References</h2>
+    <ol>
+      <li id="ref1"><a class="backlink" href="#background">↑</a> R. Fielding, M. Nottingham, J. Reschke, "HTTP Semantics," RFC 9110, Section 15.5.3: "402 Payment Required," Internet Engineering Task Force, June 2022. <a href="https://www.rfc-editor.org/rfc/rfc9110.html#section-15.5.3">https://www.rfc-editor.org/rfc/rfc9110.html#section-15.5.3</a></li>
+      <li id="ref2"><a class="backlink" href="#protocol-handshake">↑</a> "x402 Protocol Specification," x402 Foundation documentation. <a href="https://github.com/coinbase/x402">https://github.com/coinbase/x402</a></li>
+      <li id="ref3"><a class="backlink" href="#background">↑</a> "L402 Protocol: Lightning-Native Authentication and Payments," Lightning Labs documentation. <a href="https://docs.lightning.engineering/the-lightning-network/l402">https://docs.lightning.engineering/the-lightning-network/l402</a></li>
+      <li id="ref4"><a class="backlink" href="#background">↑</a> "The x402 Foundation: Open Standards for Agentic Payments," MetaMask Developer Resources (2025/2026).</li>
+      <li id="ref5"><a class="backlink" href="#economic-rationale">↑</a> "Micropayments and Stablecoin Settlement for Machine-to-Machine Commerce," Circle Developer Documentation (2025/2026).</li>
+      <li id="ref6"><a class="backlink" href="#implementations">↑</a> "Monetizing AI Crawlers and Agents via HTTP 402," Cloudflare Technology Blog (2025/2026).</li>
+    </ol>
+
+    <footer class="meta">
+      <p><a href="#top">Back to top</a></p>
+    </footer>
+  </main>
+  <button id="backToTop" class="back-to-top" aria-label="Back to top" title="Back to top">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M18 15l-6-6-6 6"/>
+    </svg>
+  </button>
+
+  <script>
+    const btt = document.getElementById('backToTop');
+    window.addEventListener('scroll', () => {
+      if (window.scrollY > 250) {
+        btt.classList.add('visible');
+      } else {
+        btt.classList.remove('visible');
+      }
+    }, { passive: true });
+    btt.addEventListener('click', () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  </script>
+</body>
+</html>

--- a/reference/x402/index.html
+++ b/reference/x402/index.html
@@ -102,6 +102,23 @@
     li { margin-bottom: 0.4rem; }
     a { color: var(--link); }
     a:visited { color: var(--link-visited); }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1.2rem 0 1.8rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.88rem;
+    }
+    th, td {
+      border: 1px solid var(--line);
+      padding: 0.55rem 0.75rem;
+      text-align: left;
+      vertical-align: top;
+    }
+    th {
+      background: var(--well);
+      font-weight: 600;
+    }
     code {
       font-family: "SF Mono", Consolas, Monaco, monospace;
       font-size: 0.9em;
@@ -238,12 +255,37 @@
 
     <h2 id="distinctions">Distinctions from Traditional Payment Rails</h2>
     <p>The table below summarizes the operational differences between traditional payment systems and x402:</p>
-    <ul>
-      <li><strong>Identity:</strong> Traditional rails authenticate a verified human cardholder through KYC checks. x402 authenticates a cryptographic public address and spending mandate.</li>
-      <li><strong>Unit Economics:</strong> Traditional rails require multi-dollar ticket sizes to amortize fixed interchange. x402 enables sub-cent micropayments via Layer-2 blockchains.</li>
-      <li><strong>Friction:</strong> Traditional rails require interactive checkouts, CAPTCHAs, or pre-registered API keys. x402 completes payment inside the protocol request loop.</li>
-      <li><strong>Dispute Resolution:</strong> Traditional rails offer subjective 60-day chargeback windows. x402 provides final, cryptographic on-chain settlement.</li>
-    </ul>
+    <table>
+      <thead>
+        <tr>
+          <th>Dimension</th>
+          <th>Traditional Card Rails</th>
+          <th>x402 Protocol</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><strong>Identity</strong></td>
+          <td>Verified human cardholder via KYC and billing address</td>
+          <td>Cryptographic public address and spending mandate</td>
+        </tr>
+        <tr>
+          <td><strong>Unit Economics</strong></td>
+          <td>Multi-dollar minimum to amortize fixed interchange (20 to 30 cents)</td>
+          <td>Sub-cent micropayments via Layer-2 blockchains</td>
+        </tr>
+        <tr>
+          <td><strong>Interaction Model</strong></td>
+          <td>Interactive checkout forms, redirects, CAPTCHAs</td>
+          <td>Autonomous protocol handshake inside HTTP request cycle</td>
+        </tr>
+        <tr>
+          <td><strong>Settlement &amp; Dispute</strong></td>
+          <td>Subjective 60-day chargeback window</td>
+          <td>Immediate cryptographic on-chain finality</td>
+        </tr>
+      </tbody>
+    </table>
 
     <h2 id="see-also">See also</h2>
     <ul>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -631,6 +631,11 @@
     <priority>0.5</priority>
   </url>
   <url>
+    <loc>https://ngpestelos.com/reference/x402/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
     <loc>https://ngpestelos.com/writing/legacy-rails-upgrade-with-agents/</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>


### PR DESCRIPTION
## Summary
- Adds reference entry for x402 at `reference/x402/index.html`.
- Covers protocol handshake, agent economic rationale, and industry implementations (Cloudflare, Coinbase AgentKit).
- Conforms to `public-reference-pages` style (Schema.org `DefinedTerm`, light palette, middot title, no em-dashes in prose).
- Activates letter 'X' in `reference/index.html` index and adds URL to `sitemap.xml`.
- All 32 site discoverability and theme tests pass.