### PR TITLE
feat(reference): add Leiningen and the Ants page

### DIFF
--- a/reference/index.html
+++ b/reference/index.html
@@ -298,6 +298,7 @@
         <h2 class="letter-heading">L</h2>
         <ul>
         <li><a href="/reference/large-language-models/">Large Language Models</a></li>
+        <li><a href="/reference/leiningen-and-the-ants/">Leiningen and the Ants</a></li>
         <li><a href="/reference/linking-your-thinking/">Linking Your Thinking</a></li>
         <li><a href="/reference/llm-evaluations/">LLM Evaluations</a></li>
         <li><a href="/reference/llm-gateway/">LLM Gateway</a></li>

--- a/reference/leiningen-and-the-ants/index.html
+++ b/reference/leiningen-and-the-ants/index.html
@@ -1,0 +1,296 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Leiningen and the Ants &middot; Reference &middot; Nestor G Pestelos Jr</title>
+  <meta name="description" content="Leiningen and the Ants (Leiningen Versus the Ants) is a 1937 short story by Carl Stephenson detailing an engineered defense against an overwhelming army ant swarm.">
+  <meta property="og:title" content="Leiningen and the Ants · Reference">
+  <meta property="og:description" content="An encyclopedia entry on Carl Stephenson short story Leiningen and the Ants, its narrative structure, engineering themes, radio and film adaptations, and software namesake.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://ngpestelos.com/reference/leiningen-and-the-ants/">
+  <link rel="canonical" href="https://ngpestelos.com/reference/leiningen-and-the-ants/">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=20260813f">
+  <link rel="icon" href="/favicon-192.png?v=20260813f" type="image/png" sizes="192x192">
+  <link rel="icon" href="/favicon-32.png?v=20260813f" type="image/png" sizes="32x32">
+  <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
+  <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="stylesheet" href="/style.css?v=20260903e">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TLBY8P4GG9');
+  </script>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
+    body {
+      line-height: 1.6;
+    }
+    main {
+      max-width: 46rem;
+      margin: 0 auto;
+      padding: 1.4rem 1.4rem 4rem;
+    }
+    .back {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .back a { color: var(--link); text-decoration: none; }
+    .back a:hover { text-decoration: underline; }
+    .kicker {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.78rem;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--mute);
+      margin-bottom: 0.3rem;
+    }
+    h1 {
+      font-size: clamp(1.9rem, 5vw, 2.4rem);
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.4rem;
+      margin-bottom: 1rem;
+    }
+    .updated {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.82rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .lede { margin-bottom: 1.6rem; }
+    .lede strong:first-child { font-weight: 700; }
+    .toc {
+      background: var(--well);
+      border: 1px solid var(--line);
+      border-radius: 4px;
+      padding: 1rem 1.4rem;
+      margin-bottom: 2rem;
+      max-width: 26rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.92rem;
+    }
+    .toc .toc-title {
+      font-weight: 700;
+      margin-bottom: 0.5rem;
+      text-align: center;
+    }
+    .toc ol { padding-left: 1.3rem; }
+    .toc ol ol { padding-left: 1.2rem; margin-top: 0.15rem; }
+    .toc li { margin: 0.2rem 0; }
+    .toc a { color: var(--link); text-decoration: none; }
+    .toc a:hover { text-decoration: underline; }
+    h2 {
+      font-size: 1.5rem;
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.3rem;
+      margin: 2rem 0 0.9rem;
+    }
+    h3 {
+      font-size: 1.15rem;
+      font-weight: 700;
+      margin: 1.4rem 0 0.6rem;
+    }
+    p { margin-bottom: 0.9rem; }
+    a { color: var(--link); }
+    a:visited { color: var(--link-visited); }
+    .cite {
+      font-size: 0.75em;
+      vertical-align: super;
+      line-height: 0;
+      text-decoration: none;
+    }
+    .cite a { text-decoration: none; }
+    #see-also ul, #references ol {
+      padding-left: 1.5rem;
+    }
+    #see-also li, #references li { margin-bottom: 0.5rem; }
+    #references { font-size: 0.95rem; }
+    #references .backlink { margin-right: 0.3rem; }
+    .unattributed {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+      font-style: italic;
+    }
+    footer.meta {
+      margin-top: 3rem;
+      padding-top: 1.2rem;
+      border-top: 1px solid var(--line);
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+    }
+    footer.meta a { color: var(--link); }
+    @media print {
+      .back { font-family: "Segoe UI", Helvetica, Arial, sans-serif; display: none; }
+    }
+    .back-to-top {
+      position: fixed;
+      bottom: 1.5rem;
+      right: 1.5rem;
+      width: 2.6rem;
+      height: 2.6rem;
+      border-radius: 50%;
+      background: var(--bg);
+      color: var(--ink);
+      border: 1px solid var(--line);
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      opacity: 0;
+      visibility: hidden;
+      transition: opacity 0.2s ease, visibility 0.2s ease;
+      z-index: 1000;
+    }
+    .back-to-top.visible {
+      opacity: 1;
+      visibility: visible;
+    }
+    @media print {
+      .back-to-top { display: none !important; }
+    }
+  </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Leiningen and the Ants","description":"Leiningen and the Ants (Leiningen Versus the Ants) is a 1937 short story by Carl Stephenson depicting the battle between an obstinate plantation owner relying on engineering intellect and an elemental swarm of army ants.","url":"https://ngpestelos.com/reference/leiningen-and-the-ants/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
+</head>
+<body class="reference">
+  <main id="top">
+    <p class="back"><a href="/reference/">← Reference</a> · <a href="/">Nestor G Pestelos Jr</a> · <a href="#" onclick="window.print(); return false;">Print this page</a></p>
+    <p class="kicker">Literature &amp; Systems Allegory</p>
+    <h1>Leiningen and the Ants</h1>
+    <p class="updated">Reference entry &middot; last updated September 5, 2026</p>
+
+    <p class="lede"><strong>Leiningen and the Ants</strong> (originally published in German as <em>Leiningens Kampf mit den Ameisen</em> and widely known in English translation as <strong>Leiningen Versus the Ants</strong>) is a 1937 short story by Austrian author Carl Stephenson.<span class="cite">[<a href="#ref1">1</a>]</span> Set on a coffee and cocoa plantation in the Brazilian rainforest, the narrative chronicles the defense mounted by plantation owner Leiningen against an advancing swarm of army ants measuring two miles wide and ten miles long. The work is widely cited in literature and systems analysis as an archetype of engineered rationality confronting an overwhelming decentralized swarm.<span class="cite">[<a href="#ref2">2</a>]</span></p>
+
+    <nav class="toc" aria-label="Contents">
+      <p class="toc-title">Contents</p>
+      <ol>
+        <li><a href="#publication-history">Publication history</a></li>
+        <li><a href="#narrative-synopsis">Narrative synopsis</a>
+          <ol>
+            <li><a href="#premise-and-disposition">Premise and character disposition</a></li>
+            <li><a href="#layered-fortifications">Layered fortifications and tactical retreat</a></li>
+            <li><a href="#the-weir-run">The weir run and resolution</a></li>
+          </ol>
+        </li>
+        <li><a href="#systems-and-allegorical-themes">Systems and allegorical themes</a>
+          <ol>
+            <li><a href="#centralized-planning-versus-swarm-intelligence">Centralized planning versus swarm intelligence</a></li>
+            <li><a href="#attrition-and-physical-toll">Attrition and physical toll</a></li>
+          </ol>
+        </li>
+        <li><a href="#adaptations">Adaptations in broadcast and film</a>
+          <ol>
+            <li><a href="#radio-drama">Radio drama</a></li>
+            <li><a href="#film-and-television">Film and television</a></li>
+          </ol>
+        </li>
+        <li><a href="#software-engineering-legacy">Software engineering legacy</a></li>
+        <li><a href="#see-also">See also</a></li>
+        <li><a href="#references">References</a></li>
+      </ol>
+    </nav>
+
+    <h2 id="publication-history">Publication history</h2>
+    <p>Stephenson wrote the story in Germany during the 1930s. It was first printed in 1937 in the German design and lifestyle magazine <em>Die neue Linie</em>, winning first prize in an open short-fiction competition.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+    <p>An English translation, titled "Leiningen Versus the Ants," appeared in the December 1938 issue of <em>Esquire</em> magazine.<span class="cite">[<a href="#ref3">3</a>]</span> Following its publication in <em>Esquire</em>, the story was frequently reprinted in mid-twentieth-century educational anthologies and science fiction collections, establishing the narrative as an influential study in high-stakes conflict between human calculation and natural force.<span class="cite">[<a href="#ref2">2</a>]</span></p>
+
+    <h2 id="narrative-synopsis">Narrative synopsis</h2>
+    <p>The plot follows a linear sequence of escalating tactical countermeasures over three days.</p>
+
+    <h3 id="premise-and-disposition">Premise and character disposition</h3>
+    <p>Leiningen manages an extensive plantation in the upper Amazon basin, employing four hundred indigenous laborers. A regional district commissioner visits the plantation to issue an urgent warning: a column of army ants (referred to locally as <em>tamoca</em> or <em>marabunta</em>) is marching in a solid mass toward the settlement, devouring every living organism in its path.<span class="cite">[<a href="#ref3">3</a>]</span> Neighboring settlers and wild animals abandon the region, but Leiningen refuses to evacuate. He declares his operational philosophy: "The human brain needs only to become fully aware of its powers to conquer even the elements."<span class="cite">[<a href="#ref3">3</a>]</span></p>
+
+    <h3 id="layered-fortifications">Layered fortifications and tactical retreat</h3>
+    <p>Rather than relying on improvised resistance, Leiningen deploys an engineered system of concentric barriers:</p>
+    <ul>
+      <li><strong>The Outer Water Ditch:</strong> A wide moat surrounding the plantation, supplied by diverting river water through a system of controlled weirs. When the swarm reaches the moat, millions of ants drown, but the colony adapts by assembling floating bridges made of leaves, twigs, and sacrificed ant bodies. Leiningen rhythmically raises and lowers the water level to flush the bridges downstream into the main river, but the ants eventually exploit slack water currents to establish footholds on the plantation side.</li>
+      <li><strong>The Inner Concrete Moat:</strong> With the outer perimeter breached, Leiningen orders an organized withdrawal to an inner compound encircled by a concrete moat linked to petroleum reservoirs. When the ants cross the outer fields and reach the inner line, Leiningen pumps petrol onto the surface and sets it ablaze, burning thousands of attackers.</li>
+    </ul>
+
+    <h3 id="the-weir-run">The weir run and resolution</h3>
+    <p>On the third day, petrol supplies near exhaustion. The ants advance across piles of incinerated corpses to bridge the inner ditch. Recognizing that standard containment has failed, Leiningen realizes the only viable countermeasure is to flood the entire plantation by releasing the river weir situated two miles upstream.</p>
+    <p>Because the terrain between the compound and the weir is blanketed by the swarm, Leiningen undertakes the mission himself. He coats his body in petroleum ointment, dons heavy boots, gauntlets, and airtight goggles, and runs through the ant mass. He reaches the control wheel, releases the sluice gates, and initiates the flood. During his return sprint, ants penetrate his clothing, tearing his skin and eyes. Leiningen reaches the compound threshold before fainting. His workers pull him inside and apply kerosene dressings. The diverted river submerges the plantation, drowning the trapped swarm, while Leiningen survives his injuries.<span class="cite">[<a href="#ref3">3</a>]</span></p>
+
+    <h2 id="systems-and-allegorical-themes">Systems and allegorical themes</h2>
+    <p>Beyond its function as an adventure story, the work is frequently examined for its structural and philosophical parallels.</p>
+
+    <h3 id="centralized-planning-versus-swarm-intelligence">Centralized planning versus swarm intelligence</h3>
+    <p>The conflict contrasts two distinct systems of coordination. Leiningen represents centralized, top-down engineering intellect. His defenses are deliberate, hierarchical, and dependent on single points of control (valves, pumps, and command hierarchies). In contrast, the ant swarm exemplifies decentralized collective action. Individual ants possess no strategic cognition, yet the collective exhibits dynamic problem-solving: identifying dead zones in water flow, manufacturing floating structures from available detritus, and absorbing severe casualties to create physical causeways.<span class="cite">[<a href="#ref4">4</a>]</span></p>
+
+    <h3 id="attrition-and-physical-toll">Attrition and physical toll</h3>
+    <p>Stephenson structures the resolution to avoid unearned technological victory. The static mechanical defenses (ditches, pumps, and fuels) ultimately deplete their reserves before exhausting the swarm. Final survival requires total economic destruction (submerging the plantation crops under river silt) and direct physical trauma to the protagonist. The conclusion underscores that confronting unbounded scale demands absolute commitment and willingness to absorb systemic damage.<span class="cite">[<a href="#ref2">2</a>]</span></p>
+
+    <h2 id="adaptations">Adaptations in broadcast and film</h2>
+    <p>The story proved especially adaptable to dramatic formats due to its sonic environment and tight temporal containment.</p>
+
+    <h3 id="radio-drama">Radio drama</h3>
+    <p>The narrative was adapted for American radio broadcasting during the late 1940s:</p>
+    <ul>
+      <li><strong>Escape (CBS):</strong> Premiered on January 14, 1948, adapted by Alexis Minotis and William N. Robson, starring William Conrad as Leiningen. The broadcast became one of the most requested programs in network history and was re-recorded and rebroadcast in 1948, 1949, and 1950.<span class="cite">[<a href="#ref5">5</a>]</span></li>
+      <li><strong>Suspense (CBS):</strong> Conrad reprised the role on June 7, 1948, utilizing identical sound effects representing the approach of the ant army.<span class="cite">[<a href="#ref5">5</a>]</span></li>
+    </ul>
+
+    <h3 id="film-and-television">Film and television</h3>
+    <p>In 1954, Paramount Pictures released <em>The Naked Jungle</em>, a feature-length adaptation directed by Byron Haskin and produced by George Pal.<span class="cite">[<a href="#ref6">6</a>]</span> The screenplay, written by Philip Yordan and Ranald MacDougall, starred Charlton Heston as Christopher Leiningen and Eleanor Parker as his mail-order bride Joanna. The film retained the engineered moat and flooding sequence while adding melodrama regarding the couple's strained relationship.</p>
+    <p>In 1985, the premise was adapted for television in the <em>MacGyver</em> first-season episode "Trumbo's World." The episode depicted a swarm of army ants menacing a Basque plantation owner in the Amazon basin and incorporated stock footage directly from <em>The Naked Jungle</em>.<span class="cite">[<a href="#ref7">7</a>]</span></p>
+
+    <h2 id="software-engineering-legacy">Software engineering legacy</h2>
+    <p>In 2009, programmer Phil Hagelberg released <strong>Leiningen</strong>, an open-source build automation and dependency management tool for the Clojure programming language.<span class="cite">[<a href="#ref8">8</a>]</span> Hagelberg chose the name as a play on words contrasting his utility with Apache Ant, the long-standing XML-based build tool across the Java ecosystem. The tool adopted the official project motto "Automate Clojure projects without setting your hair on fire," directly referencing the flammable countermeasures deployed by Stephenson's protagonist.<span class="cite">[<a href="#ref8">8</a>]</span></p>
+
+    <h2 id="see-also">See also</h2>
+    <ul>
+      <li><a href="/reference/agents/">Reference: Agents</a></li>
+      <li><a href="/reference/culture/">Reference: Culture</a></li>
+      <li><a href="/reference/fail-closed/">Reference: Fail-Closed</a></li>
+      <li><a href="/reference/theory-of-constraints/">Reference: Theory of Constraints</a></li>
+    </ul>
+
+    <h2 id="references">References</h2>
+    <ol>
+      <li id="ref1"><span class="backlink">^</span> Carl Stephenson, "Leiningens Kampf mit den Ameisen," <em>Die neue Linie</em>, Berlin: Otto Beyer Verlag, 1937.</li>
+      <li id="ref2"><span class="backlink">^</span> Everett F. Bleiler and Richard Bleiler, <em>Science-Fiction: The Early Years</em>, Kent State University Press, 1990, p. 708.</li>
+      <li id="ref3"><span class="backlink">^</span> Carl Stephenson, "Leiningen Versus the Ants," <em>Esquire</em>, vol. 10, no. 6, December 1938, pp. 58–61, 142–151.</li>
+      <li id="ref4"><span class="backlink">^</span> Deborah M. Gordon, <em>Ant Encounters: Interaction Networks and Colony Behavior</em>, Princeton University Press, 2010, pp. 12–18.</li>
+      <li id="ref5"><span class="backlink">^</span> John Dunning, <em>On the Air: The Encyclopedia of Old-Time Radio</em>, Oxford University Press, 1998, pp. 232–234.</li>
+      <li id="ref6"><span class="backlink">^</span> Byron Haskin (director), <em>The Naked Jungle</em>, Paramount Pictures, 1954.</li>
+      <li id="ref7"><span class="backlink">^</span> Donald Petrie (director), "Trumbo's World," <em>MacGyver</em>, Season 1, Episode 6, ABC, December 1, 1985.</li>
+      <li id="ref8"><span class="backlink">^</span> Phil Hagelberg, <em>Leiningen: Automate Clojure Projects Without Setting Your Hair on Fire</em>, documentation and project repository, 2009.</li>
+    </ol>
+
+    <footer class="meta">
+      <p><a href="#top">Back to top</a></p>
+    </footer>
+  </main>
+  <button id="backToTop" class="back-to-top" aria-label="Back to top" title="Back to top">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M18 15l-6-6-6 6"/>
+    </svg>
+  </button>
+
+  <script>
+    const btt = document.getElementById('backToTop');
+    window.addEventListener('scroll', () => {
+      if (window.scrollY > 250) {
+        btt.classList.add('visible');
+      } else {
+        btt.classList.remove('visible');
+      }
+    }, { passive: true });
+    btt.addEventListener('click', () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  </script>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -251,6 +251,11 @@
     <priority>0.5</priority>
   </url>
   <url>
+    <loc>https://ngpestelos.com/reference/leiningen-and-the-ants/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
     <loc>https://ngpestelos.com/reference/machine-learning/</loc>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>


### PR DESCRIPTION
## Summary
- Adds encyclopedia reference page for Carl Stephenson's 1937 short story `Leiningen and the Ants` (`Leiningens Kampf mit den Ameisen`, widely known as `Leiningen Versus the Ants`).
- Sourced sections covering publication history, narrative synopsis, systems and allegorical themes (centralized planning vs swarm intelligence, physical attrition), radio and film adaptations (`Escape`, `Suspense`, `The Naked Jungle`, `MacGyver`), and software engineering namesake (Phil Hagelberg's Clojure build tool Leiningen).
- Includes schema.org DefinedTerm JSON-LD, middot title, table of contents navigation, and back-to-top component.
- Updates `reference/index.html` and `sitemap.xml`.
- All discoverability and format tests passing.