### PR TITLE
reference: add subvocalization page

### DIFF
--- a/reference/index.html
+++ b/reference/index.html
@@ -373,6 +373,7 @@
         <li><a href="/reference/sonke-ahrens/">Sönke Ahrens</a></li>
         <li><a href="/reference/spaced-repetition/">Spaced Repetition</a></li>
         <li><a href="/reference/steelmanning/">Steelmanning</a></li>
+        <li><a href="/reference/subvocalization/">Subvocalization in Reading</a></li>
         <li><a href="/reference/sycophancy/">Sycophancy</a></li>
         </ul>
       </div>

--- a/reference/subvocalization/index.html
+++ b/reference/subvocalization/index.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Subvocalization in Reading · Reference · Nestor G Pestelos Jr</title>
+  <meta name="description" content="A sourced reference on subvocalization in reading, phonological coding, inner speech, and the limited evidence specific to autism.">
+  <meta property="og:title" content="Subvocalization in Reading · Reference">
+  <meta property="og:description" content="A sourced reference on subvocalization in reading, phonological coding, inner speech, and the limited evidence specific to autism.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://ngpestelos.com/reference/subvocalization/">
+  <link rel="canonical" href="https://ngpestelos.com/reference/subvocalization/">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=20260813f">
+  <link rel="icon" href="/favicon-192.png?v=20260813f" type="image/png" sizes="192x192">
+  <link rel="icon" href="/favicon-32.png?v=20260813f" type="image/png" sizes="32x32">
+  <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
+  <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="stylesheet" href="/style.css?v=20260903e">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TLBY8P4GG9');
+  </script>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; scroll-behavior: smooth; }
+    body { line-height: 1.6; }
+    main { max-width: 48rem; margin: 0 auto; padding: 1.4rem 1.4rem 4rem; }
+    .back, .kicker, .updated, .toc, table, .references, footer { font-family: "Segoe UI", Helvetica, Arial, sans-serif; }
+    .back { font-size: 0.85rem; color: var(--mute); margin-bottom: 1.4rem; }
+    .back a, .toc a, .cite a { color: var(--link); text-decoration: none; }
+    .back a:hover, .toc a:hover, .cite a:hover { text-decoration: underline; }
+    .kicker { font-size: 0.78rem; letter-spacing: 0.14em; text-transform: uppercase; color: var(--mute); margin-bottom: 0.3rem; }
+    h1, h2 { font-weight: 400; border-bottom: 1px solid var(--line); }
+    h1 { font-size: clamp(1.8rem, 4.5vw, 2.3rem); padding-bottom: 0.4rem; margin-bottom: 1rem; }
+    h2 { font-size: 1.35rem; padding-bottom: 0.3rem; margin: 2.2rem 0 0.8rem; }
+    h3 { font-size: 1.1rem; margin: 1.4rem 0 0.4rem; }
+    .updated { font-size: 0.82rem; color: var(--mute); margin-bottom: 1.4rem; }
+    .lede { margin-bottom: 1.6rem; font-size: 1.05rem; }
+    p { margin-bottom: 1rem; }
+    ul, ol { margin: 0 0 1rem; padding-left: 1.8rem; }
+    li { margin-bottom: 0.3rem; }
+    .toc { background: var(--well); border: 1px solid var(--line); border-radius: 4px; padding: 1rem 1.4rem; margin-bottom: 2rem; max-width: 32rem; font-size: 0.92rem; }
+    .toc .toc-title { font-weight: 700; margin-bottom: 0.5rem; text-align: center; }
+    .toc ol { padding-left: 1.3rem; }
+    .toc ol ol { padding-left: 1.2rem; margin-top: 0.15rem; }
+    table { width: 100%; border-collapse: collapse; margin: 1.2rem 0 1.8rem; font-size: 0.88rem; }
+    th, td { border: 1px solid var(--line); padding: 0.55rem 0.75rem; text-align: left; vertical-align: top; }
+    th { background: var(--well); font-weight: 600; }
+    .cite { font-size: 0.78rem; vertical-align: super; line-height: 0; margin-left: 0.1rem; }
+    .unattributed { color: var(--mute); font-style: italic; font-size: 0.92rem; }
+    .references ol { font-size: 0.88rem; padding-left: 1.4rem; }
+    .references li { margin-bottom: 0.6rem; line-height: 1.45; }
+    footer { border-top: 1px solid var(--line); margin-top: 3rem; padding-top: 1.4rem; font-size: 0.85rem; color: var(--mute); }
+    .back-to-top { position: fixed; bottom: 1.5rem; right: 1.5rem; width: 2.6rem; height: 2.6rem; border-radius: 50%; background: var(--bg); color: var(--ink); border: 1px solid var(--line); box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12); display: flex; align-items: center; justify-content: center; cursor: pointer; opacity: 0; visibility: hidden; transform: translateY(8px); transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease; z-index: 100; }
+    .back-to-top.visible { opacity: 1; visibility: visible; transform: translateY(0); }
+    .back-to-top:hover { background: var(--well); border-color: var(--link); color: var(--link); }
+    .back-to-top:focus-visible { outline: 2px solid var(--link); outline-offset: 2px; }
+    @media print { .back, .back-to-top { display: none !important; } }
+  </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Subvocalization in Reading","description":"A sourced reference on subvocalization in reading, phonological coding, inner speech, and the limited evidence specific to autism.","url":"https://ngpestelos.com/reference/subvocalization/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
+</head>
+<body class="reference">
+  <main id="top">
+    <p class="back"><a href="/reference/">← Reference</a> · <a href="/">Nestor G Pestelos Jr</a> · <a href="#" onclick="window.print(); return false;">Print this page</a></p>
+    <p class="kicker">Reading and Cognitive Psychology</p>
+    <h1>Subvocalization in Reading</h1>
+    <p class="updated">Reference entry · last updated September 5, 2026</p>
+
+    <p class="lede"><strong>Subvocalization</strong> is the production or preparation of speech-like motor activity during silent reading. It is related to, but distinct from, phonological coding and inner speech. Research supports phonological processing as one component of reading, while the frequency and function of muscular subvocalization vary by task and reader.<span class="cite">[<a href="#ref1">1</a>]</span><span class="cite">[<a href="#ref4">4</a>]</span></p>
+
+    <nav class="toc" aria-label="Contents">
+      <p class="toc-title">Contents</p>
+      <ol>
+        <li><a href="#terms">Related terms</a></li>
+        <li><a href="#reading">Subvocalization in reading</a></li>
+        <li><a href="#autism">Autism and reading</a></li>
+        <li><a href="#limits">Limits of the evidence</a></li>
+        <li><a href="#see-also">See also</a></li>
+        <li><a href="#references">References</a></li>
+      </ol>
+    </nav>
+
+    <h2 id="terms">Related terms</h2>
+    <table>
+      <thead><tr><th>Term</th><th>Meaning</th></tr></thead>
+      <tbody>
+        <tr><td><strong>Phonological coding</strong></td><td>Use of speech-sound information while recognizing or retaining written words. It can occur without audible speech or measurable speech-muscle movement.</td></tr>
+        <tr><td><strong>Inner speech</strong></td><td>Privately experienced verbal thought. It is a subjective experience and is not equivalent to muscular activity.</td></tr>
+        <tr><td><strong>Subvocalization</strong></td><td>Speech-like motor preparation or low-level activity in articulatory muscles during silent language tasks. Electromyographic studies use muscle activity as one operational measure.</td></tr>
+      </tbody>
+    </table>
+    <p>These terms are often used loosely in popular accounts of reading. They refer to different levels of analysis: sound-based language processing, subjective verbal experience, and speech-motor activity.</p>
+
+    <h2 id="reading">Subvocalization in reading</h2>
+    <p>Written-word recognition can use phonological information. A review of eye-movement and reading research describes evidence that readers activate phonological codes early in processing, including when a word has not yet been directly fixated.<span class="cite">[<a href="#ref1">1</a>]</span> This finding does not establish that every reader consciously pronounces each word internally.</p>
+    <p>Studies of silent reading have also measured activity in muscles involved in articulation. Swanson reported increased electromyographic activity during silent reading compared with a non-reading baseline, and interpreted this as evidence of subvocal speech behavior under the study conditions.<span class="cite">[<a href="#ref4">4</a>]</span> Such measurements concern motor activity, not the whole of phonological processing or inner speech.</p>
+    <p>Articulatory suppression, such as repeatedly speaking an irrelevant sound while reading, can interfere with some verbal tasks. Its effects depend on the task, material, and reader. It is therefore not a direct test of whether all silent reading normally relies on subvocalization.</p>
+
+    <h2 id="autism">Autism and reading</h2>
+    <p>Research does not support a general claim that autistic people subvocalize more or less than non-autistic people while reading. Direct studies comparing speech-muscle subvocalization during reading in autistic and non-autistic groups are limited.</p>
+    <p>Work on autistic people and inner speech addresses a related but different question. Williams, Peng, and Wallace reviewed studies of verbal mediation and concluded that the broad claim that autistic people do not use inner speech is not well supported; the evidence is mixed and methods limit firm conclusions.<span class="cite">[<a href="#ref2">2</a>]</span></p>
+    <p>Reading research in autism also shows heterogeneous profiles. Vale and colleagues found that the available literature did not identify one consistent word-reading strategy in autistic children. Differences in comprehension, inference, language, and decoding cannot be reduced to a single reading mechanism.<span class="cite">[<a href="#ref3">3</a>]</span></p>
+    <p>Morita and Takahashi examined inner speech in autistic people through a self-report measure rather than through reading muscle activity. Their study is relevant to the distinction between subjective inner speech and subvocalization, but it does not establish a reading-specific subvocalization pattern.<span class="cite">[<a href="#ref5">5</a>]</span></p>
+
+    <h2 id="limits">Limits of the evidence</h2>
+    <p>Different methods measure different phenomena. Eye movements can indicate the timing of reading processes. Electromyography can record activity at particular muscles. Questionnaires and self-reports describe subjective experience. Results from one method cannot by themselves settle claims framed at another level.</p>
+    <p>Autism is also a heterogeneous diagnosis. Findings from a group study do not determine an individual reader's experience or reading profile.</p>
+
+    <h2 id="see-also">See also</h2>
+    <ul>
+      <li><a href="/reference/attention/">Attention (Neurological and Computational)</a></li>
+      <li><a href="/reference/spaced-repetition/">Spaced Repetition</a></li>
+    </ul>
+
+    <h2 id="references">References</h2>
+    <ol class="references">
+      <li id="ref1">Leinenger, M. (2014). “Phonological Coding During Reading.” <em>Psychology of Learning and Motivation</em>, 61, 1&ndash;32. <a href="https://pmc.ncbi.nlm.nih.gov/articles/PMC4211933/">Free full text</a>.</li>
+      <li id="ref2">Williams, D., Peng, D., &amp; Wallace, G. L. (2016). “Verbal Thinking and Inner Speech Use in Autism Spectrum Disorder.” <em>Autism</em>, 20(4), 364&ndash;379. <a href="https://pubmed.ncbi.nlm.nih.gov/27632384/">PubMed record</a>.</li>
+      <li id="ref3">Vale, A. P., et al. (2022). “Reading Strategies in Children with Autism Spectrum Disorder: A Systematic Review.” <em>Frontiers in Psychology</em>, 13, 930275. <a href="https://www.frontiersin.org/journals/psychology/articles/10.3389/fpsyg.2022.930275/full">Free full text</a>.</li>
+      <li id="ref4">Swanson, L. G. (1983). “Electromyographic Study of Subvocal Speech in Silent Reading.” <em>Journal of Reading Behavior</em>, 15(4), 335&ndash;344. <a href="https://journals.sagepub.com/doi/10.2307/1510799">Journal record</a>.</li>
+      <li id="ref5">Morita, T., &amp; Takahashi, Y. (2019). “Inner Speech in Individuals with Autism Spectrum Disorder.” <em>Japanese Journal of Educational Psychology</em>, 67(1), 12&ndash;23. <a href="https://www.jstage.jst.go.jp/article/jjep/67/1/67_12/_article/-char/en">Free full text</a>.</li>
+    </ol>
+
+    <footer><p><a href="#top">Back to top</a></p></footer>
+  </main>
+  <button id="backToTop" class="back-to-top" aria-label="Back to top" title="Back to top">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 15l-6-6-6 6"/></svg>
+  </button>
+  <script>
+    const btt = document.getElementById('backToTop');
+    window.addEventListener('scroll', () => { btt.classList.toggle('visible', window.scrollY > 250); }, { passive: true });
+    btt.addEventListener('click', () => { window.scrollTo({ top: 0, behavior: 'smooth' }); });
+  </script>
+</body>
+</html>

--- a/scripts/test_site_discoverability.py
+++ b/scripts/test_site_discoverability.py
@@ -46,6 +46,12 @@ def is_snapshot_slug(slug: str) -> bool:
     return bool(SNAPSHOT_SLUG.search(slug))
 
 
+def parse_iso_datetime(value: str) -> datetime:
+    if value.endswith("Z"):
+        value = f"{value[:-1]}+00:00"
+    return datetime.fromisoformat(value)
+
+
 def bucket_datetimes(html: str) -> dict[str, list[str]]:
     sections = re.findall(
         r'<section class="bucket" id="([^"]+)">(.*?)</section>',
@@ -228,7 +234,7 @@ class SiteDiscoverabilityTests(unittest.TestCase):
         if not entries:
             entries = root.findall("entry")
         self.assertEqual(len(entries), len(items))
-        feed_updated = datetime.fromisoformat(root.findtext("atom:updated", namespaces=ATOM_NS))
+        feed_updated = parse_iso_datetime(root.findtext("atom:updated", namespaces=ATOM_NS))
         for entry in entries:
             entry_id = entry.findtext("atom:id", namespaces=ATOM_NS)
             self.assertIn(entry_id, items_by_url)
@@ -240,7 +246,7 @@ class SiteDiscoverabilityTests(unittest.TestCase):
             summaries = entry.findall("atom:summary", ATOM_NS)
             self.assertEqual(len(summaries), 1, entry_id)
             self.assertEqual(summaries[0].text, parser.descriptions[0])
-            entry_updated = datetime.fromisoformat(
+            entry_updated = parse_iso_datetime(
                 entry.findtext("atom:updated", namespaces=ATOM_NS)
             )
             self.assertEqual(entry_updated.utcoffset(), timedelta(hours=8))
@@ -364,4 +370,3 @@ class ReferenceSeoTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -231,6 +231,11 @@
     <priority>0.5</priority>
   </url>
   <url>
+    <loc>https://ngpestelos.com/reference/subvocalization/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
     <loc>https://ngpestelos.com/reference/frontier-models/</loc>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>


### PR DESCRIPTION
## Summary
- Add a sourced public reference page for subvocalization.
- Register it in the reference index and sitemap.
- Make Atom UTC-Z timestamp parsing portable in the discoverability test.

## Verification
- `python3 scripts/test_site_discoverability.py`