### PR TITLE
feat(reference): add vector (mathematics and computing) ground-truth page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.worktrees/
+.pipeline/
+.claude/
+__pycache__/
+*.pyc
+.DS_Store

--- a/reference/index.html
+++ b/reference/index.html
@@ -378,6 +378,7 @@
         <li><a href="/reference/spaced-repetition/">Spaced Repetition</a></li>
         <li><a href="/reference/steelmanning/">Steelmanning</a></li>
         <li><a href="/reference/subvocalization/">Subvocalization in Reading</a></li>
+        <li><a href="/reference/supervised-learning/">Supervised Learning</a></li>
         <li><a href="/reference/sycophancy/">Sycophancy</a></li>
         </ul>
       </div>
@@ -398,6 +399,7 @@
       <div class="letter-group" id="U">
         <h2 class="letter-heading">U</h2>
         <ul>
+        <li><a href="/reference/unsupervised-learning/">Unsupervised Learning</a></li>
         <li><a href="/reference/url-urn-uri/">URL vs URN vs URI</a></li>
         </ul>
       </div>

--- a/reference/index.html
+++ b/reference/index.html
@@ -408,6 +408,7 @@
         <h2 class="letter-heading">V</h2>
         <ul>
         <li><a href="/reference/vannevar-bush/">Vannevar Bush</a></li>
+        <li><a href="/reference/vector/">Vector (Mathematics and Computing)</a></li>
         <li><a href="/reference/vector-search/">Vector Search</a></li>
         </ul>
       </div>

--- a/reference/machine-learning/index.html
+++ b/reference/machine-learning/index.html
@@ -238,12 +238,14 @@
     <div class="companion-box">
       <h2>See Also &amp; Related References</h2>
       <ul>
-        <li>📖 <a href="/reference/artificial-intelligence/"><strong>Reference: Artificial Intelligence</strong></a> — Rational agents, historical taxonomy, and system design.</li>
-        <li>📖 <a href="/reference/neural-networks/"><strong>Reference: Neural Networks</strong></a> — Artificial neurons, activation functions, and perceptrons.</li>
-        <li>📖 <a href="/reference/deep-neural-networks/"><strong>Reference: Deep Neural Networks</strong></a> — Multi-layer architectures, backpropagation, and representation learning.</li>
-        <li>📖 <a href="/reference/reinforcement-learning/"><strong>Reference: Reinforcement Learning</strong></a> — MDPs, Bellman equations, policy gradients, and LLM alignment.</li>
-        <li>📖 <a href="/reference/large-language-models/"><strong>Reference: Large Language Models (LLMs)</strong></a> — Self-supervised training, transformers, and model selection.</li>
-        <li>📖 <a href="/reference/autoregressive/"><strong>Reference: Autoregressive Models</strong></a> — Sequential factorization and causal language modeling.</li>
+        <li>📖 <a href="/reference/supervised-learning/"><strong>Reference: Supervised Learning</strong></a>: Labeled mapping functions, loss functions, empirical risk minimization, and bias-variance tradeoff.</li>
+        <li>📖 <a href="/reference/unsupervised-learning/"><strong>Reference: Unsupervised Learning</strong></a>: Latent structure discovery, clustering taxonomy, dimensionality reduction, and density estimation.</li>
+        <li>📖 <a href="/reference/reinforcement-learning/"><strong>Reference: Reinforcement Learning</strong></a>: MDPs, Bellman equations, policy gradients, and LLM alignment.</li>
+        <li>📖 <a href="/reference/artificial-intelligence/"><strong>Reference: Artificial Intelligence</strong></a>: Rational agents, historical taxonomy, and system design.</li>
+        <li>📖 <a href="/reference/neural-networks/"><strong>Reference: Neural Networks</strong></a>: Artificial neurons, activation functions, and perceptrons.</li>
+        <li>📖 <a href="/reference/deep-neural-networks/"><strong>Reference: Deep Neural Networks</strong></a>: Multi-layer architectures, backpropagation, and representation learning.</li>
+        <li>📖 <a href="/reference/large-language-models/"><strong>Reference: Large Language Models (LLMs)</strong></a>: Self-supervised training, transformers, and model selection.</li>
+        <li>📖 <a href="/reference/autoregressive/"><strong>Reference: Autoregressive Models</strong></a>: Sequential factorization and causal language modeling.</li>
       </ul>
     </div>
 
@@ -284,13 +286,13 @@
       </thead>
       <tbody>
         <tr>
-          <td><strong>Supervised Learning</strong></td>
+          <td><a href="/reference/supervised-learning/"><strong>Supervised Learning</strong></a></td>
           <td>Labeled pairs \(\mathcal{D} = \{(x_i, y_i)\}_{i=1}^N\).</td>
           <td>Learn mapping function \(f: X \to Y\) predicting labels for unseen \(x\).</td>
           <td>Linear/Logistic Regression, Support Vector Machines (SVM), Random Forests, <a href="/reference/deep-neural-networks/">DNNs</a>.</td>
         </tr>
         <tr>
-          <td><strong>Unsupervised &amp; Self-Supervised</strong></td>
+          <td><a href="/reference/unsupervised-learning/"><strong>Unsupervised &amp; Self-Supervised</strong></a></td>
           <td>Unlabeled data \(\mathcal{D} = \{x_i\}_{i=1}^N\) (or self-derived token masks).</td>
           <td>Discover latent structure, density \(P(X)\), or predict masked tokens from context.</td>
           <td>k-Means Clustering, PCA, t-SNE, Autoencoders, <a href="/reference/autoregressive/">Autoregressive Pre-Training</a>.</td>

--- a/reference/supervised-learning/index.html
+++ b/reference/supervised-learning/index.html
@@ -1,0 +1,630 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Supervised Learning · Reference · Nestor G Pestelos Jr</title>
+  <meta name="description" content="A citable ground-truth reference on Supervised Learning: empirical risk minimization, loss functions, bias-variance tradeoff, support vector machines, decision trees, and statistical learning bounds.">
+  <meta property="og:title" content="Supervised Learning · Reference">
+  <meta property="og:description" content="A citable ground-truth reference on Supervised Learning: empirical risk minimization, loss functions, bias-variance tradeoff, support vector machines, decision trees, and statistical learning bounds.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://ngpestelos.com/reference/supervised-learning/">
+  <link rel="canonical" href="https://ngpestelos.com/reference/supervised-learning/">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=20260813f">
+  <link rel="icon" href="/favicon-192.png?v=20260813f" type="image/png" sizes="192x192">
+  <link rel="icon" href="/favicon-32.png?v=20260813f" type="image/png" sizes="32x32">
+  <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
+  <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="stylesheet" href="/style.css?v=20260903e">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TLBY8P4GG9');
+  </script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css" crossorigin="anonymous">
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
+    onload="renderMathInElement(document.body, {
+      delimiters: [
+        {left: '$$', right: '$$', display: true},
+        {left: '\\[', right: '\\]', display: true},
+        {left: '\\(', right: '\\)', display: false}
+      ]
+    });"></script>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; scroll-behavior: smooth; }
+    body {
+      line-height: 1.6;
+    }
+    main {
+      max-width: 48rem;
+      margin: 0 auto;
+      padding: 1.4rem 1.4rem 4rem;
+    }
+    .back {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .back a { color: var(--link); text-decoration: none; }
+    .back a:hover { text-decoration: underline; }
+    .kicker {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.78rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--mute);
+      margin-bottom: 0.2rem;
+    }
+    h1 {
+      font-size: clamp(1.9rem, 5vw, 2.4rem);
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.4rem;
+      margin-bottom: 0.8rem;
+    }
+    .subtitle {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 1rem;
+      color: var(--mute);
+      margin-bottom: 1.6rem;
+      line-height: 1.5;
+    }
+    .companion-box {
+      background: var(--well);
+      border: 1px solid var(--line);
+      border-left: 4px solid var(--link);
+      border-radius: 4px;
+      padding: 1rem 1.3rem;
+      margin-bottom: 1.8rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+    }
+    .companion-box h2 {
+      font-size: 0.95rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-top: 0;
+      margin-bottom: 0.5rem;
+      border-bottom: none;
+      padding-bottom: 0;
+      color: var(--ink);
+    }
+    .companion-box ul {
+      list-style: none;
+      padding-left: 0;
+      margin-bottom: 0;
+      font-size: 0.92rem;
+    }
+    .companion-box li { margin-bottom: 0.4rem; }
+    .companion-box li:last-child { margin-bottom: 0; }
+    .companion-box a { color: var(--link); text-decoration: none; }
+    .companion-box a:hover { text-decoration: underline; }
+    .toc {
+      background: var(--well);
+      border: 1px solid var(--line);
+      border-radius: 4px;
+      padding: 1.1rem 1.4rem;
+      margin-bottom: 2rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.9rem;
+    }
+    .toc h2 {
+      font-size: 1rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: 0.5rem;
+      color: var(--ink);
+      border-bottom: none;
+      padding-bottom: 0;
+      margin-top: 0;
+    }
+    .toc ol {
+      padding-left: 1.3rem;
+      margin-bottom: 0;
+    }
+    .toc ol ol {
+      padding-left: 1.2rem;
+      margin-top: 0.15rem;
+    }
+    .toc li { margin: 0.25rem 0; }
+    .toc a { color: var(--link); text-decoration: none; }
+    .toc a:hover { text-decoration: underline; }
+    h2 {
+      font-size: 1.45rem;
+      font-weight: 700;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.3rem;
+      margin-top: 2.2rem;
+      margin-bottom: 0.9rem;
+      color: var(--ink);
+    }
+    h3 {
+      font-size: 1.15rem;
+      font-weight: 700;
+      margin-top: 1.4rem;
+      margin-bottom: 0.3rem;
+      color: var(--ink);
+    }
+    p { margin-bottom: 1rem; }
+    ul, ol { margin-bottom: 1rem; padding-left: 1.5rem; }
+    li { margin-bottom: 0.4rem; }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1.2rem 0 1.8rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.88rem;
+    }
+    th, td {
+      border: 1px solid var(--line);
+      padding: 0.55rem 0.75rem;
+      text-align: left;
+      vertical-align: top;
+    }
+    th { background: var(--well); font-weight: 600; }
+    code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.88em;
+      background: #f1f3f5;
+      padding: 0.15em 0.35em;
+      border-radius: 3px;
+    }
+    .cite {
+      font-size: 0.75em;
+      vertical-align: super;
+      line-height: 0;
+      text-decoration: none;
+    }
+    .cite a { text-decoration: none; }
+    .formula-box {
+      text-align: center;
+      margin: 1.2rem 0;
+      background: var(--well);
+      padding: 0.8rem;
+      border-radius: 4px;
+      border: 1px solid var(--line);
+      overflow-x: auto;
+    }
+    #references {
+      font-size: 0.92rem;
+    }
+    #references ol {
+      padding-left: 1.5rem;
+    }
+    #references li {
+      margin-bottom: 0.5rem;
+    }
+    #references .backlink {
+      margin-right: 0.3rem;
+    }
+    footer.meta {
+      border-top: 1px solid var(--line);
+      margin-top: 3rem;
+      padding-top: 1.4rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+    }
+    footer.meta a { color: var(--link); }
+    @media print {
+      .back {font-family:"Segoe UI", Helvetica, Arial, sans-serif;display: none;}
+    }
+    .back-to-top {
+      position: fixed;
+      bottom: 1.5rem;
+      right: 1.5rem;
+      width: 2.6rem;
+      height: 2.6rem;
+      border-radius: 50%;
+      background: var(--bg);
+      color: var(--ink);
+      border: 1px solid var(--line);
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      opacity: 0;
+      visibility: hidden;
+      transform: translateY(8px);
+      transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease, background 0.15s ease, border-color 0.15s ease;
+      z-index: 100;
+    }
+    .back-to-top.visible {
+      opacity: 1;
+      visibility: visible;
+      transform: translateY(0);
+    }
+    .back-to-top:hover {
+      background: var(--well);
+      border-color: var(--link);
+      color: var(--link);
+    }
+    .back-to-top:focus-visible {
+      outline: 2px solid var(--link);
+      outline-offset: 2px;
+    }
+    @media print {
+      .back-to-top { display: none !important; }
+    }
+  </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Supervised Learning","description":"A citable ground-truth reference on Supervised Learning: empirical risk minimization, loss functions, bias-variance tradeoff, support vector machines, decision trees, and statistical learning bounds.","url":"https://ngpestelos.com/reference/supervised-learning/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
+</head>
+<body class="reference">
+  <main id="top">
+    <p class="back"><a href="/reference/">← Reference</a> · <a href="/">Nestor G Pestelos Jr</a> · <a href="#" onclick="window.print(); return false;">Print this page</a></p>
+    <p class="kicker">Machine Learning</p>
+    <h1>Supervised Learning</h1>
+    <p class="subtitle">A citable reference on Supervised Learning: mathematical problem formulation, empirical risk minimization, regression and classification loss functions, the bias-variance decomposition, algorithm taxonomy, and generalization bounds.</p>
+
+    <div class="companion-box">
+      <h2>See Also &amp; Related References</h2>
+      <ul>
+        <li>📖 <a href="/reference/machine-learning/"><strong>Reference: Machine Learning</strong></a>: Empirical risk minimization, learning paradigms, and generalization theory.</li>
+        <li>📖 <a href="/reference/unsupervised-learning/"><strong>Reference: Unsupervised Learning</strong></a>: Latent structure discovery, clustering, dimensionality reduction, and density estimation.</li>
+        <li>📖 <a href="/reference/reinforcement-learning/"><strong>Reference: Reinforcement Learning</strong></a>: Markov Decision Processes, policy gradients, and environmental reward optimization.</li>
+        <li>📖 <a href="/reference/deep-neural-networks/"><strong>Reference: Deep Neural Networks</strong></a>: Backpropagation, non-linear activation functions, and deep representations.</li>
+        <li>📖 <a href="/reference/neural-networks/"><strong>Reference: Neural Networks</strong></a>: Perceptrons, artificial neurons, and architecture topology.</li>
+      </ul>
+    </div>
+
+    <nav class="toc" aria-label="Contents">
+      <h2>Contents</h2>
+      <ol>
+        <li><a href="#formal-formulation">1. Formal Mathematical Formulation</a>
+          <ol>
+            <li><a href="#data-spaces">1.1 Data Spaces and Training Experience</a></li>
+            <li><a href="#true-vs-empirical-risk">1.2 True Risk vs. Empirical Risk Minimization (ERM)</a></li>
+            <li><a href="#regularization-framework">1.3 Regularization Framework</a></li>
+          </ol>
+        </li>
+        <li><a href="#loss-functions">2. Canonical Loss Functions</a>
+          <ol>
+            <li><a href="#regression-losses">2.1 Regression Losses</a></li>
+            <li><a href="#classification-losses">2.2 Classification Losses</a></li>
+          </ol>
+        </li>
+        <li><a href="#bias-variance">3. The Bias-Variance Tradeoff</a>
+          <ol>
+            <li><a href="#bias-variance-decomp">3.1 Analytical Error Decomposition</a></li>
+            <li><a href="#double-descent">3.2 Overfitting, Underfitting, and Double Descent</a></li>
+          </ol>
+        </li>
+        <li><a href="#algorithm-taxonomy">4. Taxonomy of Supervised Algorithms</a>
+          <ol>
+            <li><a href="#linear-models">4.1 Generalized Linear and Logistic Models</a></li>
+            <li><a href="#svm-kernels">4.2 Support Vector Machines and Kernel Methods</a></li>
+            <li><a href="#tree-ensembles">4.3 Decision Trees and Ensemble Methods</a></li>
+            <li><a href="#deep-architectures">4.4 Supervised Neural Networks</a></li>
+          </ol>
+        </li>
+        <li><a href="#statistical-learning-theory">5. Generalization Bounds and Statistical Learning Theory</a>
+          <ol>
+            <li><a href="#pac-learning">5.1 PAC Learning Framework</a></li>
+            <li><a href="#vc-dimension">5.2 VC Dimension and Rademacher Complexity</a></li>
+          </ol>
+        </li>
+        <li><a href="#references">6. References</a></li>
+      </ol>
+    </nav>
+
+    <!-- Section 1 -->
+    <h2 id="formal-formulation">1. Formal Mathematical Formulation</h2>
+    <p>
+      <strong>Supervised Learning</strong> is a machine learning paradigm in which an algorithm learns a mapping function from input features to output targets based on training examples composed of labeled pairs.<span class="cite">[<a href="#ref1">1</a>, <a href="#ref2">2</a>]</span> The objective is to produce a model that generalizes accurately to previously unseen inputs sampled from the underlying joint data distribution.
+    </p>
+
+    <h3 id="data-spaces">1.1 Data Spaces and Training Experience</h3>
+    <p>
+      Let \(\mathcal{X} \subseteq \mathbb{R}^d\) denote the input feature space and \(\mathcal{Y}\) denote the target output space. In the supervised setting, the training experience \(E\) consists of a dataset \(\mathcal{D}\) of \(N\) independent and identically distributed (i.i.d.) pairs drawn from a fixed but unknown probability distribution \(P(X, Y)\):
+    </p>
+    <div class="formula-box">
+      $$\mathcal{D} = \{(x_1, y_1), (x_2, y_2), \dots, (x_N, y_N)\} \sim P(X, Y)^N$$
+    </div>
+    <p>
+      The nature of \(\mathcal{Y}\) determines the fundamental task category:
+    </p>
+    <ul>
+      <li><strong>Regression:</strong> The target space is continuous, \(\mathcal{Y} \subseteq \mathbb{R}^k\) (typically \(k=1\)).</li>
+      <li><strong>Binary Classification:</strong> The target space contains discrete binary labels, \(\mathcal{Y} = \{-1, +1\}\) or \(\mathcal{Y} = \{0, 1\}\).</li>
+      <li><strong>Multiclass Classification:</strong> The target space contains \(C\) categorical labels, \(\mathcal{Y} = \{1, 2, \dots, C\}\).</li>
+      <li><strong>Multilabel / Structured Output:</strong> The target space consists of binary vectors \(\mathcal{Y} = \{0, 1\}^C\) or complex combinatorial objects such as parse trees, bounding boxes, or sequences.</li>
+    </ul>
+
+    <h3 id="true-vs-empirical-risk">1.2 True Risk vs. Empirical Risk Minimization (ERM)</h3>
+    <p>
+      Given a hypothesis class \(\mathcal{H}\) of parameterized candidate functions \(f_\theta: \mathcal{X} \to \mathcal{Y}\) and a loss function \(\mathcal{L}: \mathcal{Y} \times \mathcal{Y} \to \mathbb{R}_{\ge 0}\), the ideal goal is finding parameters \(\theta^*\) that minimize the <strong>True Risk</strong> (or generalization error) \(R(f_\theta)\):<span class="cite">[<a href="#ref3">3</a>]</span>
+    </p>
+    <div class="formula-box">
+      $$R(f_\theta) = \mathbb{E}_{(x, y) \sim P(X, Y)} \left[ \mathcal{L}(f_\theta(x), y) \right] = \int_{\mathcal{X} \times \mathcal{Y}} \mathcal{L}(f_\theta(x), y) \, dP(x, y)$$
+    </div>
+    <p>
+      Because \(P(X, Y)\) is unknown, the true risk cannot be computed directly. Under the <strong>Empirical Risk Minimization (ERM)</strong> principle (Vapnik, 1998), the algorithm optimizes the sample average loss across the training set:<span class="cite">[<a href="#ref3">3</a>]</span>
+    </p>
+    <div class="formula-box">
+      $$\hat{R}_{\text{emp}}(f_\theta, \mathcal{D}) = \frac{1}{N} \sum_{i=1}^N \mathcal{L}\big(f_\theta(x_i), y_i\big)$$
+    </div>
+
+    <h3 id="regularization-framework">1.3 Regularization Framework</h3>
+    <p>
+      Unconstrained minimization of empirical risk over complex hypothesis spaces leads to overfitting, where the model memorizes sample noise rather than generalizable functional relationships. <strong>Structural Risk Minimization (SRM)</strong> augments empirical risk with a complexity penalty \(\Omega(\theta)\) weighted by a hyperparameter \(\lambda > 0\):<span class="cite">[<a href="#ref2">2</a>, <a href="#ref3">3</a>]</span>
+    </p>
+    <div class="formula-box">
+      $$\hat{\theta} = \arg\min_{\theta} \left( \frac{1}{N} \sum_{i=1}^N \mathcal{L}\big(f_\theta(x_i), y_i\big) + \lambda \Omega(\theta) \right)$$
+    </div>
+    <ul>
+      <li><strong>\(L_2\) Regularization (Ridge / Weight Decay):</strong> \(\Omega(\theta) = \|\theta\|_2^2 = \sum_j \theta_j^2\). Imposes a Gaussian prior on parameters, penalizing large weights and stabilizing ill-conditioned inversions.</li>
+      <li><strong>\(L_1\) Regularization (Lasso):</strong> \(\Omega(\theta) = \|\theta\|_1 = \sum_j |\theta_j|\). Imposes a Laplacian prior on parameters, driving uninformative feature weights to zero to perform embedded feature selection.</li>
+      <li><strong>Elastic Net:</strong> \(\Omega(\theta) = \alpha \|\theta\|_1 + (1 - \alpha) \|\theta\|_2^2\), combining sparsity induction with group selection for correlated predictors.</li>
+    </ul>
+
+    <!-- Section 2 -->
+    <h2 id="loss-functions">2. Canonical Loss Functions</h2>
+    <p>
+      The loss function specifies the penalty assigned to discrepancies between model predictions \(\hat{y} = f_\theta(x)\) and ground-truth targets \(y\). The selection of loss function dictates the probabilistic interpretation and robustness of the resulting estimator.
+    </p>
+
+    <h3 id="regression-losses">2.1 Regression Losses</h3>
+    <table>
+      <thead>
+        <tr>
+          <th>Loss Function</th>
+          <th>Mathematical Definition</th>
+          <th>Optimal Point Prediction</th>
+          <th>Properties &amp; Robustness</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><strong>Squared Error (MSE / \(L_2\))</strong></td>
+          <td>\(\mathcal{L}(f(x), y) = \frac{1}{2}(y - f(x))^2\)</td>
+          <td>Conditional Mean \(\mathbb{E}[Y \mid X=x]\)</td>
+          <td>Differentiable everywhere; highly sensitive to outliers. Corresponds to Gaussian likelihood.</td>
+        </tr>
+        <tr>
+          <td><strong>Absolute Error (MAE / \(L_1\))</strong></td>
+          <td>\(\mathcal{L}(f(x), y) = |y - f(x)|\)</td>
+          <td>Conditional Median \(\text{Med}(Y \mid X=x)\)</td>
+          <td>Robust to extreme outliers; non-differentiable at \(y - f(x) = 0\). Corresponds to Laplace likelihood.</td>
+        </tr>
+        <tr>
+          <td><strong>Huber Loss</strong></td>
+          <td>
+            \(\begin{cases} \frac{1}{2}(y - f(x))^2 & |y - f(x)| \le \delta \\ \delta |y - f(x)| - \frac{1}{2}\delta^2 & |y - f(x)| > \delta \end{cases}\)
+          </td>
+          <td>Hybrid conditional statistic</td>
+          <td>Smoothly transitions from quadratic for small residuals to linear for large residuals; robust and differentiable.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3 id="classification-losses">2.2 Classification Losses</h3>
+    <table>
+      <thead>
+        <tr>
+          <th>Loss Function</th>
+          <th>Mathematical Definition</th>
+          <th>Target Setting</th>
+          <th>Properties &amp; Optimization</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><strong>Cross-Entropy Loss (Log Loss)</strong></td>
+          <td>\(\mathcal{L}(f(x), y) = -\sum_{c=1}^C y_c \log \hat{p}_c(x)\)</td>
+          <td>Probabilistic multiclass \(y \in \{0,1\}^C\)</td>
+          <td>Maximizes likelihood under multinomial distribution; strictly convex when combined with linear parameterizations.</td>
+        </tr>
+        <tr>
+          <td><strong>Hinge Loss</strong></td>
+          <td>\(\mathcal{L}(f(x), y) = \max(0, 1 - y f(x))\)</td>
+          <td>Margin classification \(y \in \{-1, +1\}\)</td>
+          <td>Convex surrogate for 0-1 loss; yields sparse support vectors by penalizing margin violations.</td>
+        </tr>
+        <tr>
+          <td><strong>Exponential Loss</strong></td>
+          <td>\(\mathcal{L}(f(x), y) = e^{-y f(x)}\)</td>
+          <td>Margin classification \(y \in \{-1, +1\}\)</td>
+          <td>Underlying loss function of AdaBoost; places high penalty on misclassified samples.</td>
+        </tr>
+        <tr>
+          <td><strong>0-1 Loss</strong></td>
+          <td>\(\mathcal{L}(f(x), y) = \mathbb{I}(y \ne \text{sign}(f(x)))\)</td>
+          <td>Binary classification</td>
+          <td>True classification error rate; NP-hard and non-convex to optimize directly.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <!-- Section 3 -->
+    <h2 id="bias-variance">3. The Bias-Variance Tradeoff</h2>
+    <p>
+      The generalization performance of a supervised model is governed by the structural tension between model simplicity and model expressiveness.<span class="cite">[<a href="#ref2">2</a>, <a href="#ref4">4</a>]</span>
+    </p>
+
+    <h3 id="bias-variance-decomp">3.1 Analytical Error Decomposition</h3>
+    <p>
+      Assume a true data-generating process \(y = g(x) + \epsilon\), where \(\mathbb{E}[\epsilon] = 0\) and \(\text{Var}(\epsilon) = \sigma^2\). For a fixed query point \(x\) and an estimator \(\hat{f}_{\mathcal{D}}(x)\) fit on random training dataset \(\mathcal{D}\), the expected mean squared test error decomposes analytically into three mutually orthogonal terms:
+    </p>
+    <div class="formula-box">
+      $$\mathbb{E}_{\mathcal{D}, \epsilon} \left[ \big(y - \hat{f}_{\mathcal{D}}(x)\big)^2 \right] = \underbrace{\Big(\mathbb{E}_{\mathcal{D}}[\hat{f}_{\mathcal{D}}(x)] - g(x)\Big)^2}_{\text{Bias}^2} + \underbrace{\mathbb{E}_{\mathcal{D}}\left[ \Big(\hat{f}_{\mathcal{D}}(x) - \mathbb{E}_{\mathcal{D}}[\hat{f}_{\mathcal{D}}(x)]\Big)^2 \right]}_{\text{Variance}} + \underbrace{\sigma^2}_{\text{Irreducible Noise}}$$
+    </div>
+    <ul>
+      <li><strong>\(\text{Bias}^2\):</strong> Systematic error arising from faulty inductive assumptions or insufficient model capacity (underfitting). High-bias models fail to capture underlying functional complexities.</li>
+      <li><strong>\(\text{Variance}\):</strong> Error stemming from estimation sensitivity to idiosyncratic variations across training datasets (overfitting). High-variance models fit sample-specific noise.</li>
+      <li><strong>\(\sigma^2\):</strong> Inherent statistical noise in the data distribution that cannot be eliminated by any learning algorithm regardless of capacity.</li>
+    </ul>
+
+    <h3 id="double-descent">3.2 Overfitting, Underfitting, and Double Descent</h3>
+    <p>
+      Classical statistical learning posits a U-shaped generalization curve where increasing model capacity initially reduces bias, reaches an optimal trade-off point, and then causes test error to escalate due to explosive variance.
+    </p>
+    <p>
+      Modern empirical research demonstrates the <strong>Double Descent</strong> phenomenon (Belkin et al., 2019): as model parameters exceed the number of training samples (the interpolation threshold where training error reaches zero), test risk peaks and subsequently decreases as capacity grows further.<span class="cite">[<a href="#ref5">5</a>]</span> Overparameterized deep networks and kernel machines find minimum-norm interpolating solutions that generalize effectively despite having zero empirical training loss.
+    </p>
+
+    <!-- Section 4 -->
+    <h2 id="algorithm-taxonomy">4. Taxonomy of Supervised Algorithms</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Family</th>
+          <th>Primary Algorithms</th>
+          <th>Inductive Bias</th>
+          <th>Typical Applications</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><strong>Linear &amp; Logistic Models</strong></td>
+          <td>Ordinary Least Squares (OLS), Ridge, Lasso, Logistic Regression, Elastic Net</td>
+          <td>Linear relationship between input features (or basis expansions) and response</td>
+          <td>Econometrics, baseline tabular modeling, risk scoring, fast inference</td>
+        </tr>
+        <tr>
+          <td><strong>Maximum Margin</strong></td>
+          <td>Support Vector Machines (SVM), Support Vector Regression (SVR)</td>
+          <td>Maximal geometric margin between decision boundary and nearest support samples</td>
+          <td>High-dimensional bioinformatics, text categorization, image classification</td>
+        </tr>
+        <tr>
+          <td><strong>Tree Ensembles</strong></td>
+          <td>CART Decision Trees, Random Forests, Gradient Boosted Decision Trees (XGBoost, LightGBM, CatBoost)</td>
+          <td>Hierarchical axis-aligned orthogonal partitions of feature space</td>
+          <td>Tabular data competitions, fraud detection, credit scoring, ranking</td>
+        </tr>
+        <tr>
+          <td><strong>Instance-Based</strong></td>
+          <td>\(k\)-Nearest Neighbors (\(k\)-NN), Locally Weighted Regression</td>
+          <td>Local smoothness; similar instances in feature space share similar target values</td>
+          <td>Low-dimensional spatial interpolation, recommendation baselines</td>
+        </tr>
+        <tr>
+          <td><strong>Deep Neural Architectures</strong></td>
+          <td>Multilayer Perceptrons (MLP), Convolutional Networks (CNN), Supervised Transformers</td>
+          <td>Hierarchical compositional representations across layers</td>
+          <td>Computer vision, speech recognition, machine translation, protein folding</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3 id="linear-models">4.1 Generalized Linear and Logistic Models</h3>
+    <p>
+      Linear models assume an expectation function \(g(\mathbb{E}[Y \mid X]) = w^T x + b\), where \(g\) is a link function.
+    </p>
+    <ul>
+      <li><strong>Ordinary Least Squares:</strong> \(\hat{w} = (X^T X)^{-1} X^T y\). Closed-form analytical solution minimizing sum of squared residuals.</li>
+      <li><strong>Logistic Regression:</strong> Utilizes the logit link function \(\log \frac{p}{1-p} = w^T x + b\), yielding posterior class probabilities modeled through the logistic sigmoid \(\sigma(z) = \frac{1}{1 + e^{-z}}\):
+        <div class="formula-box">
+          $$P(Y=1 \mid X=x) = \frac{1}{1 + e^{-(w^T x + b)}}$$
+        </div>
+      </li>
+    </ul>
+
+    <h3 id="svm-kernels">4.2 Support Vector Machines and Kernel Methods</h3>
+    <p>
+      Support Vector Machines (Cortes &amp; Vapnik, 1995) find a hyperplane \(w^T x + b = 0\) that maximizes the geometric margin \(\frac{2}{\|w\|_2}\) between two separable classes.<span class="cite">[<a href="#ref6">6</a>]</span> The primal optimization problem with soft margin slack variables \(\xi_i\) is:
+    </p>
+    <div class="formula-box">
+      $$\min_{w, b, \xi} \left( \frac{1}{2} \|w\|_2^2 + C \sum_{i=1}^N \xi_i \right) \quad \text{subject to} \quad y_i (w^T x_i + b) \ge 1 - \xi_i, \quad \xi_i \ge 0$$
+    </div>
+    <p>
+      The dual formulation depends only on pairwise inner products \(\langle x_i, x_j \rangle\). The <strong>Kernel Trick</strong> implicitly projects input vectors into a high-dimensional reproducing kernel Hilbert space (RKHS) \(\Phi(x)\) by replacing inner products with a Mercer kernel function \(K(x_i, x_j) = \langle \Phi(x_i), \Phi(x_j) \rangle\), such as the Radial Basis Function (RBF) kernel:
+    </p>
+    <div class="formula-box">
+      $$K_{\text{RBF}}(x_i, x_j) = \exp\left( -\gamma \|x_i - x_j\|_2^2 \right)$$
+    </div>
+
+    <h3 id="tree-ensembles">4.3 Decision Trees and Ensemble Methods</h3>
+    <p>
+      Decision trees recursively partition the input space into hyperrectangles by choosing greedy splits that maximize impurity reduction (measured via Gini impurity \(I_G(p) = 1 - \sum p_k^2\) or Entropy \(H(p) = -\sum p_k \log_2 p_k\)).
+    </p>
+    <ul>
+      <li><strong>Random Forests (Breiman, 2001):</strong> Bagging (Bootstrap Aggregation) ensemble of unpruned deep trees trained on bootstrap resamples of \(\mathcal{D}\) with random feature sub-sampling at each split.<span class="cite">[<a href="#ref7">7</a>]</span> Reduces variance without increasing bias.</li>
+      <li><strong>Gradient Boosted Decision Trees (Friedman, 2001):</strong> Sequential ensemble where each base learner \(h_m(x)\) fits the negative gradient (pseudo-residuals) of the loss function with respect to current ensemble predictions \(F_{m-1}(x)\):<span class="cite">[<a href="#ref8">8</a>]</span>
+        <div class="formula-box">
+          $$r_{im} = -\left[ \frac{\partial \mathcal{L}(y_i, F(x_i))}{\partial F(x_i)} \right]_{F(x) = F_{m-1}(x)}, \quad F_m(x) = F_{m-1}(x) + \eta \, h_m(x)$$
+        </div>
+      </li>
+    </ul>
+
+    <h3 id="deep-architectures">4.4 Supervised Neural Networks</h3>
+    <p>
+      In deep supervised learning, multilayer architectures perform end-to-end feature learning and target mapping. Parameters are optimized via mini-batch stochastic gradient descent (SGD) using backpropagation to compute analytical gradients of empirical loss with respect to all layer weights.<span class="cite">[<a href="#ref9">9</a>]</span>
+    </p>
+
+    <!-- Section 5 -->
+    <h2 id="statistical-learning-theory">5. Generalization Bounds and Statistical Learning Theory</h2>
+    <p>
+      Statistical learning theory provides rigorous mathematical bounds establishing conditions under which empirical risk on training data guarantees bounded true risk on unseen test distributions.
+    </p>
+
+    <h3 id="pac-learning">5.1 PAC Learning Framework</h3>
+    <p>
+      In Leslie Valiant's <strong>Probably Approximately Correct (PAC)</strong> framework (Valiant, 1984), a concept class \(\mathcal{C}\) is PAC-learnable if an algorithm can select a hypothesis \(h \in \mathcal{H}\) such that with probability at least \(1 - \delta\), the generalization error is bounded by \(\epsilon\), using a sample size polynomial in \(\frac{1}{\epsilon}\), \(\frac{1}{\delta}\), and instance size \(d\):<span class="cite">[<a href="#ref10">10</a>]</span>
+    </p>
+    <div class="formula-box">
+      $$\mathbb{P}_{\mathcal{D} \sim P^N}\Big( R(h) \le \hat{R}_{\text{emp}}(h) + \epsilon \Big) \ge 1 - \delta$$
+    </div>
+
+    <h3 id="vc-dimension">5.2 VC Dimension and Rademacher Complexity</h3>
+    <p>
+      For an infinite hypothesis space \(\mathcal{H}\), generalization error is bounded by its <strong>Vapnik-Chervonenkis (VC) Dimension</strong> \(d_{\text{VC}}\), defined as the cardinality of the largest set of points that \(\mathcal{H}\) can shatter (assign all \(2^N\) possible binary label configurations):<span class="cite">[<a href="#ref3">3</a>]</span>
+    </p>
+    <div class="formula-box">
+      $$R(h) \le \hat{R}_{\text{emp}}(h) + \sqrt{\frac{8 d_{\text{VC}} \ln(2N/d_{\text{VC}}) + 8 \ln(4/\delta)}{N}}$$
+    </div>
+    <p>
+      <strong>Rademacher Complexity</strong> \(\mathcal{R}_N(\mathcal{H})\) refines this bound by measuring the empirical capacity of hypothesis space \(\mathcal{H}\) to fit random Rademacher noise \(\sigma_i \in \{-1, +1\}\) on the actual dataset distribution, providing data-dependent generalization guarantees.
+    </p>
+
+    <!-- Section 6 -->
+    <h2 id="references">6. References</h2>
+    <ol>
+      <li id="ref1"><span class="backlink">^</span> Tom M. Mitchell, <em>Machine Learning</em> (McGraw-Hill, 1997).</li>
+      <li id="ref2"><span class="backlink">^</span> Trevor Hastie, Robert Tibshirani, and Jerome Friedman, <em>The Elements of Statistical Learning: Data Mining, Inference, and Prediction</em>, 2nd ed. (Springer, 2009). DOI: <a href="https://doi.org/10.1007/978-0-387-84858-7" target="_blank" rel="noopener">10.1007/978-0-387-84858-7</a>.</li>
+      <li id="ref3"><span class="backlink">^</span> Vladimir N. Vapnik, <em>Statistical Learning Theory</em> (John Wiley &amp; Sons, 1998).</li>
+      <li id="ref4"><span class="backlink">^</span> Christopher M. Bishop, <em>Pattern Recognition and Machine Learning</em> (Springer, 2006).</li>
+      <li id="ref5"><span class="backlink">^</span> Mikhail Belkin, Daniel Hsu, Siyuan Ma, and Soumik Mandal, "Reconciling modern machine-learning practice and the classical bias–variance trade-off," <em>Proceedings of the National Academy of Sciences</em> 116(32), 15849–15854 (2019). DOI: <a href="https://doi.org/10.1073/pnas.1903070116" target="_blank" rel="noopener">10.1073/pnas.1903070116</a>.</li>
+      <li id="ref6"><span class="backlink">^</span> Corinna Cortes and Vladimir Vapnik, "Support-vector networks," <em>Machine Learning</em> 20(3), 273–297 (1995). DOI: <a href="https://doi.org/10.1007/BF00994018" target="_blank" rel="noopener">10.1007/BF00994018</a>.</li>
+      <li id="ref7"><span class="backlink">^</span> Leo Breiman, "Random Forests," <em>Machine Learning</em> 45(1), 5–32 (2001). DOI: <a href="https://doi.org/10.1023/A:1010933404324" target="_blank" rel="noopener">10.1023/A:1010933404324</a>.</li>
+      <li id="ref8"><span class="backlink">^</span> Jerome H. Friedman, "Greedy function approximation: A gradient boosting machine," <em>The Annals of Statistics</em> 29(5), 1189–1232 (2001). DOI: <a href="https://doi.org/10.1214/aos/1013203451" target="_blank" rel="noopener">10.1214/aos/1013203451</a>.</li>
+      <li id="ref9"><span class="backlink">^</span> Yann LeCun, Yoshua Bengio, and Geoffrey Hinton, "Deep learning," <em>Nature</em> 521(7553), 436–444 (2015). DOI: <a href="https://doi.org/10.1038/nature14539" target="_blank" rel="noopener">10.1038/nature14539</a>.</li>
+      <li id="ref10"><span class="backlink">^</span> Leslie G. Valiant, "A theory of the learnable," <em>Communications of the ACM</em> 27(11), 1134–1142 (1984). DOI: <a href="https://doi.org/10.1145/1968.1972" target="_blank" rel="noopener">10.1145/1968.1972</a>.</li>
+    </ol>
+
+    <footer class="meta">
+      <p><a href="#top">Back to top</a></p>
+    </footer>
+  </main>
+  <button id="backToTop" class="back-to-top" aria-label="Back to top" title="Back to top">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M18 15l-6-6-6 6"/>
+    </svg>
+  </button>
+
+  <script>
+    const btt = document.getElementById('backToTop');
+    window.addEventListener('scroll', () => {
+      if (window.scrollY > 250) {
+        btt.classList.add('visible');
+      } else {
+        btt.classList.remove('visible');
+      }
+    }, { passive: true });
+    btt.addEventListener('click', () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  </script>
+</body>
+</html>

--- a/reference/unsupervised-learning/index.html
+++ b/reference/unsupervised-learning/index.html
@@ -1,0 +1,603 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Unsupervised Learning · Reference · Nestor G Pestelos Jr</title>
+  <meta name="description" content="A citable ground-truth reference on Unsupervised Learning: density estimation, k-means, DBSCAN, spectral clustering, PCA, t-SNE, UMAP, VAEs, GANs, and self-supervised pre-training.">
+  <meta property="og:title" content="Unsupervised Learning · Reference">
+  <meta property="og:description" content="A citable ground-truth reference on Unsupervised Learning: density estimation, k-means, DBSCAN, spectral clustering, PCA, t-SNE, UMAP, VAEs, GANs, and self-supervised pre-training.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://ngpestelos.com/reference/unsupervised-learning/">
+  <link rel="canonical" href="https://ngpestelos.com/reference/unsupervised-learning/">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=20260813f">
+  <link rel="icon" href="/favicon-192.png?v=20260813f" type="image/png" sizes="192x192">
+  <link rel="icon" href="/favicon-32.png?v=20260813f" type="image/png" sizes="32x32">
+  <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
+  <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="stylesheet" href="/style.css?v=20260903e">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TLBY8P4GG9');
+  </script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css" crossorigin="anonymous">
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
+    onload="renderMathInElement(document.body, {
+      delimiters: [
+        {left: '$$', right: '$$', display: true},
+        {left: '\\[', right: '\\]', display: true},
+        {left: '\\(', right: '\\)', display: false}
+      ]
+    });"></script>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; scroll-behavior: smooth; }
+    body {
+      line-height: 1.6;
+    }
+    main {
+      max-width: 48rem;
+      margin: 0 auto;
+      padding: 1.4rem 1.4rem 4rem;
+    }
+    .back {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .back a { color: var(--link); text-decoration: none; }
+    .back a:hover { text-decoration: underline; }
+    .kicker {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.78rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--mute);
+      margin-bottom: 0.2rem;
+    }
+    h1 {
+      font-size: clamp(1.9rem, 5vw, 2.4rem);
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.4rem;
+      margin-bottom: 0.8rem;
+    }
+    .subtitle {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 1rem;
+      color: var(--mute);
+      margin-bottom: 1.6rem;
+      line-height: 1.5;
+    }
+    .companion-box {
+      background: var(--well);
+      border: 1px solid var(--line);
+      border-left: 4px solid var(--link);
+      border-radius: 4px;
+      padding: 1rem 1.3rem;
+      margin-bottom: 1.8rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+    }
+    .companion-box h2 {
+      font-size: 0.95rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-top: 0;
+      margin-bottom: 0.5rem;
+      border-bottom: none;
+      padding-bottom: 0;
+      color: var(--ink);
+    }
+    .companion-box ul {
+      list-style: none;
+      padding-left: 0;
+      margin-bottom: 0;
+      font-size: 0.92rem;
+    }
+    .companion-box li { margin-bottom: 0.4rem; }
+    .companion-box li:last-child { margin-bottom: 0; }
+    .companion-box a { color: var(--link); text-decoration: none; }
+    .companion-box a:hover { text-decoration: underline; }
+    .toc {
+      background: var(--well);
+      border: 1px solid var(--line);
+      border-radius: 4px;
+      padding: 1.1rem 1.4rem;
+      margin-bottom: 2rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.9rem;
+    }
+    .toc h2 {
+      font-size: 1rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: 0.5rem;
+      color: var(--ink);
+      border-bottom: none;
+      padding-bottom: 0;
+      margin-top: 0;
+    }
+    .toc ol {
+      padding-left: 1.3rem;
+      margin-bottom: 0;
+    }
+    .toc ol ol {
+      padding-left: 1.2rem;
+      margin-top: 0.15rem;
+    }
+    .toc li { margin: 0.25rem 0; }
+    .toc a { color: var(--link); text-decoration: none; }
+    .toc a:hover { text-decoration: underline; }
+    h2 {
+      font-size: 1.45rem;
+      font-weight: 700;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.3rem;
+      margin-top: 2.2rem;
+      margin-bottom: 0.9rem;
+      color: var(--ink);
+    }
+    h3 {
+      font-size: 1.15rem;
+      font-weight: 700;
+      margin-top: 1.4rem;
+      margin-bottom: 0.3rem;
+      color: var(--ink);
+    }
+    p { margin-bottom: 1rem; }
+    ul, ol { margin-bottom: 1rem; padding-left: 1.5rem; }
+    li { margin-bottom: 0.4rem; }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1.2rem 0 1.8rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.88rem;
+    }
+    th, td {
+      border: 1px solid var(--line);
+      padding: 0.55rem 0.75rem;
+      text-align: left;
+      vertical-align: top;
+    }
+    th { background: var(--well); font-weight: 600; }
+    code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.88em;
+      background: #f1f3f5;
+      padding: 0.15em 0.35em;
+      border-radius: 3px;
+    }
+    .cite {
+      font-size: 0.75em;
+      vertical-align: super;
+      line-height: 0;
+      text-decoration: none;
+    }
+    .cite a { text-decoration: none; }
+    .formula-box {
+      text-align: center;
+      margin: 1.2rem 0;
+      background: var(--well);
+      padding: 0.8rem;
+      border-radius: 4px;
+      border: 1px solid var(--line);
+      overflow-x: auto;
+    }
+    #references {
+      font-size: 0.92rem;
+    }
+    #references ol {
+      padding-left: 1.5rem;
+    }
+    #references li {
+      margin-bottom: 0.5rem;
+    }
+    #references .backlink {
+      margin-right: 0.3rem;
+    }
+    footer.meta {
+      border-top: 1px solid var(--line);
+      margin-top: 3rem;
+      padding-top: 1.4rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+    }
+    footer.meta a { color: var(--link); }
+    @media print {
+      .back {font-family:"Segoe UI", Helvetica, Arial, sans-serif;display: none;}
+    }
+    .back-to-top {
+      position: fixed;
+      bottom: 1.5rem;
+      right: 1.5rem;
+      width: 2.6rem;
+      height: 2.6rem;
+      border-radius: 50%;
+      background: var(--bg);
+      color: var(--ink);
+      border: 1px solid var(--line);
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      opacity: 0;
+      visibility: hidden;
+      transform: translateY(8px);
+      transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease, background 0.15s ease, border-color 0.15s ease;
+      z-index: 100;
+    }
+    .back-to-top.visible {
+      opacity: 1;
+      visibility: visible;
+      transform: translateY(0);
+    }
+    .back-to-top:hover {
+      background: var(--well);
+      border-color: var(--link);
+      color: var(--link);
+    }
+    .back-to-top:focus-visible {
+      outline: 2px solid var(--link);
+      outline-offset: 2px;
+    }
+    @media print {
+      .back-to-top { display: none !important; }
+    }
+  </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Unsupervised Learning","description":"A citable ground-truth reference on Unsupervised Learning: density estimation, k-means, DBSCAN, spectral clustering, PCA, t-SNE, UMAP, VAEs, GANs, and self-supervised pre-training.","url":"https://ngpestelos.com/reference/unsupervised-learning/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
+</head>
+<body class="reference">
+  <main id="top">
+    <p class="back"><a href="/reference/">← Reference</a> · <a href="/">Nestor G Pestelos Jr</a> · <a href="#" onclick="window.print(); return false;">Print this page</a></p>
+    <p class="kicker">Machine Learning</p>
+    <h1>Unsupervised Learning</h1>
+    <p class="subtitle">A citable reference on Unsupervised Learning: density estimation, clustering taxonomy, linear and non-linear dimensionality reduction, manifold learning, latent variable models, and self-supervised representations.</p>
+
+    <div class="companion-box">
+      <h2>See Also &amp; Related References</h2>
+      <ul>
+        <li>📖 <a href="/reference/machine-learning/"><strong>Reference: Machine Learning</strong></a>: Empirical risk minimization, learning paradigms, and generalization theory.</li>
+        <li>📖 <a href="/reference/supervised-learning/"><strong>Reference: Supervised Learning</strong></a>: Labeled mapping functions, empirical risk minimization, loss functions, and bias-variance tradeoff.</li>
+        <li>📖 <a href="/reference/reinforcement-learning/"><strong>Reference: Reinforcement Learning</strong></a>: Markov Decision Processes, policy gradients, and environmental reward optimization.</li>
+        <li>📖 <a href="/reference/embeddings/"><strong>Reference: Embeddings</strong></a>: Dense vector representations, semantic manifolds, and metric spaces.</li>
+        <li>📖 <a href="/reference/autoregressive/"><strong>Reference: Autoregressive Models</strong></a>: Next-token prediction, sequential factorization, and causal language modeling.</li>
+      </ul>
+    </div>
+
+    <nav class="toc" aria-label="Contents">
+      <h2>Contents</h2>
+      <ol>
+        <li><a href="#formal-problem">1. Formal Problem Formulation</a>
+          <ol>
+            <li><a href="#data-setting">1.1 Unlabeled Experience and Latent Structure</a></li>
+            <li><a href="#density-estimation">1.2 Probability Density Estimation</a></li>
+          </ol>
+        </li>
+        <li><a href="#clustering">2. Taxonomy of Clustering Algorithms</a>
+          <ol>
+            <li><a href="#kmeans">2.1 Partitioning: k-Means and k-Medoids</a></li>
+            <li><a href="#hierarchical">2.2 Hierarchical Clustering and Linkage Criteria</a></li>
+            <li><a href="#density-clustering">2.3 Density-Based: DBSCAN and HDBSCAN</a></li>
+            <li><a href="#spectral-clustering">2.4 Spectral Clustering and Graph Laplacians</a></li>
+          </ol>
+        </li>
+        <li><a href="#dimensionality-reduction">3. Dimensionality Reduction and Manifold Learning</a>
+          <ol>
+            <li><a href="#pca">3.1 Principal Component Analysis (PCA)</a></li>
+            <li><a href="#matrix-factorization">3.2 Matrix Factorization and Independent Component Analysis</a></li>
+            <li><a href="#tsne-umap">3.3 Non-Linear Manifold Learning: t-SNE and UMAP</a></li>
+          </ol>
+        </li>
+        <li><a href="#generative-latent">4. Generative Modeling and Latent Variable Models</a>
+          <ol>
+            <li><a href="#autoencoders">4.1 Autoencoder Architectures</a></li>
+            <li><a href="#vaes">4.2 Variational Autoencoders (VAEs)</a></li>
+            <li><a href="#gans">4.3 Generative Adversarial Networks (GANs)</a></li>
+            <li><a href="#self-supervised">4.4 Self-Supervised Learning and Masked Modeling</a></li>
+          </ol>
+        </li>
+        <li><a href="#cluster-validation">5. Cluster Validation Metrics</a></li>
+        <li><a href="#references">6. References</a></li>
+      </ol>
+    </nav>
+
+    <!-- Section 1 -->
+    <h2 id="formal-problem">1. Formal Problem Formulation</h2>
+    <p>
+      <strong>Unsupervised Learning</strong> is a machine learning paradigm in which an algorithm extracts underlying patterns, latent representations, or probability distributions from unlabeled datasets without external supervision or ground-truth targets.<span class="cite">[<a href="#ref1">1</a>, <a href="#ref2">2</a>]</span> The learner discovers intrinsic geometric, topological, or statistical structure within the input space.
+    </p>
+
+    <h3 id="data-setting">1.1 Unlabeled Experience and Latent Structure</h3>
+    <p>
+      The training dataset \(\mathcal{D}\) consists of \(N\) observation vectors sampled independently from an unknown probability distribution \(P(X)\) defined over feature space \(\mathcal{X} \subseteq \mathbb{R}^d\):
+    </p>
+    <div class="formula-box">
+      $$\mathcal{D} = \{x_1, x_2, \dots, x_N\} \sim P(X)^N$$
+    </div>
+    <p>
+      Unlike supervised learning, no target vector \(y_i\) accompanies each sample. Unsupervised objectives generally solve one of four fundamental mathematical tasks:
+    </p>
+    <ul>
+      <li><strong>Density Estimation:</strong> Reconstruct the probability density function \(\hat{p}(x)\) that generated \(\mathcal{D}\).</li>
+      <li><strong>Clustering:</strong> Partition the sample indices \(\{1, \dots, N\}\) into \(K\) disjoint or overlapping subsets based on pairwise similarity metrics.</li>
+      <li><strong>Dimensionality Reduction:</strong> Learn a mapping \(g: \mathbb{R}^d \to \mathbb{R}^k\) (where \(k \ll d\)) that preserves critical geometric distances or topological relationships.</li>
+      <li><strong>Generative Representation:</strong> Learn a parameterized mapping from a low-dimensional prior distribution \(p(z)\) over latent space \(\mathcal{Z}\) to the data manifold \(\mathcal{X}\).</li>
+    </ul>
+
+    <h3 id="density-estimation">1.2 Probability Density Estimation</h3>
+    <p>
+      In <strong>Parametric Density Estimation</strong>, the data distribution is modeled as a parameterized family \(p(x \mid \theta)\). In a Gaussian Mixture Model (GMM) with \(K\) components, the marginal density is a convex combination of multivariate normals:<span class="cite">[<a href="#ref1">1</a>]</span>
+    </p>
+    <div class="formula-box">
+      $$p(x \mid \theta) = \sum_{k=1}^K \pi_k \, \mathcal{N}(x \mid \mu_k, \Sigma_k), \quad \sum_{k=1}^K \pi_k = 1, \quad \pi_k \ge 0$$
+    </div>
+    <p>
+      Parameters \(\theta = \{\pi_k, \mu_k, \Sigma_k\}_{k=1}^K\) are estimated using the <strong>Expectation-Maximization (EM)</strong> algorithm (Dempster et al., 1977), which iteratively alternates between computing latent component responsibilities in the E-step and updating cluster parameters in the M-step:<span class="cite">[<a href="#ref3">3</a>]</span>
+    </p>
+    <div class="formula-box">
+      $$\gamma_{ik} = \frac{\pi_k \mathcal{N}(x_i \mid \mu_k, \Sigma_k)}{\sum_{j=1}^K \pi_j \mathcal{N}(x_i \mid \mu_j, \Sigma_j)}, \quad \mu_k^{\text{new}} = \frac{\sum_{i=1}^N \gamma_{ik} x_i}{\sum_{i=1}^N \gamma_{ik}}$$
+    </div>
+    <p>
+      In <strong>Non-Parametric Density Estimation</strong>, Kernel Density Estimation (KDE) computes the empirical density without distributional assumptions via kernel function \(K\):
+    </p>
+    <div class="formula-box">
+      $$\hat{p}(x) = \frac{1}{N h^d} \sum_{i=1}^N K\left( \frac{x - x_i}{h} \right)$$
+    </div>
+
+    <!-- Section 2 -->
+    <h2 id="clustering">2. Taxonomy of Clustering Algorithms</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Clustering Paradigm</th>
+          <th>Representative Algorithms</th>
+          <th>Optimization Objective / Criterion</th>
+          <th>Cluster Shape Assumption</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><strong>Partitioning</strong></td>
+          <td>\(k\)-Means, \(k\)-Medoids (PAM), \(k\)-Means++</td>
+          <td>Minimize Within-Cluster Sum of Squares (WCSS)</td>
+          <td>Spherical, convex, equal variance</td>
+        </tr>
+        <tr>
+          <td><strong>Hierarchical</strong></td>
+          <td>Agglomerative (Single, Complete, Average, Ward)</td>
+          <td>Iterative pairwise merge based on linkage distance metric</td>
+          <td>Arbitrary tree hierarchies; dendrogram-based</td>
+        </tr>
+        <tr>
+          <td><strong>Density-Based</strong></td>
+          <td>DBSCAN, OPTICS, HDBSCAN</td>
+          <td>Discover connected dense regions separated by low-density noise</td>
+          <td>Arbitrary non-convex shapes; robust to outliers</td>
+        </tr>
+        <tr>
+          <td><strong>Model-Based</strong></td>
+          <td>Gaussian Mixture Models (GMM), Latent Dirichlet Allocation (LDA)</td>
+          <td>Maximize log-likelihood of mixture distributions via EM</td>
+          <td>Ellipsoidal distributions with variable covariance</td>
+        </tr>
+        <tr>
+          <td><strong>Graph / Spectral</strong></td>
+          <td>Spectral Clustering, Normalized Cuts</td>
+          <td>Min-cut partition of graph Laplacian eigenvectors</td>
+          <td>Complex manifolds, non-linear connectivity</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3 id="kmeans">2.1 Partitioning: k-Means and k-Medoids</h3>
+    <p>
+      The standard <strong>\(k\)-Means</strong> algorithm (MacQueen, 1967; Lloyd, 1982) partitions \(N\) observations into \(K\) disjoint sets \(S = \{S_1, \dots, S_K\}\) to minimize the Within-Cluster Sum of Squares (WCSS):<span class="cite">[<a href="#ref4">4</a>, <a href="#ref5">5</a>]</span>
+    </p>
+    <div class="formula-box">
+      $$\arg\min_S \sum_{k=1}^K \sum_{x \in S_k} \|x - \mu_k\|_2^2, \quad \text{where } \mu_k = \frac{1}{|S_k|} \sum_{x \in S_k} x$$
+    </div>
+    <p>
+      Because finding the global minimum is NP-hard in general metric spaces, Lloyd's heuristic alternates between assigning each sample to its nearest centroid \(\mu_k\) and recomputing centroids as sample means. <strong>\(k\)-Means++</strong> (Arthur &amp; Vassilvitskii, 2007) seeds initial centers with probability proportional to squared distance \(D(x)^2\) from existing centers, guaranteeing an \(O(\log K)\) competitive approximation ratio.<span class="cite">[<a href="#ref6">6</a>]</span>
+    </p>
+
+    <h3 id="hierarchical">2.2 Hierarchical Clustering and Linkage Criteria</h3>
+    <p>
+      Agglomerative hierarchical clustering begins with each point in its own singleton cluster and sequentially merges the closest pair of clusters until all points reside in a single root. Linkage functions define inter-cluster distance \(D(A, B)\):
+    </p>
+    <ul>
+      <li><strong>Single Linkage:</strong> \(D(A, B) = \min_{a \in A, b \in B} \|a - b\|\) (susceptible to chaining artifacts).</li>
+      <li><strong>Complete Linkage:</strong> \(D(A, B) = \max_{a \in A, b \in B} \|a - b\|\) (favors compact, equal-diameter clusters).</li>
+      <li><strong>Average Linkage (UPGMA):</strong> \(D(A, B) = \frac{1}{|A||B|} \sum_{a \in A} \sum_{b \in B} \|a - b\|\).</li>
+      <li><strong>Ward's Linkage:</strong> Minimizes total within-cluster variance increase upon merging:
+        <div class="formula-box">
+          $$\Delta \text{ESS}_{AB} = \frac{|A||B|}{|A| + |B|} \|\mu_A - \mu_B\|_2^2$$
+        </div>
+      </li>
+    </ul>
+
+    <h3 id="density-clustering">2.3 Density-Based: DBSCAN and HDBSCAN</h3>
+    <p>
+      <strong>DBSCAN</strong> (Ester et al., 1996) defines clusters as continuous density-reachable components.<span class="cite">[<a href="#ref7">7</a>]</span> For a radius \(\epsilon\) and minimum points threshold \(\text{MinPts}\):
+    </p>
+    <ul>
+      <li>A point \(p\) is a <strong>Core Point</strong> if \(|N_\epsilon(p)| \ge \text{MinPts}\), where \(N_\epsilon(p) = \{q \in \mathcal{D} \mid \|p - q\| \le \epsilon\}\).</li>
+      <li>A point \(q\) is <strong>Directly Density-Reachable</strong> from \(p\) if \(q \in N_\epsilon(p)\) and \(p\) is a core point.</li>
+      <li>Points that are not density-reachable from any core point are classified as noise (outliers).</li>
+    </ul>
+
+    <h3 id="spectral-clustering">2.4 Spectral Clustering and Graph Laplacians</h3>
+    <p>
+      Spectral clustering maps non-linearly separable data into a subspace defined by the lowest eigenvectors of a graph Laplacian.<span class="cite">[<a href="#ref8">8</a>]</span> Given an affinity adjacency matrix \(W\) and degree matrix \(D_{ii} = \sum_j W_{ij}\):
+    </p>
+    <ul>
+      <li><strong>Unnormalized Graph Laplacian:</strong> \(L = D - W\).</li>
+      <li><strong>Symmetric Normalized Laplacian:</strong> \(L_{\text{sym}} = D^{-1/2} L D^{-1/2} = I - D^{-1/2} W D^{-1/2}\).</li>
+      <li><strong>Random Walk Laplacian:</strong> \(L_{\text{rw}} = D^{-1} L = I - D^{-1} W\).</li>
+    </ul>
+    <p>
+      By the Rayleigh-Ritz theorem, the first \(K\) eigenvectors of \(L_{\text{sym}}\) solve the continuous relaxation of the Normalized Cut (NCut) graph partitioning problem.
+    </p>
+
+    <!-- Section 3 -->
+    <h2 id="dimensionality-reduction">3. Dimensionality Reduction and Manifold Learning</h2>
+    <p>
+      High-dimensional representations frequently lie near lower-dimensional smooth manifolds embedded in \(\mathbb{R}^d\). Dimensionality reduction algorithms extract these intrinsic degrees of freedom.
+    </p>
+
+    <h3 id="pca">3.1 Principal Component Analysis (PCA)</h3>
+    <p>
+      <strong>Principal Component Analysis</strong> (Pearson, 1901; Hotelling, 1933) finds an orthogonal linear transformation that projects centered data \(X \in \mathbb{R}^{N \times d}\) onto a \(k\)-dimensional subspace while maximizing preserved variance (or equivalently, minimizing reconstruction error).<span class="cite">[<a href="#ref9">9</a>]</span>
+    </p>
+    <div class="formula-box">
+      $$\Sigma = \frac{1}{N} X^T X = V \Lambda V^T, \quad Z = X V_k$$
+    </div>
+    <p>
+      where \(V_k \in \mathbb{R}^{d \times k}\) contains the eigenvectors corresponding to the \(k\) largest eigenvalues \(\lambda_1 \ge \lambda_2 \ge \dots \ge \lambda_k\) of sample covariance matrix \(\Sigma\). Via Singular Value Decomposition (SVD) \(X = U S V^T\), the principal coordinates are computed directly as \(Z = U_k S_k\).
+    </p>
+
+    <h3 id="matrix-factorization">3.2 Matrix Factorization and Independent Component Analysis</h3>
+    <ul>
+      <li><strong>Non-Negative Matrix Factorization (NMF):</strong> Decomposes non-negative matrix \(V \approx W H\) subject to \(W \ge 0, H \ge 0\), learning additive, parts-based representations.</li>
+      <li><strong>Independent Component Analysis (ICA):</strong> Assumes observed signals \(x = A s\) are linear mixtures of statistically independent, non-Gaussian source signals \(s\). Algorithms maximize non-Gaussianity (measured via kurtosis or negentropy) to estimate unmixing matrix \(W = A^{-1}\).</li>
+    </ul>
+
+    <h3 id="tsne-umap">3.3 Non-Linear Manifold Learning: t-SNE and UMAP</h3>
+    <p>
+      <strong>t-SNE</strong> (van der Maaten &amp; Hinton, 2008) converts pairwise Euclidean distances in high-dimensional space into conditional Gaussian probabilities \(p_{j \mid i}\) and models low-dimensional points \(y_i, y_j \in \mathbb{R}^2\) using a heavy-tailed Student-t distribution \(q_{ij}\):<span class="cite">[<a href="#ref10">10</a>]</span>
+    </p>
+    <div class="formula-box">
+      $$p_{j \mid i} = \frac{\exp(-\|x_i - x_j\|^2 / 2\sigma_i^2)}{\sum_{k \ne i} \exp(-\|x_i - x_k\|^2 / 2\sigma_i^2)}, \quad q_{ij} = \frac{(1 + \|y_i - y_j\|^2)^{-1}}{\sum_{k} \sum_{l \ne k} (1 + \|y_k - y_l\|^2)^{-1}}$$
+    </div>
+    <p>
+      The low-dimensional embedding is optimized by minimizing the Kullback-Leibler divergence \(\text{KL}(P \,\|\, Q) = \sum_{i \ne j} p_{ij} \log \frac{p_{ij}}{q_{ij}}\) via gradient descent. The heavy tail of the Student-t distribution eliminates the crowding problem by allowing moderate high-dimensional distances to expand in low dimensions.
+    </p>
+    <p>
+      <strong>UMAP</strong> (McInnes et al., 2018) builds on Riemannian geometry and algebraic topology, modeling the manifold with fuzzy simplicial sets and optimizing cross-entropy between high- and low-dimensional fuzzy sets.<span class="cite">[<a href="#ref11">11</a>]</span> UMAP preserves both local and global manifold structure while exhibiting faster computational scaling than t-SNE.
+    </p>
+
+    <!-- Section 4 -->
+    <h2 id="generative-latent">4. Generative Modeling and Latent Variable Models</h2>
+    <p>
+      Deep unsupervised architectures learn generative representations that map simple latent priors to complex target data manifolds.
+    </p>
+
+    <h3 id="autoencoders">4.1 Autoencoder Architectures</h3>
+    <p>
+      An autoencoder consists of an encoder \(z = f_\phi(x)\) and a decoder \(\hat{x} = g_\theta(z)\) trained to minimize reconstruction error \(\mathcal{L}(x, g_\theta(f_\phi(x)))\). Undercomplete bottlenecks (\(\dim(z) \ll \dim(x)\)), sparsity penalties (\(L_1\) norm on \(z\)), or contractive Jacobian regularizers (\(\|J_f(x)\|_F^2\)) force the network to discard noise and retain latent manifold coordinates.
+    </p>
+
+    <h3 id="vaes">4.2 Variational Autoencoders (VAEs)</h3>
+    <p>
+      <strong>Variational Autoencoders</strong> (Kingma &amp; Welling, 2013; Rezende et al., 2014) introduce probabilistic latent variables \(z \sim p(z) = \mathcal{N}(0, I)\).<span class="cite">[<a href="#ref12">12</a>]</span> Because the true posterior \(p_\theta(z \mid x)\) is intractable, a variational encoder \(q_\phi(z \mid x) = \mathcal{N}(\mu_\phi(x), \Sigma_\phi(x))\) approximates it by maximizing the <strong>Evidence Lower Bound (ELBO)</strong>:
+    </p>
+    <div class="formula-box">
+      $$\log p_\theta(x) \ge \mathcal{L}_{\text{ELBO}}(\theta, \phi; x) = \mathbb{E}_{q_\phi(z \mid x)} \left[ \log p_\theta(x \mid z) \right] - D_{\text{KL}}\big(q_\phi(z \mid x) \,\|\, p(z)\big)$$
+    </div>
+    <p>
+      Differentiability during backpropagation is achieved through the <strong>Reparameterization Trick</strong>, expressing stochastic latent vectors as a deterministic transformation of standard normal noise:
+    </p>
+    <div class="formula-box">
+      $$z = \mu_\phi(x) + \sigma_\phi(x) \odot \epsilon, \quad \text{where } \epsilon \sim \mathcal{N}(0, I)$$
+    </div>
+
+    <h3 id="gans">4.3 Generative Adversarial Networks (GANs)</h3>
+    <p>
+      <strong>Generative Adversarial Networks</strong> (Goodfellow et al., 2014) formulate generative modeling as a two-player zero-sum minimax game between a Generator \(G_\theta\) and a Discriminator \(D_\phi\):<span class="cite">[<a href="#ref13">13</a>]</span>
+    </p>
+    <div class="formula-box">
+      $$\min_G \max_D V(D, G) = \mathbb{E}_{x \sim P_{\text{data}}(x)} \left[ \log D(x) \right] + \mathbb{E}_{z \sim p_z(z)} \left[ \log\big(1 - D(G(z))\big) \right]$$
+    </div>
+    <p>
+      For an optimal discriminator \(D^*(x) = \frac{p_{\text{data}}(x)}{p_{\text{data}}(x) + p_g(x)}\), the minimax objective reduces to minimizing the Jensen-Shannon divergence \(2 D_{\text{JS}}(p_{\text{data}} \,\|\, p_g) - 2 \log 2\) between the data distribution and the model distribution.
+    </p>
+
+    <h3 id="self-supervised">4.4 Self-Supervised Learning and Masked Modeling</h3>
+    <p>
+      In modern machine learning, self-supervised learning uses structural aspects of the unlabeled data itself as supervisory targets.
+    </p>
+    <ul>
+      <li><strong>Masked Autoencoding (MAE / BERT):</strong> Masks a fraction of input tokens or image patches and trains a transformer to reconstruct missing components from unmasked context.</li>
+      <li><strong>Contrastive Learning (SimCLR / InfoNCE):</strong> Maximizes agreement between differently augmented views of the same sample while minimizing similarity to negative distractors using the InfoNCE objective:<span class="cite">[<a href="#ref14">14</a>]</span>
+        <div class="formula-box">
+          $$\mathcal{L}_{\text{InfoNCE}} = -\log \frac{\exp(\text{sim}(z_i, z_j)/\tau)}{\sum_{k=1}^{2K} \mathbb{I}_{[k \ne i]} \exp(\text{sim}(z_i, z_k)/\tau)}$$
+        </div>
+      </li>
+    </ul>
+
+    <!-- Section 5 -->
+    <h2 id="cluster-validation">5. Cluster Validation Metrics</h2>
+    <p>
+      Because unsupervised tasks lack external ground truth, clustering quality is evaluated via internal geometry or external partition comparisons:
+    </p>
+    <ul>
+      <li><strong>Silhouette Coefficient:</strong> For sample \(i\), let \(a(i)\) be mean intra-cluster distance and \(b(i)\) be minimum mean distance to points in any other cluster:
+        <div class="formula-box">
+          $$s(i) = \frac{b(i) - a(i)}{\max(a(i), b(i))}, \quad s(i) \in [-1, 1]$$
+        </div>
+      </li>
+      <li><strong>Davies-Bouldin Index:</strong> Measures the similarity between each cluster \(R_{ij} = \frac{s_i + s_j}{d(\mu_i, \mu_j)}\) and computes \(\frac{1}{K}\sum_{i} \max_{j \ne i} R_{ij}\); lower values indicate superior partition separation.</li>
+      <li><strong>Adjusted Rand Index (ARI):</strong> Evaluates agreement between cluster assignments and ground-truth classes, normalized for chance:
+        <div class="formula-box">
+          $$\text{ARI} = \frac{\text{Index} - \text{Expected Index}}{\text{Max Index} - \text{Expected Index}} \in [-1, 1]$$
+        </div>
+      </li>
+    </ul>
+
+    <!-- Section 6 -->
+    <h2 id="references">6. References</h2>
+    <ol>
+      <li id="ref1"><span class="backlink">^</span> Christopher M. Bishop, <em>Pattern Recognition and Machine Learning</em> (Springer, 2006).</li>
+      <li id="ref2"><span class="backlink">^</span> Trevor Hastie, Robert Tibshirani, and Jerome Friedman, <em>The Elements of Statistical Learning: Data Mining, Inference, and Prediction</em>, 2nd ed. (Springer, 2009). DOI: <a href="https://doi.org/10.1007/978-0-387-84858-7" target="_blank" rel="noopener">10.1007/978-0-387-84858-7</a>.</li>
+      <li id="ref3"><span class="backlink">^</span> Arthur P. Dempster, Nan M. Laird, and Donald B. Rubin, "Maximum likelihood from incomplete data via the EM algorithm," <em>Journal of the Royal Statistical Society: Series B</em> 39(1), 1–38 (1977). DOI: <a href="https://doi.org/10.1111/j.2517-6161.1977.tb01600.x" target="_blank" rel="noopener">10.1111/j.2517-6161.1977.tb01600.x</a>.</li>
+      <li id="ref4"><span class="backlink">^</span> J. B. MacQueen, "Some Methods for classification and Analysis of Multivariate Observations," <em>Proceedings of 5th Berkeley Symposium on Mathematical Statistics and Probability</em> 1, 281–297 (1967).</li>
+      <li id="ref5"><span class="backlink">^</span> Stuart P. Lloyd, "Least squares quantization in PCM," <em>IEEE Transactions on Information Theory</em> 28(2), 129–137 (1982). DOI: <a href="https://doi.org/10.1109/TIT.1982.1056489" target="_blank" rel="noopener">10.1109/TIT.1982.1056489</a>.</li>
+      <li id="ref6"><span class="backlink">^</span> David Arthur and Sergei Vassilvitskii, "k-means++: The advantages of careful seeding," <em>Proceedings of the Eighteenth Annual ACM-SIAM Symposium on Discrete Algorithms</em>, 1027–1035 (2007). URL: <a href="https://dl.acm.org/doi/10.5555/1283383.1283494" target="_blank" rel="noopener">ACM Digital Library</a>.</li>
+      <li id="ref7"><span class="backlink">^</span> Martin Ester, Hans-Peter Kriegel, Jörg Sander, and Xiaowei Xu, "A density-based algorithm for discovering clusters in large spatial databases with noise," <em>Proceedings of the Second International Conference on Knowledge Discovery and Data Mining (KDD-96)</em>, 226–231 (1996).</li>
+      <li id="ref8"><span class="backlink">^</span> Ulrike von Luxburg, "A tutorial on spectral clustering," <em>Statistics and Computing</em> 17(4), 395–416 (2007). DOI: <a href="https://doi.org/10.1007/s11222-007-9033-z" target="_blank" rel="noopener">10.1007/s11222-007-9033-z</a>.</li>
+      <li id="ref9"><span class="backlink">^</span> Karl Pearson, "On lines and planes of closest fit to systems of points in space," <em>Philosophical Magazine</em> 2(11), 559–572 (1901). DOI: <a href="https://doi.org/10.1080/14786440109462720" target="_blank" rel="noopener">10.1080/14786440109462720</a>.</li>
+      <li id="ref10"><span class="backlink">^</span> Laurens van der Maaten and Geoffrey Hinton, "Visualizing data using t-SNE," <em>Journal of Machine Learning Research</em> 9, 2579–2605 (2008). URL: <a href="https://www.jmlr.org/papers/v9/vandermaaten08a.html" target="_blank" rel="noopener">JMLR</a>.</li>
+      <li id="ref11"><span class="backlink">^</span> Leland McInnes, John Healy, and James Melville, "UMAP: Uniform Manifold Approximation and Projection for Dimension Reduction," <em>arXiv:1802.03426</em> (2018). DOI: <a href="https://doi.org/10.48550/arXiv.1802.03426" target="_blank" rel="noopener">10.48550/arXiv.1802.03426</a>.</li>
+      <li id="ref12"><span class="backlink">^</span> Diederik P. Kingma and Max Welling, "Auto-Encoding Variational Bayes," <em>International Conference on Learning Representations (ICLR 2014)</em>, <em>arXiv:1312.6114</em> (2013). DOI: <a href="https://doi.org/10.48550/arXiv.1312.6114" target="_blank" rel="noopener">10.48550/arXiv.1312.6114</a>.</li>
+      <li id="ref13"><span class="backlink">^</span> Ian J. Goodfellow, Jean Pouget-Abadie, Mehdi Mirza, Bing Xu, David Warde-Farley, Sherjil Ozair, Aaron Courville, and Yoshua Bengio, "Generative Adversarial Nets," <em>Advances in Neural Information Processing Systems</em> 27 (NeurIPS 2014). URL: <a href="https://proceedings.neurips.cc/paper/2014/file/5ca3e9b122f61f8f06494c97b1afccf3-Paper.pdf" target="_blank" rel="noopener">NeurIPS Proceedings</a>.</li>
+      <li id="ref14"><span class="backlink">^</span> Ting Chen, Simon Kornblith, Mohammad Norouzi, and Geoffrey Hinton, "A Simple Framework for Contrastive Learning of Visual Representations," <em>International Conference on Machine Learning (ICML 2020)</em>, <em>arXiv:2002.05709</em> (2020). DOI: <a href="https://doi.org/10.48550/arXiv.2002.05709" target="_blank" rel="noopener">10.48550/arXiv.2002.05709</a>.</li>
+    </ol>
+
+    <footer class="meta">
+      <p><a href="#top">Back to top</a></p>
+    </footer>
+  </main>
+  <button id="backToTop" class="back-to-top" aria-label="Back to top" title="Back to top">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M18 15l-6-6-6 6"/>
+    </svg>
+  </button>
+
+  <script>
+    const btt = document.getElementById('backToTop');
+    window.addEventListener('scroll', () => {
+      if (window.scrollY > 250) {
+        btt.classList.add('visible');
+      } else {
+        btt.classList.remove('visible');
+      }
+    }, { passive: true });
+    btt.addEventListener('click', () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  </script>
+</body>
+</html>

--- a/reference/vector-search/index.html
+++ b/reference/vector-search/index.html
@@ -258,6 +258,7 @@
     <section class="see-also" id="see-also">
       <h2>See also</h2>
       <ul>
+        <li><a href="/reference/vector/">Vector (Mathematics and Computing)</a> &middot; Vector space axioms, inner products, norms, and linear algebra foundations.</li>
         <li><a href="/eli5/vector-search/">ELI5: Vector Search</a> &middot; Visual picture-book explainer of finding ideas with a concept map.</li>
         <li><a href="/reference/embeddings/">Embeddings and Vector Representations</a> &middot; High-dimensional geometry and representation learning.</li>
         <li><a href="/reference/retrieval-augmented-generation/">Retrieval-Augmented Generation (RAG)</a> &middot; Augmenting LLM context with retrieved vector search passages.</li>

--- a/reference/vector/index.html
+++ b/reference/vector/index.html
@@ -1,0 +1,642 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Vector (Mathematics and Computing) · Reference · Nestor G Pestelos Jr</title>
+  <meta name="description" content="A citable ground-truth reference on vectors: formal vector space axioms, linear independence, inner product and Hilbert spaces, norms, matrix transformations, SIMD hardware vectorization, and high-dimensional semantic embeddings.">
+  <meta property="og:title" content="Vector (Mathematics and Computing) · Reference">
+  <meta property="og:description" content="A citable ground-truth reference on vectors: formal vector space axioms, linear independence, inner product and Hilbert spaces, norms, matrix transformations, SIMD hardware vectorization, and high-dimensional semantic embeddings.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://ngpestelos.com/reference/vector/">
+  <link rel="canonical" href="https://ngpestelos.com/reference/vector/">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=20260813f">
+  <link rel="icon" href="/favicon-192.png?v=20260813f" type="image/png" sizes="192x192">
+  <link rel="icon" href="/favicon-32.png?v=20260813f" type="image/png" sizes="32x32">
+  <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
+  <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="stylesheet" href="/style.css?v=20260903e">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TLBY8P4GG9');
+  </script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css" crossorigin="anonymous">
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
+    onload="renderMathInElement(document.body, {
+      delimiters: [
+        {left: '$$', right: '$$', display: true},
+        {left: '\\[', right: '\\]', display: true},
+        {left: '\\(', right: '\\)', display: false}
+      ]
+    });"></script>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; scroll-behavior: smooth; }
+    body {
+      line-height: 1.6;
+    }
+    main {
+      max-width: 48rem;
+      margin: 0 auto;
+      padding: 1.4rem 1.4rem 4rem;
+    }
+    .back {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .back a { color: var(--link); text-decoration: none; }
+    .back a:hover { text-decoration: underline; }
+    .kicker {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.78rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--mute);
+      margin-bottom: 0.2rem;
+    }
+    h1 {
+      font-size: clamp(1.9rem, 5vw, 2.4rem);
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.4rem;
+      margin-bottom: 0.8rem;
+    }
+    .subtitle {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 1rem;
+      color: var(--mute);
+      margin-bottom: 1.6rem;
+      line-height: 1.5;
+    }
+    .companion-box {
+      background: var(--well);
+      border: 1px solid var(--line);
+      border-left: 4px solid var(--link);
+      border-radius: 4px;
+      padding: 1rem 1.3rem;
+      margin-bottom: 1.8rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+    }
+    .companion-box h2 {
+      font-size: 0.95rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-top: 0;
+      margin-bottom: 0.5rem;
+      border-bottom: none;
+      padding-bottom: 0;
+      color: var(--ink);
+    }
+    .companion-box ul {
+      list-style: none;
+      padding-left: 0;
+      margin-bottom: 0;
+      font-size: 0.92rem;
+    }
+    .companion-box li { margin-bottom: 0.4rem; }
+    .companion-box li:last-child { margin-bottom: 0; }
+    .companion-box a { color: var(--link); text-decoration: none; }
+    .companion-box a:hover { text-decoration: underline; }
+    .toc {
+      background: var(--well);
+      border: 1px solid var(--line);
+      border-radius: 4px;
+      padding: 1.1rem 1.4rem;
+      margin-bottom: 2rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.9rem;
+    }
+    .toc h2 {
+      font-size: 1rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: 0.5rem;
+      color: var(--ink);
+      border-bottom: none;
+      padding-bottom: 0;
+      margin-top: 0;
+    }
+    .toc ol {
+      padding-left: 1.3rem;
+      margin-bottom: 0;
+    }
+    .toc ol ol {
+      padding-left: 1.2rem;
+      margin-top: 0.15rem;
+    }
+    .toc li { margin: 0.25rem 0; }
+    .toc a { color: var(--link); text-decoration: none; }
+    .toc a:hover { text-decoration: underline; }
+    h2 {
+      font-size: 1.45rem;
+      font-weight: 700;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.3rem;
+      margin-top: 2.2rem;
+      margin-bottom: 0.9rem;
+      color: var(--ink);
+    }
+    h3 {
+      font-size: 1.15rem;
+      font-weight: 700;
+      margin-top: 1.4rem;
+      margin-bottom: 0.3rem;
+      color: var(--ink);
+    }
+    p { margin-bottom: 1rem; }
+    ul, ol { margin-bottom: 1rem; padding-left: 1.5rem; }
+    li { margin-bottom: 0.4rem; }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1.2rem 0 1.8rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.88rem;
+    }
+    th, td {
+      border: 1px solid var(--line);
+      padding: 0.55rem 0.75rem;
+      text-align: left;
+      vertical-align: top;
+    }
+    th { background: var(--well); font-weight: 600; }
+    code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.88em;
+      background: #f1f3f5;
+      padding: 0.15em 0.35em;
+      border-radius: 3px;
+    }
+    .cite {
+      font-size: 0.75em;
+      vertical-align: super;
+      line-height: 0;
+      text-decoration: none;
+    }
+    .cite a { text-decoration: none; }
+    .formula-box {
+      text-align: center;
+      margin: 1.2rem 0;
+      background: var(--well);
+      padding: 0.8rem;
+      border-radius: 4px;
+      border: 1px solid var(--line);
+      overflow-x: auto;
+    }
+    #references {
+      font-size: 0.92rem;
+    }
+    #references ol {
+      padding-left: 1.5rem;
+    }
+    #references li {
+      margin-bottom: 0.5rem;
+    }
+    #references .backlink {
+      margin-right: 0.3rem;
+    }
+    footer.meta {
+      border-top: 1px solid var(--line);
+      margin-top: 3rem;
+      padding-top: 1.4rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+    }
+    footer.meta a { color: var(--link); }
+    @media print {
+      .back {font-family:"Segoe UI", Helvetica, Arial, sans-serif;display: none;}
+    }
+    .back-to-top {
+      position: fixed;
+      bottom: 1.5rem;
+      right: 1.5rem;
+      width: 2.6rem;
+      height: 2.6rem;
+      border-radius: 50%;
+      background: var(--bg);
+      color: var(--ink);
+      border: 1px solid var(--line);
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      opacity: 0;
+      visibility: hidden;
+      transform: translateY(8px);
+      transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease, background 0.15s ease, border-color 0.15s ease;
+      z-index: 100;
+    }
+    .back-to-top.visible {
+      opacity: 1;
+      visibility: visible;
+      transform: translateY(0);
+    }
+    .back-to-top:hover {
+      background: var(--well);
+      border-color: var(--link);
+      color: var(--link);
+    }
+    .back-to-top:focus-visible {
+      outline: 2px solid var(--link);
+      outline-offset: 2px;
+    }
+    @media print {
+      .back-to-top { display: none !important; }
+    }
+  </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Vector (Mathematics and Computing)","description":"A citable ground-truth reference on vectors: formal vector space axioms, linear independence, inner product and Hilbert spaces, norms, matrix transformations, SIMD hardware vectorization, and high-dimensional semantic embeddings.","url":"https://ngpestelos.com/reference/vector/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
+</head>
+<body class="reference">
+  <main id="top">
+    <p class="back"><a href="/reference/">← Reference</a> · <a href="/">Nestor G Pestelos Jr</a> · <a href="#" onclick="window.print(); return false;">Print this page</a></p>
+    <p class="kicker">Mathematics &amp; Computer Science</p>
+    <h1>Vector (Mathematics and Computing)</h1>
+    <p class="subtitle">A citable reference on vectors: formal vector space axioms, linear independence and bases, inner products, norm metrics, linear transformations, SIMD execution, and high-dimensional representations in machine learning.</p>
+
+    <div class="companion-box">
+      <h2>See Also &amp; Related References</h2>
+      <ul>
+        <li>📖 <a href="/reference/vector-search/"><strong>Reference: Vector Search</strong></a>: Approximate Nearest Neighbor (ANN) search, HNSW graphs, and product quantization.</li>
+        <li>📖 <a href="/reference/embeddings/"><strong>Reference: Embeddings</strong></a>: Dense vector representations, semantic manifolds, and continuous metric spaces.</li>
+        <li>📖 <a href="/reference/machine-learning/"><strong>Reference: Machine Learning</strong></a>: Empirical risk minimization, feature representations, and generalization theory.</li>
+        <li>📖 <a href="/reference/deep-neural-networks/"><strong>Reference: Deep Neural Networks</strong></a>: Multilayer weight matrices, tensor operations, and hidden state activations.</li>
+        <li>📖 <a href="/reference/transformer-architecture/"><strong>Reference: Transformer Architecture</strong></a>: Multi-head attention projections, residual streams, and contextual vector representations.</li>
+      </ul>
+    </div>
+
+    <nav class="toc" aria-label="Contents">
+      <h2>Contents</h2>
+      <ol>
+        <li><a href="#formal-axioms">1. Formal Vector Space Axioms</a>
+          <ol>
+            <li><a href="#vector-space-def">1.1 Algebraic Definition</a></li>
+            <li><a href="#linear-comb-span">1.2 Linear Combinations, Span, and Independence</a></li>
+            <li><a href="#basis-dimension">1.3 Basis, Dimension, and Coordinate Isomorphisms</a></li>
+          </ol>
+        </li>
+        <li><a href="#inner-product-normed">2. Inner Product, Normed, and Metric Spaces</a>
+          <ol>
+            <li><a href="#inner-product">2.1 Inner Product and Hilbert Spaces</a></li>
+            <li><a href="#norms-lp">2.2 Vector Norms and Lp Spaces</a></li>
+            <li><a href="#cosine-similarity">2.3 Angles and Cosine Similarity</a></li>
+            <li><a href="#metric-distances">2.4 Induced Metric Spaces</a></li>
+          </ol>
+        </li>
+        <li><a href="#operations-transforms">3. Vector Operations and Linear Transformations</a>
+          <ol>
+            <li><a href="#products">3.1 Dot, Cross, and Outer Products</a></li>
+            <li><a href="#linear-maps">3.2 Linear Maps and Matrix Representations</a></li>
+            <li><a href="#orthogonality">3.3 Orthogonality and Gram-Schmidt Process</a></li>
+            <li><a href="#eigensystems">3.4 Eigenvectors and Spectral Decomposition</a></li>
+          </ol>
+        </li>
+        <li><a href="#computational-hardware">4. Computational Representation and Hardware Vectorization</a>
+          <ol>
+            <li><a href="#memory-layout">4.1 Memory Layout, Alignment, and Strides</a></li>
+            <li><a href="#simd-parallelism">4.2 SIMD Instruction Sets and Parallel Execution</a></li>
+            <li><a href="#sparse-vectors">4.3 Dense vs. Sparse Vector Encodings</a></li>
+          </ol>
+        </li>
+        <li><a href="#vectors-in-ml">5. High-Dimensional Vectors in Machine Learning and AI</a>
+          <ol>
+            <li><a href="#feature-vectors">5.1 Feature Vectors and Coordinate Mapping</a></li>
+            <li><a href="#dense-embeddings">5.2 Latent Representations and Semantic Embeddings</a></li>
+            <li><a href="#curse-geometry">5.3 Geometric Peculiarities of High Dimensions</a></li>
+            <li><a href="#vector-indexing">5.4 Vector Indexing and Search</a></li>
+          </ol>
+        </li>
+        <li><a href="#references">6. References</a></li>
+      </ol>
+    </nav>
+
+    <!-- Section 1 -->
+    <h2 id="formal-axioms">1. Formal Vector Space Axioms</h2>
+    <p>
+      <strong>Vector</strong> (in mathematics and computing) is an element of a vector space, represented geometrically as a directed line segment with magnitude and direction, algebraically as an ordered tuple of scalars, or computationally as a contiguous array of numerical data.<span class="cite">[<a href="#ref1">1</a>, <a href="#ref2">2</a>]</span>
+    </p>
+
+    <h3 id="vector-space-def">1.1 Algebraic Definition</h3>
+    <p>
+      Formally, a <strong>vector space</strong> (or linear space) over a field \(\mathbb{F}\) (typically the real numbers \(\mathbb{R}\) or complex numbers \(\mathbb{C}\)) is a set \(V\) equipped with two binary operations:
+    </p>
+    <ul>
+      <li><strong>Vector Addition:</strong> \(+: V \times V \to V\), denoted \((u, v) \mapsto u + v\).</li>
+      <li><strong>Scalar Multiplication:</strong> \(\cdot: \mathbb{F} \times V \to V\), denoted \((a, v) \mapsto a v\).</li>
+    </ul>
+    <p>
+      The set \(V\) must satisfy eight fundamental algebraic axioms for all \(u, v, w \in V\) and all \(a, b \in \mathbb{F}\):<span class="cite">[<a href="#ref2">2</a>]</span>
+    </p>
+    <table>
+      <thead>
+        <tr>
+          <th>Category</th>
+          <th>Axiom Name</th>
+          <th>Formal Mathematical Statement</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td rowspan="4"><strong>Addition</strong></td>
+          <td>Associativity</td>
+          <td>\(u + (v + w) = (u + v) + w\)</td>
+        </tr>
+        <tr>
+          <td>Commutativity</td>
+          <td>\(u + v = v + u\)</td>
+        </tr>
+        <tr>
+          <td>Identity Element</td>
+          <td>\(\exists \, 0 \in V \text{ such that } v + 0 = v\)</td>
+        </tr>
+        <tr>
+          <td>Inverse Element</td>
+          <td>\(\forall \, v \in V, \, \exists \, (-v) \in V \text{ such that } v + (-v) = 0\)</td>
+        </tr>
+        <tr>
+          <td rowspan="4"><strong>Multiplication</strong></td>
+          <td>Scalar Compatibility</td>
+          <td>\(a(b v) = (ab)v\)</td>
+        </tr>
+        <tr>
+          <td>Scalar Identity</td>
+          <td>\(1 v = v\), where \(1 \in \mathbb{F}\) is the multiplicative identity</td>
+        </tr>
+        <tr>
+          <td>Vector Distributivity</td>
+          <td>\(a(u + v) = a u + a v\)</td>
+        </tr>
+        <tr>
+          <td>Scalar Distributivity</td>
+          <td>\((a + b)v = a v + b v\)</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3 id="linear-comb-span">1.2 Linear Combinations, Span, and Independence</h3>
+    <p>
+      Given vectors \(v_1, v_2, \dots, v_k \in V\) and scalars \(c_1, c_2, \dots, c_k \in \mathbb{F}\), the sum \(w = \sum_{i=1}^k c_i v_i\) is a <strong>linear combination</strong>. The <strong>span</strong> of a subset \(S \subseteq V\) is the set of all linear combinations of elements in \(S\):
+    </p>
+    <div class="formula-box">
+      $$\text{span}(S) = \left\{ \sum_{i=1}^k c_i v_i \;\middle|\; k \in \mathbb{N}, \, c_i \in \mathbb{F}, \, v_i \in S \right\}$$
+    </div>
+    <p>
+      A set of vectors \(\{v_1, \dots, v_k\}\) is <strong>linearly independent</strong> if the only scalars satisfying \(\sum_{i=1}^k c_i v_i = 0\) are \(c_1 = c_2 = \dots = c_k = 0\). If non-trivial scalars exist, the set is linearly dependent, meaning at least one vector can be expressed as a linear combination of the remaining vectors.
+    </p>
+
+    <h3 id="basis-dimension">1.3 Basis, Dimension, and Coordinate Isomorphisms</h3>
+    <p>
+      A subset \(\mathcal{B} = \{e_1, e_2, \dots, e_n\} \subset V\) is a <strong>basis</strong> of \(V\) if \(\mathcal{B}\) is linearly independent and \(\text{span}(\mathcal{B}) = V\). Every vector \(v \in V\) has a unique expansion in terms of basis \(\mathcal{B}\):
+    </p>
+    <div class="formula-box">
+      $$v = \sum_{i=1}^n x_i e_i, \quad [v]_\mathcal{B} = \begin{bmatrix} x_1 \\ x_2 \\ \vdots \\ x_n \end{bmatrix} \in \mathbb{F}^n$$
+    </div>
+    <p>
+      The number of basis vectors \(n\) is an invariant of the vector space, termed the <strong>dimension</strong> \(\dim(V) = n\). Every finite-dimensional vector space over \(\mathbb{F}\) with dimension \(n\) is linearly isomorphic to the coordinate space \(\mathbb{F}^n\).
+    </p>
+
+    <!-- Section 2 -->
+    <h2 id="inner-product-normed">2. Inner Product, Normed, and Metric Spaces</h2>
+    <p>
+      Geometric concepts of length, angle, and distance require endowing bare vector spaces with additional algebraic structures.<span class="cite">[<a href="#ref1">1</a>, <a href="#ref3">3</a>]</span>
+    </p>
+
+    <h3 id="inner-product">2.1 Inner Product and Hilbert Spaces</h3>
+    <p>
+      An <strong>inner product space</strong> is a vector space \(V\) over \(\mathbb{R}\) (or \(\mathbb{C}\)) equipped with an inner product \(\langle \cdot, \cdot \rangle: V \times V \to \mathbb{F}\) satisfying:
+    </p>
+    <ul>
+      <li><strong>Conjugate Symmetry:</strong> \(\langle u, v \rangle = \overline{\langle v, u \rangle}\) (for real spaces, \(\langle u, v \rangle = \langle v, u \rangle\)).</li>
+      <li><strong>Linearity in the First Argument:</strong> \(\langle a u + b v, w \rangle = a \langle u, w \rangle + b \langle v, w \rangle\).</li>
+      <li><strong>Positive-Definiteness:</strong> \(\langle v, v \rangle \ge 0\), and \(\langle v, v \rangle = 0 \iff v = 0\).</li>
+    </ul>
+    <p>
+      The <strong>Cauchy-Schwarz Inequality</strong> bounds the inner product by the product of induced norms:<span class="cite">[<a href="#ref2">2</a>]</span>
+    </p>
+    <div class="formula-box">
+      $$|\langle u, v \rangle|^2 \le \langle u, u \rangle \langle v, v \rangle$$
+    </div>
+    <p>
+      An inner product space that is complete with respect to its induced metric (every Cauchy sequence converges within the space) is a <strong>Hilbert Space</strong> \(\mathcal{H}\).
+    </p>
+
+    <h3 id="norms-lp">2.2 Vector Norms and Lp Spaces</h3>
+    <p>
+      A <strong>norm</strong> \(\|\cdot\|: V \to \mathbb{R}_{\ge 0}\) assigns a non-negative scalar length to each vector, satisfying non-negativity (\(\|v\| \ge 0\)), absolute homogeneity (\(\|a v\| = |a| \|v\|\)), and subadditivity (the Triangle Inequality: \(\|u + v\| \le \|u\| + \|v\|\)).
+    </p>
+    <table>
+      <thead>
+        <tr>
+          <th>Norm Family</th>
+          <th>Mathematical Formula</th>
+          <th>Geometric Intuition &amp; Properties</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><strong>\(L_2\) Norm (Euclidean)</strong></td>
+          <td>\(\|v\|_2 = \sqrt{\sum_{i=1}^d v_i^2} = \sqrt{\langle v, v \rangle}\)</td>
+          <td>Straight-line geometric length; strictly convex unit ball; rotationally invariant.</td>
+        </tr>
+        <tr>
+          <td><strong>\(L_1\) Norm (Manhattan / Taxicab)</strong></td>
+          <td>\(\|v\|_1 = \sum_{i=1}^d |v_i|\)</td>
+          <td>Sum of absolute coordinate differences; induces sparse parameter solutions in optimization (Lasso).</td>
+        </tr>
+        <tr>
+          <td><strong>\(L_\infty\) Norm (Chebyshev / Max)</strong></td>
+          <td>\(\|v\|_\infty = \max_{1 \le i \le d} |v_i|\)</td>
+          <td>Maximum coordinate displacement; unit ball is a hypercube.</td>
+        </tr>
+        <tr>
+          <td><strong>\(L_p\) Norm</strong></td>
+          <td>\(\|v\|_p = \left( \sum_{i=1}^d |v_i|^p \right)^{1/p}, \quad p \ge 1\)</td>
+          <td>Generalization across norms; dual norm to \(L_q\) where \(\frac{1}{p} + \frac{1}{q} = 1\) (Hölder's Inequality).</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3 id="cosine-similarity">2.3 Angles and Cosine Similarity</h3>
+    <p>
+      In an inner product space, the angle \(\theta \in [0, \pi]\) between two non-zero vectors \(u, v\) is defined through the Cauchy-Schwarz inequality:
+    </p>
+    <div class="formula-box">
+      $$\cos(\theta) = \frac{\langle u, v \rangle}{\|u\|_2 \|v\|_2} = \frac{u \cdot v}{\|u\|_2 \|v\|_2}$$
+    </div>
+    <p>
+      In high-dimensional information retrieval and language modeling, <strong>Cosine Similarity</strong> measures directional alignment regardless of vector magnitude. <strong>Cosine Distance</strong> is defined as \(d_{\text{cos}}(u, v) = 1 - \cos(\theta)\).
+    </p>
+
+    <h3 id="metric-distances">2.4 Induced Metric Spaces</h3>
+    <p>
+      Every normed vector space induces a <strong>metric space</strong> \((V, d)\) with distance function \(d(u, v) = \|u - v\|\). Common induced metrics include Euclidean distance \(d_2(u, v) = \sqrt{\sum (u_i - v_i)^2}\), Manhattan distance \(d_1(u, v) = \sum |u_i - v_i|\), and Minkowski distance \(d_p(u, v) = \left(\sum |u_i - v_i|^p\right)^{1/p}\).
+    </p>
+
+    <!-- Section 3 -->
+    <h2 id="operations-transforms">3. Vector Operations and Linear Transformations</h2>
+
+    <h3 id="products">3.1 Dot, Cross, and Outer Products</h3>
+    <ul>
+      <li><strong>Dot Product (Scalar Product):</strong> Maps two vectors \(u, v \in \mathbb{R}^d\) to a scalar \(u \cdot v = u^T v = \sum_{i=1}^d u_i v_i\).</li>
+      <li><strong>Cross Product (Vector Product):</strong> Defined for \(\mathbb{R}^3\), produces an orthogonal vector with magnitude \(\|u \times v\| = \|u\| \|v\| \sin(\theta)\):
+        <div class="formula-box">
+          $$u \times v = \begin{bmatrix} u_2 v_3 - u_3 v_2 \\ u_3 v_1 - u_1 v_3 \\ u_1 v_2 - u_2 v_1 \end{bmatrix}$$
+        </div>
+      </li>
+      <li><strong>Outer Product (Tensor Product):</strong> Produces a rank-1 matrix \(u \otimes v = u v^T \in \mathbb{R}^{m \times n}\) with entries \((u v^T)_{ij} = u_i v_j\).</li>
+    </ul>
+
+    <h3 id="linear-maps">3.2 Linear Maps and Matrix Representations</h3>
+    <p>
+      A function \(T: V \to W\) between vector spaces is a <strong>linear transformation</strong> if it preserves vector addition and scalar multiplication: \(T(a u + b v) = a T(u) + b T(v)\). Given ordered bases for \(V\) and \(W\), every linear transformation is uniquely represented by matrix multiplication:
+    </p>
+    <div class="formula-box">
+      $$[T(v)]_W = A \, [v]_V, \quad \text{where } A \in \mathbb{F}^{m \times n}$$
+    </div>
+
+    <h3 id="orthogonality">3.3 Orthogonality and Gram-Schmidt Process</h3>
+    <p>
+      Two vectors are <strong>orthogonal</strong> if \(\langle u, v \rangle = 0\), denoted \(u \perp v\). An <strong>orthonormal set</strong> satisfies \(\langle u_i, u_j \rangle = \delta_{ij}\) (where \(\delta_{ij}\) is the Kronecker delta).
+    </p>
+    <p>
+      The <strong>Gram-Schmidt Orthogonalization Process</strong> converts any linearly independent basis \(\{v_1, \dots, v_k\}\) into an orthonormal basis \(\{u_1, \dots, u_k\}\) by iteratively subtracting vector projections:<span class="cite">[<a href="#ref1">1</a>]</span>
+    </p>
+    <div class="formula-box">
+      $$u_1 = \frac{v_1}{\|v_1\|}, \quad w_k = v_k - \sum_{j=1}^{k-1} \langle v_k, u_j \rangle u_j, \quad u_k = \frac{w_k}{\|w_k\|}$$
+    </div>
+
+    <h3 id="eigensystems">3.4 Eigenvectors and Spectral Decomposition</h3>
+    <p>
+      For a linear operator represented by square matrix \(A \in \mathbb{F}^{n \times n}\), a non-zero vector \(v\) is an <strong>eigenvector</strong> with corresponding <strong>eigenvalue</strong> \(\lambda\) if:
+    </p>
+    <div class="formula-box">
+      $$A v = \lambda v \iff (A - \lambda I) v = 0$$
+    </div>
+    <p>
+      By the <strong>Spectral Theorem</strong>, any symmetric real matrix \(A = A^T\) can be factored into an orthonormal basis of eigenvectors: \(A = Q \Lambda Q^T\), where \(Q\) is an orthogonal matrix (\(Q^T Q = I\)) and \(\Lambda\) is diagonal.<span class="cite">[<a href="#ref3">3</a>]</span>
+    </p>
+
+    <!-- Section 4 -->
+    <h2 id="computational-hardware">4. Computational Representation and Hardware Vectorization</h2>
+
+    <h3 id="memory-layout">4.1 Memory Layout, Alignment, and Strides</h3>
+    <p>
+      In computer memory, a dense vector \(v \in \mathbb{R}^d\) is represented as a contiguous block of \(d\) IEEE 754 floating-point numbers (e.g. 32-bit <code>float</code> or 64-bit <code>double</code>). Key performance parameters include:
+    </p>
+    <ul>
+      <li><strong>Stride:</strong> The byte offset between consecutive vector elements in memory. A stride of 1 (unit stride) ensures optimal cache line utilization.</li>
+      <li><strong>Memory Alignment:</strong> Aligning vector starting addresses to 32-byte or 64-byte hardware boundaries allows single-cycle vector load/store instructions without crossing cache line splits.</li>
+    </ul>
+
+    <h3 id="simd-parallelism">4.2 SIMD Instruction Sets and Parallel Execution</h3>
+    <p>
+      Modern microprocessors exploit data-level parallelism via <strong>SIMD (Single Instruction, Multiple Data)</strong> execution units.<span class="cite">[<a href="#ref4">4</a>]</span> Rather than executing operations element-by-element in scalar registers, SIMD instructions operate simultaneously on packed vector registers:
+    </p>
+    <ul>
+      <li><strong>x86-64:</strong> AVX2 (256-bit registers, 8 \(\times\) float32 per cycle) and AVX-512 (512-bit registers, 16 \(\times\) float32 per cycle).</li>
+      <li><strong>ARM:</strong> ARM Neon (128-bit) and Scalable Vector Extension (SVE/SVE2 with variable hardware vector lengths).</li>
+      <li><strong>GPUs &amp; TPUs:</strong> Massive SIMT (Single Instruction, Multiple Threads) execution across warps (NVIDIA, 32 threads) or wavefronts (AMD, 64 threads), computing matrix-vector products with high memory bandwidth.</li>
+    </ul>
+
+    <h3 id="sparse-vectors">4.3 Dense vs. Sparse Vector Encodings</h3>
+    <p>
+      When a high-dimensional vector contains predominantly zero values (for example, bag-of-words text representations or term-frequency indices like BM25), dense storage becomes inefficient:
+    </p>
+    <ul>
+      <li><strong>Coordinate List (COO):</strong> Stores parallel arrays of non-zero indices and scalar values: <code>indices = [2, 14, 89]</code>, <code>values = [0.5, 1.2, -0.8]</code>.</li>
+      <li><strong>Compressed Sparse Row / Column (CSR / CSC):</strong> Compact representation for sparse matrix-vector computations optimizing cache locality and arithmetic throughput.<span class="cite">[<a href="#ref3">3</a>]</span></li>
+    </ul>
+
+    <!-- Section 5 -->
+    <h2 id="vectors-in-ml">5. High-Dimensional Vectors in Machine Learning and AI</h2>
+
+    <h3 id="feature-vectors">5.1 Feature Vectors and Coordinate Mapping</h3>
+    <p>
+      In classical machine learning, raw entities (tabular rows, audio signals, pixels) are mapped into a \(d\)-dimensional numerical coordinate space as a <strong>feature vector</strong> \(x = [x_1, x_2, \dots, x_d]^T \in \mathbb{R}^d\). Supervised decision boundaries (e.g. SVM separating hyperplanes \(w^T x + b = 0\)) operate directly on these geometric representations.<span class="cite">[<a href="#ref5">5</a>]</span>
+    </p>
+
+    <h3 id="dense-embeddings">5.2 Latent Representations and Semantic Embeddings</h3>
+    <p>
+      Deep neural networks transform discrete tokens, images, or multimodal artifacts into dense continuous vectors termed <strong>embeddings</strong>. The internal activations of hidden layers project inputs onto low-dimensional semantic manifolds where geometric distance approximates semantic similarity:
+    </p>
+    <ul>
+      <li><strong>Word Embeddings (Word2Vec / GloVe):</strong> Learned vector spaces capturing linear relational analogies: \(\vec{v}_{\text{King}} - \vec{v}_{\text{Man}} + \vec{v}_{\text{Woman}} \approx \vec{v}_{\text{Queen}}\).<span class="cite">[<a href="#ref6">6</a>]</span></li>
+      <li><strong>Transformer Residual Streams:</strong> Contextual vectors \(h_t \in \mathbb{R}^{d_{\text{model}}}\) updated sequentially across layers via multi-head self-attention mechanisms.<span class="cite">[<a href="#ref7">7</a>]</span></li>
+    </ul>
+
+    <h3 id="curse-geometry">5.3 Geometric Peculiarities of High Dimensions</h3>
+    <p>
+      As dimensionality \(d\) scales to hundreds or thousands (e.g. \(d = 1536\) or \(d = 4096\)), geometry behaves counter-intuitively due to the <strong>Curse of Dimensionality</strong>:<span class="cite">[<a href="#ref5">5</a>, <a href="#ref8">8</a>]</span>
+    </p>
+    <ul>
+      <li><strong>Concentration of Measure:</strong> Almost all volume of a \(d\)-dimensional hypersphere of radius \(r\) resides in a thin outer shell of thickness \(\approx r/d\).</li>
+      <li><strong>Near-Orthogonality:</strong> For independent random vectors uniformly distributed on the unit sphere \(\mathbb{S}^{d-1}\), their inner product concentrates sharply around zero with variance \(\text{Var}(\langle u, v \rangle) = \frac{1}{d}\). Any two random vectors in high dimensions are nearly orthogonal.</li>
+      <li><strong>Distance Metric Collapse:</strong> The relative contrast between the distance to the nearest neighbor and the distance to the farthest neighbor diminishes:
+        <div class="formula-box">
+          $$\lim_{d \to \infty} \frac{d_{\max} - d_{\min}}{d_{\min}} \to 0$$
+        </div>
+      </li>
+    </ul>
+
+    <h3 id="vector-indexing">5.4 Vector Indexing and Search</h3>
+    <p>
+      Because exhaustive brute-force \(k\)-Nearest Neighbor search over \(N\) high-dimensional vectors requires \(O(N \cdot d)\) comparisons per query, production retrieval systems rely on <strong>Approximate Nearest Neighbor (ANN)</strong> indexing:<span class="cite">[<a href="#ref9">9</a>]</span>
+    </p>
+    <ul>
+      <li><strong>Hierarchical Navigable Small World (HNSW):</strong> Multi-layer proximity graphs providing \(O(\log N)\) logarithmic search latency.</li>
+      <li><strong>Inverted File Index (IVF):</strong> Voronoi partitioning of vector space into clusters via \(k\)-means, restricting query searches to adjacent centroids.</li>
+      <li><strong>Product Quantization (PQ):</strong> Sub-vector decomposition into quantized codebooks, compressing high-dimensional vectors to compact byte codes and enabling fast distance estimation via precomputed lookup tables.</li>
+    </ul>
+
+    <!-- Section 6 -->
+    <h2 id="references">6. References</h2>
+    <ol>
+      <li id="ref1"><span class="backlink">^</span> Gilbert Strang, <em>Introduction to Linear Algebra</em>, 5th ed. (Wellesley-Cambridge Press, 2016).</li>
+      <li id="ref2"><span class="backlink">^</span> Sheldon Axler, <em>Linear Algebra Done Right</em>, 3rd ed. (Springer, 2015). DOI: <a href="https://doi.org/10.1007/978-3-319-11080-6" target="_blank" rel="noopener">10.1007/978-3-319-11080-6</a>.</li>
+      <li id="ref3"><span class="backlink">^</span> Gene H. Golub and Charles F. Van Loan, <em>Matrix Computations</em>, 4th ed. (Johns Hopkins University Press, 2013).</li>
+      <li id="ref4"><span class="backlink">^</span> John L. Hennessy and David A. Patterson, <em>Computer Architecture: A Quantitative Approach</em>, 6th ed. (Morgan Kaufmann, 2017).</li>
+      <li id="ref5"><span class="backlink">^</span> Christopher M. Bishop, <em>Pattern Recognition and Machine Learning</em> (Springer, 2006).</li>
+      <li id="ref6"><span class="backlink">^</span> Tomas Mikolov, Ilya Sutskever, Kai Chen, Greg S. Corrado, and Jeffrey Dean, "Distributed Representations of Words and Phrases and their Compositionality," <em>Advances in Neural Information Processing Systems</em> 26 (NeurIPS 2013). URL: <a href="https://proceedings.neurips.cc/paper/2013/file/9aa42b31882ec039965f3c4923ce901b-Paper.pdf" target="_blank" rel="noopener">NeurIPS Proceedings</a>.</li>
+      <li id="ref7"><span class="backlink">^</span> Ashish Vaswani, Noam Shazeer, Niki Parmar, et al., "Attention Is All You Need," <em>Advances in Neural Information Processing Systems</em> 30 (NeurIPS 2017). URL: <a href="https://arxiv.org/abs/1706.03762" target="_blank" rel="noopener">arXiv:1706.03762</a>.</li>
+      <li id="ref8"><span class="backlink">^</span> Thomas M. Cover and Joy A. Thomas, <em>Elements of Information Theory</em>, 2nd ed. (Wiley-Interscience, 2006).</li>
+      <li id="ref9"><span class="backlink">^</span> Yu A. Malkov and D. A. Yashunin, "Efficient and robust approximate nearest neighbor search using Hierarchical Navigable Small World graphs," <em>IEEE Transactions on Pattern Analysis and Machine Intelligence</em> 42(4), 824–836 (2020). DOI: <a href="https://doi.org/10.1109/TPAMI.2018.2889473" target="_blank" rel="noopener">10.1109/TPAMI.2018.2889473</a>.</li>
+    </ol>
+
+    <footer class="meta">
+      <p><a href="#top">Back to top</a></p>
+    </footer>
+  </main>
+  <button id="backToTop" class="back-to-top" aria-label="Back to top" title="Back to top">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M18 15l-6-6-6 6"/>
+    </svg>
+  </button>
+
+  <script>
+    const btt = document.getElementById('backToTop');
+    window.addEventListener('scroll', () => {
+      if (window.scrollY > 250) {
+        btt.classList.add('visible');
+      } else {
+        btt.classList.remove('visible');
+      }
+    }, { passive: true });
+    btt.addEventListener('click', () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  </script>
+</body>
+</html>

--- a/scripts/test_site_discoverability.py
+++ b/scripts/test_site_discoverability.py
@@ -387,6 +387,19 @@ class ReferenceSeoTests(unittest.TestCase):
         self.assertIn('href="/reference/unsupervised-learning/"', ml_html)
 
 
+    def test_vector_reference_registered(self):
+        html = (REF / "index.html").read_text(encoding="utf-8")
+        locs = sitemap_locs(SITEMAP.read_text(encoding="utf-8"))
+        self.assertIn('href="/reference/vector/"', html, "Missing from reference/index.html: vector")
+        self.assertIn("https://ngpestelos.com/reference/vector/", locs, "Missing from sitemap.xml: vector")
+        entry_html = (REF / "vector" / "index.html").read_text(encoding="utf-8")
+        self.assertIn("application/ld+json", entry_html)
+        self.assertIn('"@type":"DefinedTerm"', entry_html)
+        vs_html = (REF / "vector-search" / "index.html").read_text(encoding="utf-8")
+        self.assertIn('href="/reference/vector/"', vs_html)
+
+
 if __name__ == "__main__":
     unittest.main()
+
 

--- a/scripts/test_site_discoverability.py
+++ b/scripts/test_site_discoverability.py
@@ -368,5 +368,25 @@ class ReferenceSeoTests(unittest.TestCase):
             self.assertIn(link, html, f"Missing cross-link in large-language-models: {link}")
 
 
+    def test_learning_paradigms_reference_registered(self):
+        html = (REF / "index.html").read_text(encoding="utf-8")
+        locs = sitemap_locs(SITEMAP.read_text(encoding="utf-8"))
+        for slug in ("supervised-learning", "unsupervised-learning"):
+            self.assertIn(f'href="/reference/{slug}/"', html, f"Missing from reference/index.html: {slug}")
+            self.assertIn(
+                f"https://ngpestelos.com/reference/{slug}/",
+                locs,
+                f"Missing from sitemap.xml: {slug}",
+            )
+            entry_html = (REF / slug / "index.html").read_text(encoding="utf-8")
+            self.assertIn("application/ld+json", entry_html)
+            self.assertIn('"@type":"DefinedTerm"', entry_html)
+
+        ml_html = (REF / "machine-learning" / "index.html").read_text(encoding="utf-8")
+        self.assertIn('href="/reference/supervised-learning/"', ml_html)
+        self.assertIn('href="/reference/unsupervised-learning/"', ml_html)
+
+
 if __name__ == "__main__":
     unittest.main()
+

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1035,4 +1035,9 @@
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
+  <url>
+    <loc>https://ngpestelos.com/reference/vector/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
 </urlset>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1025,4 +1025,14 @@
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
+  <url>
+    <loc>https://ngpestelos.com/reference/supervised-learning/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://ngpestelos.com/reference/unsupervised-learning/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
## Summary

- Add citable ground-truth reference page for **Vector (Mathematics and Computing)** (`/reference/vector/`) covering vector space axioms, linear independence, basis/dimension, inner products and Hilbert spaces, Lp norms, linear maps, SIMD hardware vectorization, and high-dimensional semantic embeddings.
- Register entry in reference alphabetical index (`/reference/index.html`) and `sitemap.xml`.
- Cross-link from `/reference/vector-search/`.
- Add test coverage in `scripts/test_site_discoverability.py`.

## Verification

- `python3 scripts/test_site_discoverability.py` passed (19 tests)
- `python3 scripts/test_site_theme.py` passed (6 tests)
- `python3 scripts/test_writing_layout.py` passed (9 tests)
- Title middots, KaTeX delimiter escaping, and Schema.org DefinedTerm JSON-LD checks passed.