### PR TITLE
feat(reference): add perception, working-memory, and consciousness reference pages

### DIFF
--- a/reference/attention/index.html
+++ b/reference/attention/index.html
@@ -222,7 +222,7 @@
     <h1>Attention (Neurological and Computational)</h1>
     <p class="updated">Reference entry · last updated September 5, 2026</p>
 
-    <p class="lede"><strong>Attention</strong> refers to mechanisms for selectively prioritizing a subset of available information for concentrated processing while filtering out competing stimuli. In cognitive neuroscience and psychology, attention is a capacity-limited biological function mediated by frontoparietal neural networks that governs perception, working memory, and conscious awareness.<span class="cite">[<a href="#ref1">1</a>]</span> In artificial intelligence and machine learning, attention is a computational mechanism that dynamically weights relationships among input representations through learned matrix projections, most prominently instantiated as scaled dot-product self-attention in Transformer architectures.<span class="cite">[<a href="#ref2">2</a>]</span> Although both systems solve the challenge of allocating finite representational capacity, they operate under fundamentally different physical substrates, mathematical constraints, and behavioral imperatives.</p>
+    <p class="lede"><strong>Attention</strong> refers to mechanisms for selectively prioritizing a subset of available information for concentrated processing while filtering out competing stimuli. In cognitive neuroscience and psychology, attention is a capacity-limited biological function mediated by frontoparietal neural networks that governs <a href="/reference/perception/">perception</a>, <a href="/reference/working-memory/">working memory</a>, and <a href="/reference/consciousness/">conscious awareness</a>.<span class="cite">[<a href="#ref1">1</a>]</span> In artificial intelligence and machine learning, attention is a computational mechanism that dynamically weights relationships among input representations through learned matrix projections, most prominently instantiated as scaled dot-product self-attention in Transformer architectures.<span class="cite">[<a href="#ref2">2</a>]</span> Although both systems solve the challenge of allocating finite representational capacity, they operate under fundamentally different physical substrates, mathematical constraints, and behavioral imperatives.</p>
 
     <nav class="toc" aria-label="Contents">
       <p class="toc-title">Contents</p>
@@ -418,6 +418,9 @@
 
     <h2 id="see-also">See also</h2>
     <ul>
+      <li><a href="/reference/consciousness/">Reference: Consciousness</a></li>
+      <li><a href="/reference/perception/">Reference: Perception</a></li>
+      <li><a href="/reference/working-memory/">Reference: Working Memory</a></li>
       <li><a href="/reference/transformer-architecture/">Reference: Transformer Architecture</a></li>
       <li><a href="/reference/context-window/">Reference: Context Windows</a></li>
       <li><a href="/reference/context-engineering/">Reference: Context Engineering</a></li>

--- a/reference/consciousness/index.html
+++ b/reference/consciousness/index.html
@@ -1,0 +1,285 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Consciousness (Cognitive Science and Philosophy) &middot; Reference &middot; Nestor G Pestelos Jr</title>
+  <meta name="description" content="Consciousness is the state of subjective qualitative experience, awareness of mental events, and executive availability for cognitive control and verbal report.">
+  <meta property="og:title" content="Consciousness (Cognitive Science and Philosophy) · Reference">
+  <meta property="og:description" content="An encyclopedia reference entry on consciousness, phenomenal versus access consciousness, global workspace theory, integrated information, and neural correlates.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://ngpestelos.com/reference/consciousness/">
+  <link rel="canonical" href="https://ngpestelos.com/reference/consciousness/">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=20260813f">
+  <link rel="icon" href="/favicon-192.png?v=20260813f" type="image/png" sizes="192x192">
+  <link rel="icon" href="/favicon-32.png?v=20260813f" type="image/png" sizes="32x32">
+  <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
+  <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="stylesheet" href="/style.css?v=20260903e">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TLBY8P4GG9');
+  </script>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
+    body {
+      line-height: 1.6;
+    }
+    main {
+      max-width: 46rem;
+      margin: 0 auto;
+      padding: 1.4rem 1.4rem 4rem;
+    }
+    .back {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .back a { color: var(--link); text-decoration: none; }
+    .back a:hover { text-decoration: underline; }
+    .kicker {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.78rem;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--mute);
+      margin-bottom: 0.3rem;
+    }
+    h1 {
+      font-size: clamp(1.9rem, 5vw, 2.4rem);
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.4rem;
+      margin-bottom: 1rem;
+    }
+    .updated {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.82rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .lede { margin-bottom: 1.6rem; }
+    .lede strong:first-child { font-weight: 700; }
+    .toc {
+      background: var(--well);
+      border: 1px solid var(--line);
+      border-radius: 4px;
+      padding: 1rem 1.4rem;
+      margin-bottom: 2rem;
+      max-width: 26rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.92rem;
+    }
+    .toc .toc-title {
+      font-weight: 700;
+      margin-bottom: 0.5rem;
+      text-align: center;
+    }
+    .toc ol { padding-left: 1.3rem; }
+    .toc ol ol { padding-left: 1.2rem; margin-top: 0.15rem; }
+    .toc li { margin: 0.2rem 0; }
+    .toc a { color: var(--link); text-decoration: none; }
+    .toc a:hover { text-decoration: underline; }
+    h2 {
+      font-size: 1.5rem;
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.3rem;
+      margin: 2rem 0 0.9rem;
+    }
+    h3 {
+      font-size: 1.15rem;
+      font-weight: 700;
+      margin: 1.4rem 0 0.6rem;
+    }
+    p { margin-bottom: 0.9rem; }
+    a { color: var(--link); }
+    a:visited { color: var(--link-visited); }
+    .cite {
+      font-size: 0.75em;
+      vertical-align: super;
+      line-height: 0;
+      text-decoration: none;
+    }
+    .cite a { text-decoration: none; }
+    #see-also ul, #references ol {
+      padding-left: 1.5rem;
+    }
+    #see-also li, #references li { margin-bottom: 0.5rem; }
+    #references { font-size: 0.95rem; }
+    #references .backlink { margin-right: 0.3rem; }
+    .unattributed {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+      font-style: italic;
+    }
+    footer.meta {
+      margin-top: 3rem;
+      padding-top: 1.2rem;
+      border-top: 1px solid var(--line);
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+    }
+    footer.meta a { color: var(--link); }
+    @media print {
+      .back { font-family: "Segoe UI", Helvetica, Arial, sans-serif; display: none; }
+    }
+    .back-to-top {
+      position: fixed;
+      bottom: 1.5rem;
+      right: 1.5rem;
+      width: 2.6rem;
+      height: 2.6rem;
+      border-radius: 50%;
+      background: var(--bg);
+      color: var(--ink);
+      border: 1px solid var(--line);
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      opacity: 0;
+      visibility: hidden;
+      transition: opacity 0.2s ease, visibility 0.2s ease;
+      z-index: 1000;
+    }
+    .back-to-top.visible {
+      opacity: 1;
+      visibility: visible;
+    }
+    @media print {
+      .back-to-top { display: none !important; }
+    }
+  </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Consciousness (Cognitive Science and Philosophy)","description":"Consciousness is the state of subjective qualitative experience, awareness of mental events, and executive availability for cognitive control and verbal report.","url":"https://ngpestelos.com/reference/consciousness/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
+</head>
+<body class="reference">
+  <main id="top">
+    <p class="back"><a href="/reference/">← Reference</a> · <a href="/">Nestor G Pestelos Jr</a> · <a href="#" onclick="window.print(); return false;">Print this page</a></p>
+    <p class="kicker">Philosophy of Mind &amp; Cognitive Neuroscience</p>
+    <h1>Consciousness (Cognitive Science and Philosophy)</h1>
+    <p class="updated">Reference entry &middot; last updated September 5, 2026</p>
+
+    <p class="lede"><strong>Consciousness</strong> is the state of subjective qualitative experience, awareness of internal and external stimuli, and executive availability of information for reasoning, planning, and verbal report.<span class="cite">[<a href="#ref1">1</a>]</span> In philosophy of mind and cognitive neuroscience, inquiry divides between empirical mechanisms explaining how neural circuits discriminate and report sensory inputs, and the foundational question of why physical neurobiological computation is accompanied by subjective experiential feeling.<span class="cite">[<a href="#ref2">2</a>]</span></p>
+
+    <nav class="toc" aria-label="Contents">
+      <p class="toc-title">Contents</p>
+      <ol>
+        <li><a href="#philosophical-taxonomy">Philosophical taxonomy</a>
+          <ol>
+            <li><a href="#access-versus-phenomenal">Access versus phenomenal consciousness</a></li>
+            <li><a href="#the-hard-problem">The hard problem</a></li>
+            <li><a href="#multiple-drafts-model">Multiple drafts model</a></li>
+          </ol>
+        </li>
+        <li><a href="#neuroscientific-theories">Neuroscientific theories</a>
+          <ol>
+            <li><a href="#global-neuronal-workspace">Global Neuronal Workspace Theory</a></li>
+            <li><a href="#integrated-information-theory">Integrated Information Theory</a></li>
+            <li><a href="#recurrent-processing">Recurrent processing theory</a></li>
+          </ol>
+        </li>
+        <li><a href="#relationship-to-attention">Relationship to attention</a></li>
+        <li><a href="#clinical-assessment">Clinical assessment and states of consciousness</a></li>
+        <li><a href="#artificial-intelligence-perspectives">Artificial intelligence perspectives</a></li>
+        <li><a href="#see-also">See also</a></li>
+        <li><a href="#references">References</a></li>
+      </ol>
+    </nav>
+
+    <h2 id="philosophical-taxonomy">Philosophical taxonomy</h2>
+    <p>Contemporary analysis relies on foundational distinctions established in twentieth-century philosophy of mind.</p>
+
+    <h3 id="access-versus-phenomenal">Access versus phenomenal consciousness</h3>
+    <p>Ned Block established a formal taxonomy dividing conscious processing into two distinct dimensions:<span class="cite">[<a href="#ref1">1</a>]</span></p>
+    <ul>
+      <li><strong>Phenomenal Consciousness (P-consciousness):</strong> The experiential, qualitative aspect of mental states, commonly designated as qualia (for example, the subjective redness of a rose or the felt agony of physical pain).</li>
+      <li><strong>Access Consciousness (A-consciousness):</strong> The availability of mental representations for use in deliberate thought, speech generation, working memory manipulation, and motor execution.</li>
+    </ul>
+
+    <h3 id="the-hard-problem">The hard problem</h3>
+    <p>David Chalmers formulated the distinction between the "easy problems" and the "hard problem" of consciousness.<span class="cite">[<a href="#ref2">2</a>]</span> The easy problems concern cognitive functions explainable through standard computational or neurobiological mechanisms, such as stimulus categorization, behavioral integration, verbal reportability, and attentional focus. The hard problem asks why these functional operations are accompanied by first-person inner experience rather than occurring completely in the dark, without qualitative presence.</p>
+
+    <h3 id="multiple-drafts-model">Multiple drafts model</h3>
+    <p>Daniel Dennett rejected the traditional assumption of a centralized locus of experience, a conceptual trap he labeled the "Cartesian Theater."<span class="cite">[<a href="#ref3">3</a>]</span> In the multiple drafts model, parallel streams of perceptual interpretations, narrative fragments, and motor intentions compete continuously across distributed neural coalitions. Consciousness does not consist of a privileged playback screen; rather, a representation becomes conscious when it wins transient narrative salience and triggers observable behavioral probes.</p>
+
+    <h2 id="neuroscientific-theories">Neuroscientific theories</h2>
+    <p>Empirical neuroscience investigates conscious states through measurable architectural frameworks.</p>
+
+    <h3 id="global-neuronal-workspace">Global Neuronal Workspace Theory</h3>
+    <p>Originally formulated as a cognitive blackboard model by Bernard Baars and expanded neurobiologically by Stanislas Dehaene and Jean-Pierre Changeux, Global Neuronal Workspace Theory (GNWT) posits that sensory information remains unconscious when confined to modular, encapsulated cortical processors.<span class="cite">[<a href="#ref4">4</a>]</span> When sensory signals achieve sufficient intensity and attentional reinforcement, they trigger non-linear "ignition" across long-range excitatory frontoparietal networks. This ignition broadcasts the winning representation globally across specialized processors, making it accessible to working memory, motor control, and linguistic reporting systems.<span class="cite">[<a href="#ref5">5</a>]</span></p>
+
+    <h3 id="integrated-information-theory">Integrated Information Theory</h3>
+    <p>Developed by Giulio Tononi, Integrated Information Theory (IIT) begins with phenomenological axioms and derives mathematical conditions for conscious physical substrates.<span class="cite">[<a href="#ref6">6</a>]</span> Under IIT, consciousness corresponds to an intrinsic causal property of a system, quantified as &Phi; (phi). High &Phi; requires that a system generate more cause-effect information as an integrated whole than can be accounted for by the sum of its independent parts. Systems with high functional modularity or strictly feedforward connectivity exhibit minimal &Phi; regardless of computational complexity.</p>
+
+    <h3 id="recurrent-processing">Recurrent processing theory</h3>
+    <p>Victor Lamme proposes that initial feedforward sweeps through the visual cortex reflect unconscious perceptual extraction.<span class="cite">[<a href="#ref7">7</a>]</span> Conscious experience emerges when localized horizontal and feedback connections initiate recurrent reverberating loops within sensory cortex. Recurrent processing can sustain phenomenal perceptual experience even before signals ignite the broader frontoparietal workspace required for verbal reporting.</p>
+
+    <h2 id="relationship-to-attention">Relationship to attention</h2>
+    <p>While historically treated as synonymous or coupled processes, cognitive neuroscience increasingly models attention and consciousness as dissociable mechanisms.<span class="cite">[<a href="#ref8">8</a>]</span> Attention operates as a selective routing filter that allocates finite representational capacity to priority targets. Experiments demonstrate that subjects can selectively attend to subliminal, masked stimuli that never enter conscious awareness, while top-down attentional suppression can occur without conscious perception of the filtered distractor.<span class="cite">[<a href="#ref8">8</a>]</span></p>
+
+    <h2 id="clinical-assessment">Clinical assessment and states of consciousness</h2>
+    <p>Medicine evaluates consciousness across two orthogonal dimensions: wakefulness (arousal, mediated by the ascending reticular activating system in the brainstem) and awareness (content, mediated by frontoparietal and thalamocortical networks). Clinical conditions such as coma, unresponsive wakefulness syndrome, and minimally conscious states present dissociated combinations of arousal and awareness. Diagnostic innovations such as the Perturbational Complexity Index (PCI) deliver transcranial magnetic stimulation pulses to the cortex and measure the algorithmic complexity of evoked electroencephalographic responses to assess covert capacity for integrated experience.<span class="cite">[<a href="#ref9">9</a>]</span></p>
+
+    <h2 id="artificial-intelligence-perspectives">Artificial intelligence perspectives</h2>
+    <p>Modern machine learning systems demonstrate high task competence across complex domains (linguistic reasoning, vision, strategic gameplay) through deep neural network inference. However, technical consensus distinguishes functional simulation of reasoning from conscious subjective awareness.<span class="cite">[<a href="#ref10">10</a>]</span> Stateless evaluation of static weights via matrix transformations processes informational tokens without continuous metabolic persistence, subjective qualia, or integrated causal feedback loops described by biological theories of consciousness.</p>
+
+    <h2 id="see-also">See also</h2>
+    <ul>
+      <li><a href="/reference/attention/">Reference: Attention</a></li>
+      <li><a href="/reference/epistemology/">Reference: Epistemology</a></li>
+      <li><a href="/reference/perception/">Reference: Perception</a></li>
+      <li><a href="/reference/working-memory/">Reference: Working Memory</a></li>
+      <li><a href="/reference/agents/">Reference: Agents</a></li>
+    </ul>
+
+    <h2 id="references">References</h2>
+    <ol>
+      <li id="ref1"><span class="backlink">^</span> Ned Block, "On a confusion about a function of consciousness," <em>Behavioral and Brain Sciences</em>, vol. 18, no. 2, 1995, pp. 227–247.</li>
+      <li id="ref2"><span class="backlink">^</span> David J. Chalmers, "Facing up to the problem of consciousness," <em>Journal of Consciousness Studies</em>, vol. 2, no. 3, 1995, pp. 200–219.</li>
+      <li id="ref3"><span class="backlink">^</span> Daniel C. Dennett, <em>Consciousness Explained</em>, Little, Brown and Company, 1991, pp. 101–138.</li>
+      <li id="ref4"><span class="backlink">^</span> Bernard J. Baars, <em>A Cognitive Theory of Consciousness</em>, Cambridge University Press, 1988.</li>
+      <li id="ref5"><span class="backlink">^</span> Stanislas Dehaene and Jean-Pierre Changeux, "Experimental and theoretical approaches to conscious processing," <em>Neuron</em>, vol. 70, no. 2, 2011, pp. 200–227.</li>
+      <li id="ref6"><span class="backlink">^</span> Giulio Tononi, "An information integration theory of consciousness," <em>BMC Neuroscience</em>, vol. 5, no. 42, 2004.</li>
+      <li id="ref7"><span class="backlink">^</span> Victor A. F. Lamme, "Why visual attention and awareness are different," <em>Trends in Cognitive Sciences</em>, vol. 7, no. 1, 2003, pp. 12–18.</li>
+      <li id="ref8"><span class="backlink">^</span> Christof Koch and Naotsugu Tsuchiya, "Attention and consciousness: two distinct brain processes," <em>Trends in Cognitive Sciences</em>, vol. 11, no. 1, 2007, pp. 16–22.</li>
+      <li id="ref9"><span class="backlink">^</span> Adenauer G. Casali et al., "A theoretically based index of consciousness independent of sensory processing and behavior," <em>Science Translational Medicine</em>, vol. 5, no. 198, 2013, p. 198ra105.</li>
+      <li id="ref10"><span class="backlink">^</span> John R. Searle, "Minds, brains, and programs," <em>Behavioral and Brain Sciences</em>, vol. 3, no. 3, 1980, pp. 417–424.</li>
+    </ol>
+
+    <footer class="meta">
+      <p><a href="#top">Back to top</a></p>
+    </footer>
+  </main>
+  <button id="backToTop" class="back-to-top" aria-label="Back to top" title="Back to top">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M18 15l-6-6-6 6"/>
+    </svg>
+  </button>
+
+  <script>
+    const btt = document.getElementById('backToTop');
+    window.addEventListener('scroll', () => {
+      if (window.scrollY > 250) {
+        btt.classList.add('visible');
+      } else {
+        btt.classList.remove('visible');
+      }
+    }, { passive: true });
+    btt.addEventListener('click', () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  </script>
+</body>
+</html>

--- a/reference/index.html
+++ b/reference/index.html
@@ -188,7 +188,7 @@
       <a href="#T">T</a>
       <a href="#U">U</a>
       <a href="#V">V</a>
-      <span class="empty">W</span>
+      <a href="#W">W</a>
       <a href="#X">X</a>
       <span class="empty">Y</span>
       <a href="#Z">Z</a>
@@ -227,6 +227,7 @@
         <h2 class="letter-heading">C</h2>
         <ul>
         <li><a href="/reference/chiquito/">Chiquito (Actor)</a></li>
+        <li><a href="/reference/consciousness/">Consciousness</a></li>
         <li><a href="/reference/context-engineering/">Context Engineering</a></li>
         <li><a href="/reference/context-window/">Context Windows</a></li>
         <li><a href="/reference/continuous-batching/">Continuous Batching</a></li>
@@ -341,6 +342,7 @@
       <div class="letter-group" id="P">
         <h2 class="letter-heading">P</h2>
         <ul>
+        <li><a href="/reference/perception/">Perception</a></li>
         <li><a href="/reference/personal-knowledge-management/">Personal Knowledge Management</a></li>
         <li><a href="/reference/plan-approve-execute/">Plan-Approve-Execute</a></li>
         <li><a href="/reference/pre-training/">Pre-Training</a></li>
@@ -402,6 +404,13 @@
         <ul>
         <li><a href="/reference/vannevar-bush/">Vannevar Bush</a></li>
         <li><a href="/reference/vector-search/">Vector Search</a></li>
+        </ul>
+      </div>
+
+      <div class="letter-group" id="W">
+        <h2 class="letter-heading">W</h2>
+        <ul>
+        <li><a href="/reference/working-memory/">Working Memory</a></li>
         </ul>
       </div>
 

--- a/reference/perception/index.html
+++ b/reference/perception/index.html
@@ -1,0 +1,273 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Perception (Cognitive Science) &middot; Reference &middot; Nestor G Pestelos Jr</title>
+  <meta name="description" content="Perception is the neurocognitive process of organizing, identifying, and interpreting sensory information to construct an internal representation of the environment.">
+  <meta property="og:title" content="Perception (Cognitive Science) · Reference">
+  <meta property="og:description" content="An encyclopedia reference entry on sensory perception, bottom-up feature hierarchies, Bayesian predictive processing, multisensory binding, and attentional modulation.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://ngpestelos.com/reference/perception/">
+  <link rel="canonical" href="https://ngpestelos.com/reference/perception/">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=20260813f">
+  <link rel="icon" href="/favicon-192.png?v=20260813f" type="image/png" sizes="192x192">
+  <link rel="icon" href="/favicon-32.png?v=20260813f" type="image/png" sizes="32x32">
+  <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
+  <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="stylesheet" href="/style.css?v=20260903e">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TLBY8P4GG9');
+  </script>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
+    body {
+      line-height: 1.6;
+    }
+    main {
+      max-width: 46rem;
+      margin: 0 auto;
+      padding: 1.4rem 1.4rem 4rem;
+    }
+    .back {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .back a { color: var(--link); text-decoration: none; }
+    .back a:hover { text-decoration: underline; }
+    .kicker {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.78rem;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--mute);
+      margin-bottom: 0.3rem;
+    }
+    h1 {
+      font-size: clamp(1.9rem, 5vw, 2.4rem);
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.4rem;
+      margin-bottom: 1rem;
+    }
+    .updated {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.82rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .lede { margin-bottom: 1.6rem; }
+    .lede strong:first-child { font-weight: 700; }
+    .toc {
+      background: var(--well);
+      border: 1px solid var(--line);
+      border-radius: 4px;
+      padding: 1rem 1.4rem;
+      margin-bottom: 2rem;
+      max-width: 26rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.92rem;
+    }
+    .toc .toc-title {
+      font-weight: 700;
+      margin-bottom: 0.5rem;
+      text-align: center;
+    }
+    .toc ol { padding-left: 1.3rem; }
+    .toc ol ol { padding-left: 1.2rem; margin-top: 0.15rem; }
+    .toc li { margin: 0.2rem 0; }
+    .toc a { color: var(--link); text-decoration: none; }
+    .toc a:hover { text-decoration: underline; }
+    h2 {
+      font-size: 1.5rem;
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.3rem;
+      margin: 2rem 0 0.9rem;
+    }
+    h3 {
+      font-size: 1.15rem;
+      font-weight: 700;
+      margin: 1.4rem 0 0.6rem;
+    }
+    p { margin-bottom: 0.9rem; }
+    a { color: var(--link); }
+    a:visited { color: var(--link-visited); }
+    .cite {
+      font-size: 0.75em;
+      vertical-align: super;
+      line-height: 0;
+      text-decoration: none;
+    }
+    .cite a { text-decoration: none; }
+    #see-also ul, #references ol {
+      padding-left: 1.5rem;
+    }
+    #see-also li, #references li { margin-bottom: 0.5rem; }
+    #references { font-size: 0.95rem; }
+    #references .backlink { margin-right: 0.3rem; }
+    .unattributed {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+      font-style: italic;
+    }
+    footer.meta {
+      margin-top: 3rem;
+      padding-top: 1.2rem;
+      border-top: 1px solid var(--line);
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+    }
+    footer.meta a { color: var(--link); }
+    @media print {
+      .back { font-family: "Segoe UI", Helvetica, Arial, sans-serif; display: none; }
+    }
+    .back-to-top {
+      position: fixed;
+      bottom: 1.5rem;
+      right: 1.5rem;
+      width: 2.6rem;
+      height: 2.6rem;
+      border-radius: 50%;
+      background: var(--bg);
+      color: var(--ink);
+      border: 1px solid var(--line);
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      opacity: 0;
+      visibility: hidden;
+      transition: opacity 0.2s ease, visibility 0.2s ease;
+      z-index: 1000;
+    }
+    .back-to-top.visible {
+      opacity: 1;
+      visibility: visible;
+    }
+    @media print {
+      .back-to-top { display: none !important; }
+    }
+  </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Perception (Cognitive Science)","description":"Perception is the neurocognitive process of organizing, identifying, and interpreting sensory information to construct an internal mental representation of the environment.","url":"https://ngpestelos.com/reference/perception/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
+</head>
+<body class="reference">
+  <main id="top">
+    <p class="back"><a href="/reference/">← Reference</a> · <a href="/">Nestor G Pestelos Jr</a> · <a href="#" onclick="window.print(); return false;">Print this page</a></p>
+    <p class="kicker">Cognitive Neuroscience &amp; Psychology</p>
+    <h1>Perception (Cognitive Science)</h1>
+    <p class="updated">Reference entry &middot; last updated September 5, 2026</p>
+
+    <p class="lede"><strong>Perception</strong> is the neurocognitive process of organizing, identifying, and interpreting sensory signals to construct an internal mental representation of the environment.<span class="cite">[<a href="#ref1">1</a>]</span> Unlike passive sensation, which consists of biological transduction converting physical energy into neural electrical impulses, perception involves active computational inference that transforms ambiguous, noisy sensory data into coherent objects, spatial relationships, and event categories.<span class="cite">[<a href="#ref2">2</a>]</span></p>
+
+    <nav class="toc" aria-label="Contents">
+      <p class="toc-title">Contents</p>
+      <ol>
+        <li><a href="#sensation-versus-perception">Sensation versus perception</a></li>
+        <li><a href="#processing-frameworks">Processing frameworks</a>
+          <ol>
+            <li><a href="#hierarchical-feature-extraction">Hierarchical feature extraction</a></li>
+            <li><a href="#predictive-processing-and-bayesian-inference">Predictive processing and Bayesian inference</a></li>
+          </ol>
+        </li>
+        <li><a href="#multisensory-integration">Multisensory integration and binding</a></li>
+        <li><a href="#attentional-modulation">Attentional modulation</a>
+          <ol>
+            <li><a href="#feature-binding-mechanisms">Feature binding mechanisms</a></li>
+            <li><a href="#inattentional-phenomena">Inattentional and change blindness</a></li>
+          </ol>
+        </li>
+        <li><a href="#artificial-perception">Artificial perception in computational systems</a></li>
+        <li><a href="#see-also">See also</a></li>
+        <li><a href="#references">References</a></li>
+      </ol>
+    </nav>
+
+    <h2 id="sensation-versus-perception">Sensation versus perception</h2>
+    <p>Cognitive science distinguishes between peripheral sensory registration and central perceptual synthesis. Sensation occurs at peripheral receptor organs, such as photoreceptors in the retina, hair cells within the cochlea, and mechanoreceptors in the dermis. These structures transduce electromagnetic, acoustic, and kinetic stimuli into action potentials transmitted along sensory nerves.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+    <p>Perception begins when central neural structures organize these fragmented signals into unified environmental models. Because raw sensory input is inherently underdetermined (a two-dimensional retinal projection can correspond to infinitely many three-dimensional physical structures), the nervous system must apply prior constraints and probabilistic assumptions to resolve sensory ambiguity.<span class="cite">[<a href="#ref3">3</a>]</span></p>
+
+    <h2 id="processing-frameworks">Processing frameworks</h2>
+    <p>Modern cognitive neuroscience explains perception through two complementary computational streams.</p>
+
+    <h3 id="hierarchical-feature-extraction">Hierarchical feature extraction</h3>
+    <p>In bottom-up architectures, sensory cortex extracts increasingly abstract representations across successive anatomical stages. In the primate visual pathway, simple cells in primary visual cortex (V1) isolate local contrast borders and orientations. Intermediate cortical areas (V4, MT) integrate local orientations into contours, surfaces, and motion vectors. Higher-tier structures, such as the inferotemporal cortex, synthesize these features into viewpoint-invariant representations of complex entities, including faces and tools.<span class="cite">[<a href="#ref4">4</a>]</span></p>
+
+    <h3 id="predictive-processing-and-bayesian-inference">Predictive processing and Bayesian inference</h3>
+    <p>Top-down accounts, tracing historically to Hermann von Helmholtz's concept of unconscious inference, model perception as hierarchical Bayesian inference.<span class="cite">[<a href="#ref3">3</a>]</span> Under predictive coding frameworks, higher cortical regions generate generative prior predictions regarding incoming sensory patterns and transmit them down feedback connections. Lower sensory areas compare these predictions against incoming afferent signals, computing prediction error residuals. Only unexplained residual variance ascends the cortical hierarchy to update internal generative models, optimizing energy expenditure and latency in dynamic environments.<span class="cite">[<a href="#ref5">5</a>]</span></p>
+
+    <h2 id="multisensory-integration">Multisensory integration and binding</h2>
+    <p>Environmental events routinely stimulate multiple sensory organs concurrently. The brain resolves temporal and spatial alignment across visual, auditory, and somatosensory channels within structures such as the superior colliculus and intraparietal sulcus. In the McGurk effect, incongruent visual lip movements modify the auditory perception of spoken phonemes, demonstrating that conscious speech perception relies on obligatory cross-modal synthesis rather than isolated acoustic parsing.<span class="cite">[<a href="#ref6">6</a>]</span></p>
+
+    <h2 id="attentional-modulation">Attentional modulation</h2>
+    <p>Sensory channels receive far more raw information than central nervous systems can process. Attention acts as a capacity-limiting filter that routes priority stimuli into higher processing stages.</p>
+
+    <h3 id="feature-binding-mechanisms">Feature binding mechanisms</h3>
+    <p>According to feature integration theory, low-level features (such as color, orientation, and motion) are parsed preattentively and in parallel across distinct cortical maps. Concentrated spatial attention is necessary to bind these distributed features to shared object coordinates, preventing illusory conjunctions where color from one item attaches to the shape of an adjacent item.<span class="cite">[<a href="#ref7">7</a>]</span></p>
+
+    <h3 id="inattentional-phenomena">Inattentional and change blindness</h3>
+    <p>When selective attention is heavily engaged by a primary task, observers routinely fail to perceive salient unexpected events within their visual field. In inattentional blindness experiments, individuals tracking dynamic objects fail to notice prominent secondary figures crossing the display.<span class="cite">[<a href="#ref8">8</a>]</span> Similarly, change blindness demonstrations show that substantial alterations to visual scenes remain undetected when masked by brief visual saccades or visual occlusions, proving that perceived visual richness does not imply exhaustive internal representation.</p>
+
+    <h2 id="artificial-perception">Artificial perception in computational systems</h2>
+    <p>In artificial intelligence, perception refers to the automated extraction of semantic representations from sensor data. Computer vision and audio processing systems utilize deep neural networks to convert multidimensional arrays (pixel grids, spectrograms) into dense continuous vector embeddings. Multimodal foundation models project image, audio, and text representations into shared latent spaces, enabling cross-modal reasoning that mirrors biological sensory integration without biological metabolic constraints.<span class="cite">[<a href="#ref9">9</a>]</span></p>
+
+    <h2 id="see-also">See also</h2>
+    <ul>
+      <li><a href="/reference/attention/">Reference: Attention</a></li>
+      <li><a href="/reference/working-memory/">Reference: Working Memory</a></li>
+      <li><a href="/reference/consciousness/">Reference: Consciousness</a></li>
+      <li><a href="/reference/embeddings/">Reference: Embeddings</a></li>
+      <li><a href="/reference/transformer-architecture/">Reference: Transformer Architecture</a></li>
+    </ul>
+
+    <h2 id="references">References</h2>
+    <ol>
+      <li id="ref1"><span class="backlink">^</span> E. Bruce Goldstein and James R. Brockmole, <em>Sensation and Perception</em>, 10th edition, Cengage Learning, 2017, pp. 2–8.</li>
+      <li id="ref2"><span class="backlink">^</span> David Marr, <em>Vision: A Computational Investigation into the Human Representation and Processing of Visual Information</em>, W. H. Freeman and Company, 1982, pp. 19–38.</li>
+      <li id="ref3"><span class="backlink">^</span> Hermann von Helmholtz, <em>Handbuch der physiologischen Optik</em>, Leopold Voss, 1867.</li>
+      <li id="ref4"><span class="backlink">^</span> David H. Hubel and Torsten N. Wiesel, "Receptive fields, binocular interaction and functional architecture in the cat's visual cortex," <em>The Journal of Physiology</em>, vol. 160, no. 1, 1962, pp. 106–154.</li>
+      <li id="ref5"><span class="backlink">^</span> Karl Friston, "A theory of cortical responses," <em>Philosophical Transactions of the Royal Society B: Biological Sciences</em>, vol. 360, no. 1456, 2005, pp. 815–836.</li>
+      <li id="ref6"><span class="backlink">^</span> Harry McGurk and John MacDonald, "Hearing lips and seeing voices," <em>Nature</em>, vol. 264, no. 5588, 1976, pp. 746–748.</li>
+      <li id="ref7"><span class="backlink">^</span> Anne M. Treisman and Garry Gelade, "A feature-integration theory of attention," <em>Cognitive Psychology</em>, vol. 12, no. 1, 1980, pp. 97–136.</li>
+      <li id="ref8"><span class="backlink">^</span> Daniel J. Simons and Christopher F. Chabris, "Gorillas in our midst: sustained inattentional blindness for dynamic events," <em>Perception</em>, vol. 28, no. 9, 1999, pp. 1059–1074.</li>
+      <li id="ref9"><span class="backlink">^</span> Yann LeCun, Yoshua Bengio, and Geoffrey Hinton, "Deep learning," <em>Nature</em>, vol. 521, no. 7553, 2015, pp. 436–444.</li>
+    </ol>
+
+    <footer class="meta">
+      <p><a href="#top">Back to top</a></p>
+    </footer>
+  </main>
+  <button id="backToTop" class="back-to-top" aria-label="Back to top" title="Back to top">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M18 15l-6-6-6 6"/>
+    </svg>
+  </button>
+
+  <script>
+    const btt = document.getElementById('backToTop');
+    window.addEventListener('scroll', () => {
+      if (window.scrollY > 250) {
+        btt.classList.add('visible');
+      } else {
+        btt.classList.remove('visible');
+      }
+    }, { passive: true });
+    btt.addEventListener('click', () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  </script>
+</body>
+</html>

--- a/reference/working-memory/index.html
+++ b/reference/working-memory/index.html
@@ -1,0 +1,283 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Working Memory &middot; Reference &middot; Nestor G Pestelos Jr</title>
+  <meta name="description" content="Working memory is a limited-capacity cognitive system responsible for temporarily holding and manipulating information during complex reasoning and learning tasks.">
+  <meta property="og:title" content="Working Memory · Reference">
+  <meta property="og:description" content="An encyclopedia reference entry on working memory architecture, Baddeley multicomponent model, Cowan capacity limits, prefrontal substrates, and cognitive load theory.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://ngpestelos.com/reference/working-memory/">
+  <link rel="canonical" href="https://ngpestelos.com/reference/working-memory/">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=20260813f">
+  <link rel="icon" href="/favicon-192.png?v=20260813f" type="image/png" sizes="192x192">
+  <link rel="icon" href="/favicon-32.png?v=20260813f" type="image/png" sizes="32x32">
+  <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
+  <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="stylesheet" href="/style.css?v=20260903e">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TLBY8P4GG9');
+  </script>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
+    body {
+      line-height: 1.6;
+    }
+    main {
+      max-width: 46rem;
+      margin: 0 auto;
+      padding: 1.4rem 1.4rem 4rem;
+    }
+    .back {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .back a { color: var(--link); text-decoration: none; }
+    .back a:hover { text-decoration: underline; }
+    .kicker {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.78rem;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--mute);
+      margin-bottom: 0.3rem;
+    }
+    h1 {
+      font-size: clamp(1.9rem, 5vw, 2.4rem);
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.4rem;
+      margin-bottom: 1rem;
+    }
+    .updated {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.82rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .lede { margin-bottom: 1.6rem; }
+    .lede strong:first-child { font-weight: 700; }
+    .toc {
+      background: var(--well);
+      border: 1px solid var(--line);
+      border-radius: 4px;
+      padding: 1rem 1.4rem;
+      margin-bottom: 2rem;
+      max-width: 26rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.92rem;
+    }
+    .toc .toc-title {
+      font-weight: 700;
+      margin-bottom: 0.5rem;
+      text-align: center;
+    }
+    .toc ol { padding-left: 1.3rem; }
+    .toc ol ol { padding-left: 1.2rem; margin-top: 0.15rem; }
+    .toc li { margin: 0.2rem 0; }
+    .toc a { color: var(--link); text-decoration: none; }
+    .toc a:hover { text-decoration: underline; }
+    h2 {
+      font-size: 1.5rem;
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.3rem;
+      margin: 2rem 0 0.9rem;
+    }
+    h3 {
+      font-size: 1.15rem;
+      font-weight: 700;
+      margin: 1.4rem 0 0.6rem;
+    }
+    p { margin-bottom: 0.9rem; }
+    a { color: var(--link); }
+    a:visited { color: var(--link-visited); }
+    .cite {
+      font-size: 0.75em;
+      vertical-align: super;
+      line-height: 0;
+      text-decoration: none;
+    }
+    .cite a { text-decoration: none; }
+    #see-also ul, #references ol {
+      padding-left: 1.5rem;
+    }
+    #see-also li, #references li { margin-bottom: 0.5rem; }
+    #references { font-size: 0.95rem; }
+    #references .backlink { margin-right: 0.3rem; }
+    .unattributed {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+      font-style: italic;
+    }
+    footer.meta {
+      margin-top: 3rem;
+      padding-top: 1.2rem;
+      border-top: 1px solid var(--line);
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+    }
+    footer.meta a { color: var(--link); }
+    @media print {
+      .back { font-family: "Segoe UI", Helvetica, Arial, sans-serif; display: none; }
+    }
+    .back-to-top {
+      position: fixed;
+      bottom: 1.5rem;
+      right: 1.5rem;
+      width: 2.6rem;
+      height: 2.6rem;
+      border-radius: 50%;
+      background: var(--bg);
+      color: var(--ink);
+      border: 1px solid var(--line);
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      opacity: 0;
+      visibility: hidden;
+      transition: opacity 0.2s ease, visibility 0.2s ease;
+      z-index: 1000;
+    }
+    .back-to-top.visible {
+      opacity: 1;
+      visibility: visible;
+    }
+    @media print {
+      .back-to-top { display: none !important; }
+    }
+  </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Working Memory","description":"Working memory is a limited-capacity cognitive system responsible for temporarily holding and manipulating information during complex reasoning and learning tasks.","url":"https://ngpestelos.com/reference/working-memory/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
+</head>
+<body class="reference">
+  <main id="top">
+    <p class="back"><a href="/reference/">← Reference</a> · <a href="/">Nestor G Pestelos Jr</a> · <a href="#" onclick="window.print(); return false;">Print this page</a></p>
+    <p class="kicker">Cognitive Psychology &amp; Neuroscience</p>
+    <h1>Working Memory</h1>
+    <p class="updated">Reference entry &middot; last updated September 5, 2026</p>
+
+    <p class="lede"><strong>Working memory</strong> is a cognitive system with limited capacity responsible for temporarily holding and actively manipulating information necessary for complex cognitive operations, including reasoning, mathematical deduction, and language comprehension.<span class="cite">[<a href="#ref1">1</a>]</span> Unlike simple short-term memory, which refers primarily to passive maintenance of sensory traces across brief delays, working memory incorporates executive coordination, selective interference suppression, and dynamic information transformation.<span class="cite">[<a href="#ref2">2</a>]</span></p>
+
+    <nav class="toc" aria-label="Contents">
+      <p class="toc-title">Contents</p>
+      <ol>
+        <li><a href="#theoretical-architectures">Theoretical architectures</a>
+          <ol>
+            <li><a href="#baddeley-multicomponent-model">Baddeley and Hitch multicomponent model</a></li>
+            <li><a href="#cowan-embedded-processes">Cowan embedded-processes model</a></li>
+          </ol>
+        </li>
+        <li><a href="#capacity-constraints">Capacity constraints and chunking</a>
+          <ol>
+            <li><a href="#the-four-item-limit">The four-item capacity baseline</a></li>
+            <li><a href="#chunking-mechanisms">Chunking and schema automation</a></li>
+          </ol>
+        </li>
+        <li><a href="#neurobiological-substrate">Neurobiological substrate</a></li>
+        <li><a href="#cognitive-load-theory">Cognitive load theory and instructional limits</a></li>
+        <li><a href="#computational-analogies">Computational analogies and differences</a></li>
+        <li><a href="#see-also">See also</a></li>
+        <li><a href="#references">References</a></li>
+      </ol>
+    </nav>
+
+    <h2 id="theoretical-architectures">Theoretical architectures</h2>
+    <p>Cognitive psychology models working memory through two prominent structural paradigms.</p>
+
+    <h3 id="baddeley-multicomponent-model">Baddeley and Hitch multicomponent model</h3>
+    <p>Introduced by Alan Baddeley and Graham Hitch in 1974, this modular framework divides working memory into specialized domain subsystems governed by a supervisory control unit:<span class="cite">[<a href="#ref1">1</a>]</span></p>
+    <ul>
+      <li><strong>Central Executive:</strong> An attentional control system responsible for binding information, focusing selective attention, switching tasks, and suppressing irrelevant intrusions.</li>
+      <li><strong>Phonological Loop:</strong> Maintains verbal and auditory information through an inner ear store subject to temporal decay, refreshed via sub-vocal articulatory rehearsal.</li>
+      <li><strong>Visuospatial Sketchpad:</strong> Maintains spatial layouts, visual patterns, and kinesthetic trajectories.</li>
+      <li><strong>Episodic Buffer:</strong> Added in 2000, this limited-capacity component integrates multidimensional representations from the subsidiary stores and long-term memory into coherent temporal episodes.<span class="cite">[<a href="#ref2">2</a>]</span></li>
+    </ul>
+
+    <h3 id="cowan-embedded-processes">Cowan embedded-processes model</h3>
+    <p>Nelson Cowan proposed an alternative embedded-processes framework. Rather than positing physically distinct storage buffers, Cowan models working memory as a hierarchical state: long-term memory contains inactive knowledge traces, a subset of which enter an activated state through contextual priming. Working memory corresponds to the fraction of activated representations currently enclosed within the conscious focus of attention.<span class="cite">[<a href="#ref3">3</a>]</span></p>
+
+    <h2 id="capacity-constraints">Capacity constraints and chunking</h2>
+    <p>Working memory is severely constrained in both duration and volume. Information degrades within seconds unless sustained by continuous attentional refreshing or active rehearsal.</p>
+
+    <h3 id="the-four-item-limit">The four-item capacity baseline</h3>
+    <p>George Miller famously identified seven items (plus or minus two) as the limit of unidimensional human immediate recall.<span class="cite">[<a href="#ref4">4</a>]</span> Subsequent empirical research by Nelson Cowan established that when verbal rehearsal strategies, mnemonics, and grouping mechanisms are strictly prevented, the pure central storage capacity of human working memory is approximately four chunks of information.<span class="cite">[<a href="#ref3">3</a>]</span></p>
+
+    <h3 id="chunking-mechanisms">Chunking and schema automation</h3>
+    <p>To overcome biological item constraints, human cognition groups basic informational elements into larger, functionally organized units called chunks. In classic experiments by Chase and Simon, chess grandmasters recalled complex mid-game board configurations with high accuracy while performing at novice levels on randomized piece distributions. Expertise allows long-term memory schemas to package multi-piece constellations into individual chunks, consuming single working memory slots.<span class="cite">[<a href="#ref5">5</a>]</span></p>
+
+    <h2 id="neurobiological-substrate">Neurobiological substrate</h2>
+    <p>Working memory maintenance relies on sustained neuronal firing across frontoparietal networks. Early electrophysiological work by Patricia Goldman-Rakic demonstrated that pyramidal neurons within the dorsolateral prefrontal cortex (DLPFC) maintain elevated spiking during the delay period between stimulus presentation and behavioral execution, holding sensory targets in an active representational state.<span class="cite">[<a href="#ref6">6</a>]</span> Prefrontal regions interact bidirectionally with posterior sensory cortices, exerting top-down inhibitory and excitatory bias to stabilize task-relevant signals against distractors.</p>
+
+    <h2 id="cognitive-load-theory">Cognitive load theory and instructional limits</h2>
+    <p>Formulated by John Sweller, cognitive load theory examines how working memory limitations govern human learning and problem-solving.<span class="cite">[<a href="#ref7">7</a>]</span> The theory partitions cognitive burden into three categories:</p>
+    <ul>
+      <li><strong>Intrinsic Load:</strong> The inherent relational complexity of the information, defined by the number of interacting elements that must be processed concurrently.</li>
+      <li><strong>Extraneous Load:</strong> Unnecessary mental effort imposed by poor presentation formats, fragmented materials, or extraneous instructional steps.</li>
+      <li><strong>Germane Load:</strong> Mental processing dedicated to constructing and automating permanent schemas in long-term memory.</li>
+    </ul>
+    <p>When combined intrinsic and extraneous load exceeds working memory capacity, comprehension and retention fail completely.</p>
+
+    <h2 id="computational-analogies">Computational analogies and differences</h2>
+    <p>Computer architectures parallel working memory through high-speed CPU registers and L1/L2 SRAM caches, which hold immediate data for arithmetic logic units while relying on slower, higher-capacity DRAM and solid-state drives for persistence. In artificial intelligence, Transformer architectures maintain a context window of tokens processed in parallel via self-attention.<span class="cite">[<a href="#ref8">8</a>]</span> Unlike biological working memory, which requires continuous metabolic energy and active neural reverberation to avoid instant decay, computational context buffers are stateless matrix allocations evaluated deterministically on silicon hardware.</p>
+
+    <h2 id="see-also">See also</h2>
+    <ul>
+      <li><a href="/reference/attention/">Reference: Attention</a></li>
+      <li><a href="/reference/consciousness/">Reference: Consciousness</a></li>
+      <li><a href="/reference/context-window/">Reference: Context Windows</a></li>
+      <li><a href="/reference/perception/">Reference: Perception</a></li>
+      <li><a href="/reference/theory-of-constraints/">Reference: Theory of Constraints</a></li>
+    </ul>
+
+    <h2 id="references">References</h2>
+    <ol>
+      <li id="ref1"><span class="backlink">^</span> Alan D. Baddeley and Graham Hitch, "Working Memory," <em>Psychology of Learning and Motivation</em>, vol. 8, 1974, pp. 47–89.</li>
+      <li id="ref2"><span class="backlink">^</span> Alan Baddeley, "The episodic buffer: a new component of working memory?" <em>Trends in Cognitive Sciences</em>, vol. 4, no. 11, 2000, pp. 417–423.</li>
+      <li id="ref3"><span class="backlink">^</span> Nelson Cowan, "The magical number 4 in short-term memory: A reconsideration of mental storage capacity," <em>Behavioral and Brain Sciences</em>, vol. 24, no. 1, 2001, pp. 87–114.</li>
+      <li id="ref4"><span class="backlink">^</span> George A. Miller, "The magical number seven, plus or minus two: Some limits on our capacity for processing information," <em>Psychological Review</em>, vol. 63, no. 2, 1956, pp. 81–97.</li>
+      <li id="ref5"><span class="backlink">^</span> William G. Chase and Herbert A. Simon, "Perception in chess," <em>Cognitive Psychology</em>, vol. 4, no. 1, 1973, pp. 55–81.</li>
+      <li id="ref6"><span class="backlink">^</span> Patricia S. Goldman-Rakic, "Cellular basis of working memory," <em>Neuron</em>, vol. 14, no. 3, 1995, pp. 477–485.</li>
+      <li id="ref7"><span class="backlink">^</span> John Sweller, "Cognitive load during problem solving: Effects on learning," <em>Cognitive Science</em>, vol. 12, no. 2, 1988, pp. 257–285.</li>
+      <li id="ref8"><span class="backlink">^</span> Ashish Vaswani et al., "Attention Is All You Need," <em>Advances in Neural Information Processing Systems</em>, vol. 30, 2017.</li>
+    </ol>
+
+    <footer class="meta">
+      <p><a href="#top">Back to top</a></p>
+    </footer>
+  </main>
+  <button id="backToTop" class="back-to-top" aria-label="Back to top" title="Back to top">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M18 15l-6-6-6 6"/>
+    </svg>
+  </button>
+
+  <script>
+    const btt = document.getElementById('backToTop');
+    window.addEventListener('scroll', () => {
+      if (window.scrollY > 250) {
+        btt.classList.add('visible');
+      } else {
+        btt.classList.remove('visible');
+      }
+    }, { passive: true });
+    btt.addEventListener('click', () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  </script>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -311,6 +311,11 @@
     <priority>0.5</priority>
   </url>
   <url>
+    <loc>https://ngpestelos.com/reference/working-memory/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
     <loc>https://ngpestelos.com/reference/prompt/</loc>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
@@ -382,6 +387,11 @@
   </url>
   <url>
     <loc>https://ngpestelos.com/reference/firewall-llm/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://ngpestelos.com/reference/perception/</loc>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
@@ -987,6 +997,11 @@
   </url>
   <url>
     <loc>https://ngpestelos.com/reference/marginal-price/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://ngpestelos.com/reference/consciousness/</loc>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>


### PR DESCRIPTION
## Summary
- Adds three new public encyclopedia reference pages for the cognitive triad governed by attention:
  - `/reference/perception/` (Perception in Cognitive Science)
  - `/reference/working-memory/` (Working Memory)
  - `/reference/consciousness/` (Consciousness in Cognitive Science and Philosophy)
- Links all three terms directly within the lede definition and `See also` sections of `/reference/attention/index.html`.
- Updates `reference/index.html` (including activating the `W` letter group in the alphabet navigation and listing) and `sitemap.xml`.
- All pages include Schema.org `DefinedTerm` JSON-LD, middot title formats, table of contents navigation, and back-to-top component.
- All 32 discoverability and theme tests passing.