### PR TITLE
fix: correct subvocalization citations

### DIFF
--- a/reference/subvocalization/index.html
+++ b/reference/subvocalization/index.html
@@ -103,7 +103,7 @@
     <p>Morita and Takahashi compared reading aloud and subvocalization while measuring text comprehension and eye movements in an undergraduate experiment.<span class="cite">[<a href="#ref5">5</a>]</span> This is a reading-mode study, not an autism study.</p>
 
     <h2 id="autism">Autism and reading</h2>
-    <p>Research does not support a general claim that autistic people subvocalize more or less than non-autistic people while reading. Direct studies comparing speech-muscle subvocalization during reading in autistic and non-autistic groups are limited.</p>
+    <p>The cited reviews do not establish a uniform autism effect on phonological coding, inner speech, or muscular subvocalization.<span class="cite">[<a href="#ref2">2</a>]</span><span class="cite">[<a href="#ref3">3</a>]</span> This page does not cite a direct comparison of speech-muscle subvocalization during reading.</p>
     <p>Work on autistic people and inner speech addresses a related but different question. Williams, Peng, and Wallace reviewed studies of verbal mediation and concluded that the broad claim that autistic people do not use inner speech is not well supported; the evidence is mixed and methods limit firm conclusions.<span class="cite">[<a href="#ref2">2</a>]</span></p>
     <p>Reading research in autism also shows heterogeneous profiles. Vale and colleagues' systematic review describes variation in word-reading skills across the literature on autistic people.<span class="cite">[<a href="#ref3">3</a>]</span></p>
 

--- a/reference/subvocalization/index.html
+++ b/reference/subvocalization/index.html
@@ -72,7 +72,7 @@
     <h1>Subvocalization in Reading</h1>
     <p class="updated">Reference entry · last updated September 5, 2026</p>
 
-    <p class="lede"><strong>Subvocalization</strong> is the production or preparation of speech-like motor activity during silent reading. It is related to, but distinct from, phonological coding and inner speech. Research supports phonological processing as one component of reading, while the frequency and function of muscular subvocalization vary by task and reader.<span class="cite">[<a href="#ref1">1</a>]</span><span class="cite">[<a href="#ref4">4</a>]</span></p>
+    <p class="lede"><strong>Subvocalization</strong> is the production or preparation of speech-like motor activity during silent reading. It is related to, but distinct from, phonological coding and inner speech. Research supports phonological processing as one component of reading.<span class="cite">[<a href="#ref1">1</a>]</span></p>
 
     <nav class="toc" aria-label="Contents">
       <p class="toc-title">Contents</p>
@@ -92,24 +92,23 @@
       <tbody>
         <tr><td><strong>Phonological coding</strong></td><td>Use of speech-sound information while recognizing or retaining written words. It can occur without audible speech or measurable speech-muscle movement.</td></tr>
         <tr><td><strong>Inner speech</strong></td><td>Privately experienced verbal thought. It is a subjective experience and is not equivalent to muscular activity.</td></tr>
-        <tr><td><strong>Subvocalization</strong></td><td>Speech-like motor preparation or low-level activity in articulatory muscles during silent language tasks. Electromyographic studies use muscle activity as one operational measure.</td></tr>
+        <tr><td><strong>Subvocalization</strong></td><td>Speech-like motor preparation or low-level activity in articulatory muscles during silent language tasks.</td></tr>
       </tbody>
     </table>
     <p>These terms are often used loosely in popular accounts of reading. They refer to different levels of analysis: sound-based language processing, subjective verbal experience, and speech-motor activity.</p>
 
     <h2 id="reading">Subvocalization in reading</h2>
     <p>Written-word recognition can use phonological information. A review of eye-movement and reading research describes evidence that readers activate phonological codes early in processing, including when a word has not yet been directly fixated.<span class="cite">[<a href="#ref1">1</a>]</span> This finding does not establish that every reader consciously pronounces each word internally.</p>
-    <p>Studies of silent reading have also measured activity in muscles involved in articulation. Swanson reported increased electromyographic activity during silent reading compared with a non-reading baseline, and interpreted this as evidence of subvocal speech behavior under the study conditions.<span class="cite">[<a href="#ref4">4</a>]</span> Such measurements concern motor activity, not the whole of phonological processing or inner speech.</p>
-    <p>Articulatory suppression, such as repeatedly speaking an irrelevant sound while reading, can interfere with some verbal tasks. Its effects depend on the task, material, and reader. It is therefore not a direct test of whether all silent reading normally relies on subvocalization.</p>
+    <p>Articulatory suppression, such as repeatedly speaking an irrelevant sound while reading, can interfere with some verbal tasks. Swanson studied the effects of suppressing subvocal speech on sentence comprehension in learning-disabled readers.<span class="cite">[<a href="#ref4">4</a>]</span> Such interventions do not directly measure muscular activity during ordinary silent reading.</p>
+    <p>Morita and Takahashi compared reading aloud and subvocalization while measuring text comprehension and eye movements in an undergraduate experiment.<span class="cite">[<a href="#ref5">5</a>]</span> This is a reading-mode study, not an autism study.</p>
 
     <h2 id="autism">Autism and reading</h2>
     <p>Research does not support a general claim that autistic people subvocalize more or less than non-autistic people while reading. Direct studies comparing speech-muscle subvocalization during reading in autistic and non-autistic groups are limited.</p>
     <p>Work on autistic people and inner speech addresses a related but different question. Williams, Peng, and Wallace reviewed studies of verbal mediation and concluded that the broad claim that autistic people do not use inner speech is not well supported; the evidence is mixed and methods limit firm conclusions.<span class="cite">[<a href="#ref2">2</a>]</span></p>
-    <p>Reading research in autism also shows heterogeneous profiles. Vale and colleagues found that the available literature did not identify one consistent word-reading strategy in autistic children. Differences in comprehension, inference, language, and decoding cannot be reduced to a single reading mechanism.<span class="cite">[<a href="#ref3">3</a>]</span></p>
-    <p>Morita and Takahashi examined inner speech in autistic people through a self-report measure rather than through reading muscle activity. Their study is relevant to the distinction between subjective inner speech and subvocalization, but it does not establish a reading-specific subvocalization pattern.<span class="cite">[<a href="#ref5">5</a>]</span></p>
+    <p>Reading research in autism also shows heterogeneous profiles. Vale and colleagues' systematic review describes variation in word-reading skills across the literature on autistic people.<span class="cite">[<a href="#ref3">3</a>]</span></p>
 
     <h2 id="limits">Limits of the evidence</h2>
-    <p>Different methods measure different phenomena. Eye movements can indicate the timing of reading processes. Electromyography can record activity at particular muscles. Questionnaires and self-reports describe subjective experience. Results from one method cannot by themselves settle claims framed at another level.</p>
+    <p>Different methods measure different phenomena. Eye movements can indicate the timing of reading processes. Questionnaires and self-reports describe subjective experience. Results from one method cannot by themselves settle claims framed at another level.</p>
     <p>Autism is also a heterogeneous diagnosis. Findings from a group study do not determine an individual reader's experience or reading profile.</p>
 
     <h2 id="see-also">See also</h2>
@@ -121,10 +120,10 @@
     <h2 id="references">References</h2>
     <ol class="references">
       <li id="ref1">Leinenger, M. (2014). “Phonological Coding During Reading.” <em>Psychology of Learning and Motivation</em>, 61, 1&ndash;32. <a href="https://pmc.ncbi.nlm.nih.gov/articles/PMC4211933/">Free full text</a>.</li>
-      <li id="ref2">Williams, D., Peng, D., &amp; Wallace, G. L. (2016). “Verbal Thinking and Inner Speech Use in Autism Spectrum Disorder.” <em>Autism</em>, 20(4), 364&ndash;379. <a href="https://pubmed.ncbi.nlm.nih.gov/27632384/">PubMed record</a>.</li>
-      <li id="ref3">Vale, A. P., et al. (2022). “Reading Strategies in Children with Autism Spectrum Disorder: A Systematic Review.” <em>Frontiers in Psychology</em>, 13, 930275. <a href="https://www.frontiersin.org/journals/psychology/articles/10.3389/fpsyg.2022.930275/full">Free full text</a>.</li>
-      <li id="ref4">Swanson, L. G. (1983). “Electromyographic Study of Subvocal Speech in Silent Reading.” <em>Journal of Reading Behavior</em>, 15(4), 335&ndash;344. <a href="https://journals.sagepub.com/doi/10.2307/1510799">Journal record</a>.</li>
-      <li id="ref5">Morita, T., &amp; Takahashi, Y. (2019). “Inner Speech in Individuals with Autism Spectrum Disorder.” <em>Japanese Journal of Educational Psychology</em>, 67(1), 12&ndash;23. <a href="https://www.jstage.jst.go.jp/article/jjep/67/1/67_12/_article/-char/en">Free full text</a>.</li>
+      <li id="ref2">Williams, D., Peng, D., &amp; Wallace, G. L. (2016). “Verbal Thinking and Inner Speech Use in Autism Spectrum Disorder.” <em>Neuropsychological Review</em>, 26(4), 394&ndash;419. <a href="https://pubmed.ncbi.nlm.nih.gov/27632384/">PubMed record</a>.</li>
+      <li id="ref3">Vale, A. P., et al. (2022). “Word Reading Skills in Autism Spectrum Disorder: A Systematic Review.” <em>Frontiers in Psychology</em>, 13, 930275. <a href="https://www.frontiersin.org/journals/psychology/articles/10.3389/fpsyg.2022.930275/full">Free full text</a>.</li>
+      <li id="ref4">Swanson, H. L. (1983). “Effects of Subvocal Suppression on Learning Disabled Readers’ Sentence Comprehension.” <em>Learning Disability Quarterly</em>, 6(2). <a href="https://journals.sagepub.com/doi/10.2307/1510799">Journal record</a>.</li>
+      <li id="ref5">Morita, T., &amp; Takahashi, Y. (2019). “Effects of Reading Aloud and Subvocalization on Text Comprehension and Eye Movements.” <em>Japanese Journal of Educational Psychology</em>, 67(1), 12&ndash;23. <a href="https://www.jstage.jst.go.jp/article/jjep/67/1/67_12/_article/-char/en">Free full text</a>.</li>
     </ol>
 
     <footer><p><a href="#top">Back to top</a></p></footer>


### PR DESCRIPTION
Corrects source metadata and removes unsupported claims from the newly merged subvocalization reference page.\n\nVerification: python3 scripts/test_site_discoverability.py