### PR TITLE
Publish daily briefing for 20260907

### DIFF
--- a/daily/20260907/index.html
+++ b/daily/20260907/index.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Daily briefing · 20260907</title>
+<link rel="stylesheet" href="/style.css?v=20260903e">
+<link rel="canonical" href="https://ngpestelos.com/daily/20260907/">
+<style>.daily-briefing .table-wrap{overflow-x:auto}body:has(main.daily-briefing) main.daily-briefing .table-wrap table{min-width:58rem}.daily-briefing td:nth-child(2),.daily-briefing td:nth-child(3),.daily-briefing td:nth-child(4),.daily-briefing td:nth-child(6){font-family:monospace;font-variant-numeric:tabular-nums;white-space:nowrap}@media print{body:has(main.daily-briefing) main.daily-briefing .table-wrap table{min-width:0}.daily-briefing td{white-space:normal!important}}</style>
+</head><body><main class="article daily-briefing">
+<p class="back" id="top"><a href="/">Home</a></p>
+<h1>Daily briefing · 20260907</h1>
+<p class="byline">Nestor Pestelos · 20260907</p>
+<section aria-labelledby="market-awareness"><h2 id="market-awareness">Market awareness</h2>
+<p>Snapshot fetched: 2026-09-07T12:32:39.398206+08:00.</p>
+<p>Each row retains its own session date. Daily and weekly changes use available upstream baselines. Older sessions can reflect closures or delayed data. — means unavailable.</p>
+<h3>Market context</h3>
+<p>This edition combines several market dates. The USD/PHP and USD/JPY observations are from 20260903, most other markets are from 20260904, and the crypto prices were sampled on 20260907. Read the cutoffs before comparing moves.</p>
+<p>The snapshot shows mixed equity moves: SPX is down on its daily comparison, while QQQ, EFA and EEM are up. These observations do not establish a common cause.</p>
+<p>The 2s10s curve is calculated using a two-year yield proxy. Read that spread with the proxy limitation in mind.</p>
+<h3>Rates and inflation</h3>
+<div class="table-wrap"><table>
+<caption>Rates and inflation observations</caption><thead><tr><th scope="col">Instrument</th><th scope="col">Value</th><th scope="col">Daily Δ</th><th scope="col">Weekly Δ</th><th scope="col">Quality</th><th scope="col">Session / observation / fetch</th><th scope="col">Source</th></tr></thead><tbody>
+<tr><td>US2Y · 2y yield proxy</td><td>4.2 %</td><td>+0 bps</td><td>+3 bps</td><td>Proxy</td><td>20260904<details><summary>Timestamps</summary>Observed: 2026-09-07T12:32:39.398206+08:00<br>Fetched: 2026-09-07T12:32:39.398206+08:00</details></td><td><a href="https://finance.yahoo.com/quote/2YY%3DF/">Source</a></td></tr>
+<tr><td>US10Y · 10y benchmark yield</td><td>4.784 %</td><td>+2.2 bps</td><td>+6.4 bps</td><td>Reported</td><td>20260904<details><summary>Timestamps</summary>Observed: 2026-09-07T12:32:39.398206+08:00<br>Fetched: 2026-09-07T12:32:39.398206+08:00</details></td><td><a href="https://finance.yahoo.com/quote/%5ETNX/">Source</a></td></tr>
+<tr><td>US2s10s · 2s10s curve</td><td>58.4 bps</td><td>+2.2 bps</td><td>—</td><td>Reported</td><td>20260904<details><summary>Timestamps</summary>Observed: 2026-09-07T12:32:39.398206+08:00<br>Fetched: 2026-09-07T12:32:39.398206+08:00</details></td><td>Derived: US10Y minus US2Y (basis points)</td></tr>
+<tr><td>US5YIE · 5y inflation expectations</td><td>—</td><td>—</td><td>—</td><td>Missing</td><td>20260904<details><summary>Timestamps</summary>Observed: 2026-09-07T12:32:39.398206+08:00<br>Fetched: 2026-09-07T12:32:39.398206+08:00</details></td><td><a href="https://finance.yahoo.com/quote/%5ET5YIE/">Source</a></td></tr>
+</tbody></table></div>
+<h3>Credit</h3>
+<div class="table-wrap"><table>
+<caption>Credit observations</caption><thead><tr><th scope="col">Instrument</th><th scope="col">Value</th><th scope="col">Daily Δ</th><th scope="col">Weekly Δ</th><th scope="col">Quality</th><th scope="col">Session / observation / fetch</th><th scope="col">Source</th></tr></thead><tbody>
+<tr><td>HYG · HY credit ETF proxy</td><td>79.16 USD</td><td>-0.0631%</td><td>-0.7274%</td><td>Proxy</td><td>20260904<details><summary>Timestamps</summary>Observed: 2026-09-07T12:32:39.398206+08:00<br>Fetched: 2026-09-07T12:32:39.398206+08:00</details></td><td><a href="https://finance.yahoo.com/quote/HYG/">Source</a></td></tr>
+</tbody></table></div>
+<h3>Volatility</h3>
+<div class="table-wrap"><table>
+<caption>Volatility observations</caption><thead><tr><th scope="col">Instrument</th><th scope="col">Value</th><th scope="col">Daily Δ</th><th scope="col">Weekly Δ</th><th scope="col">Quality</th><th scope="col">Session / observation / fetch</th><th scope="col">Source</th></tr></thead><tbody>
+<tr><td>VIX · equity vol benchmark</td><td>14.53 points</td><td>+0.21 points</td><td>+0.1 points</td><td>Reported</td><td>20260904<details><summary>Timestamps</summary>Observed: 2026-09-07T12:32:39.398206+08:00<br>Fetched: 2026-09-07T12:32:39.398206+08:00</details></td><td><a href="https://finance.yahoo.com/quote/%5EVIX/">Source</a></td></tr>
+</tbody></table></div>
+<h3>Currencies</h3>
+<div class="table-wrap"><table>
+<caption>Currencies observations</caption><thead><tr><th scope="col">Instrument</th><th scope="col">Value</th><th scope="col">Daily Δ</th><th scope="col">Weekly Δ</th><th scope="col">Quality</th><th scope="col">Session / observation / fetch</th><th scope="col">Source</th></tr></thead><tbody>
+<tr><td>DXY · broad USD</td><td>99.16 index</td><td>+0.1616%</td><td>-0.5416%</td><td>Reported</td><td>20260904<details><summary>Timestamps</summary>Observed: 2026-09-07T12:32:39.398206+08:00<br>Fetched: 2026-09-07T12:32:39.398206+08:00</details></td><td><a href="https://finance.yahoo.com/quote/DX-Y.NYB/">Source</a></td></tr>
+<tr><td>USDPHP · USD/PHP</td><td>62.395 PHP per USD</td><td>-0.136%</td><td>+0.8486%</td><td>Reported</td><td>20260903<details><summary>Timestamps</summary>Observed: 2026-09-07T12:32:39.398206+08:00<br>Fetched: 2026-09-07T12:32:39.398206+08:00</details></td><td><a href="https://finance.yahoo.com/quote/PHP%3DX/">Source</a></td></tr>
+<tr><td>USDJPY · USD/JPY</td><td>155.66 JPY per USD</td><td>-2.0532%</td><td>-2.2979%</td><td>Reported</td><td>20260903<details><summary>Timestamps</summary>Observed: 2026-09-07T12:32:39.398206+08:00<br>Fetched: 2026-09-07T12:32:39.398206+08:00</details></td><td><a href="https://finance.yahoo.com/quote/JPY%3DX/">Source</a></td></tr>
+</tbody></table></div>
+<h3>Equities</h3>
+<div class="table-wrap"><table>
+<caption>Equities observations</caption><thead><tr><th scope="col">Instrument</th><th scope="col">Value</th><th scope="col">Daily Δ</th><th scope="col">Weekly Δ</th><th scope="col">Quality</th><th scope="col">Session / observation / fetch</th><th scope="col">Source</th></tr></thead><tbody>
+<tr><td>SPX · US broad</td><td>7,718.6001 index</td><td>-0.3757%</td><td>+0.0887%</td><td>Reported</td><td>20260904<details><summary>Timestamps</summary>Observed: 2026-09-07T12:32:39.398206+08:00<br>Fetched: 2026-09-07T12:32:39.398206+08:00</details></td><td><a href="https://finance.yahoo.com/quote/%5EGSPC/">Source</a></td></tr>
+<tr><td>QQQ · US growth ETF proxy</td><td>718.96 USD</td><td>+0.1798%</td><td>+0.3531%</td><td>Proxy</td><td>20260904<details><summary>Timestamps</summary>Observed: 2026-09-07T12:32:39.398206+08:00<br>Fetched: 2026-09-07T12:32:39.398206+08:00</details></td><td><a href="https://finance.yahoo.com/quote/QQQ/">Source</a></td></tr>
+<tr><td>EFA · developed ex-US ETF proxy</td><td>108.35 USD</td><td>+0.1294%</td><td>+0.5848%</td><td>Proxy</td><td>20260904<details><summary>Timestamps</summary>Observed: 2026-09-07T12:32:39.398206+08:00<br>Fetched: 2026-09-07T12:32:39.398206+08:00</details></td><td><a href="https://finance.yahoo.com/quote/EFA/">Source</a></td></tr>
+<tr><td>EEM · EM ETF proxy</td><td>68.7 USD</td><td>+1.823%</td><td>+2.3235%</td><td>Proxy</td><td>20260904<details><summary>Timestamps</summary>Observed: 2026-09-07T12:32:39.398206+08:00<br>Fetched: 2026-09-07T12:32:39.398206+08:00</details></td><td><a href="https://finance.yahoo.com/quote/EEM/">Source</a></td></tr>
+</tbody></table></div>
+<h3>Commodities</h3>
+<div class="table-wrap"><table>
+<caption>Commodities observations</caption><thead><tr><th scope="col">Instrument</th><th scope="col">Value</th><th scope="col">Daily Δ</th><th scope="col">Weekly Δ</th><th scope="col">Quality</th><th scope="col">Session / observation / fetch</th><th scope="col">Source</th></tr></thead><tbody>
+<tr><td>GOLD · gold futures</td><td>4,429.7998 USD</td><td>-1.3781%</td><td>-1.0786%</td><td>Reported</td><td>20260904<details><summary>Timestamps</summary>Observed: 2026-09-07T12:32:39.398206+08:00<br>Fetched: 2026-09-07T12:32:39.398206+08:00</details></td><td><a href="https://finance.yahoo.com/quote/GC%3DF/">Source</a></td></tr>
+<tr><td>WTI · WTI crude</td><td>91.48 USD</td><td>+0.1972%</td><td>+9.6883%</td><td>Reported</td><td>20260904<details><summary>Timestamps</summary>Observed: 2026-09-07T12:32:39.398206+08:00<br>Fetched: 2026-09-07T12:32:39.398206+08:00</details></td><td><a href="https://finance.yahoo.com/quote/CL%3DF/">Source</a></td></tr>
+<tr><td>HG · copper</td><td>6.597 USD</td><td>+0.3041%</td><td>+0.5334%</td><td>Reported</td><td>20260904<details><summary>Timestamps</summary>Observed: 2026-09-07T12:32:39.398206+08:00<br>Fetched: 2026-09-07T12:32:39.398206+08:00</details></td><td><a href="https://finance.yahoo.com/quote/HG%3DF/">Source</a></td></tr>
+</tbody></table></div>
+<h3>Crypto</h3>
+<div class="table-wrap"><table>
+<caption>Crypto observations</caption><thead><tr><th scope="col">Instrument</th><th scope="col">Value</th><th scope="col">Daily Δ</th><th scope="col">Weekly Δ</th><th scope="col">Quality</th><th scope="col">Session / observation / fetch</th><th scope="col">Source</th></tr></thead><tbody>
+<tr><td>BTC · bitcoin</td><td>79,603 USD</td><td>—</td><td>—</td><td>Sampled; not OHLC</td><td>20260907<details><summary>Timestamps</summary>Observed: 2026-09-07T12:32:39.398206+08:00<br>Fetched: 2026-09-07T12:32:39.398206+08:00</details></td><td><a href="https://www.coingecko.com/en/coins/bitcoin">Source</a></td></tr>
+<tr><td>ETH · ether</td><td>2,497.18 USD</td><td>—</td><td>—</td><td>Sampled; not OHLC</td><td>20260907<details><summary>Timestamps</summary>Observed: 2026-09-07T12:32:39.398206+08:00<br>Fetched: 2026-09-07T12:32:39.398206+08:00</details></td><td><a href="https://www.coingecko.com/en/coins/ethereum">Source</a></td></tr>
+</tbody></table></div>
+<h3>Philippines</h3>
+<div class="table-wrap"><table>
+<caption>Philippines observations</caption><thead><tr><th scope="col">Instrument</th><th scope="col">Value</th><th scope="col">Daily Δ</th><th scope="col">Weekly Δ</th><th scope="col">Quality</th><th scope="col">Session / observation / fetch</th><th scope="col">Source</th></tr></thead><tbody>
+<tr><td>PSEI · PSEi composite</td><td>6,063.21 index</td><td>—</td><td>—</td><td>Reported</td><td>20260904<details><summary>Timestamps</summary>Observed: 2026-09-07T12:32:39.398206+08:00<br>Fetched: 2026-09-07T12:32:39.398206+08:00</details></td><td><a href="https://frames.pse.com.ph/compositeSector">Source</a></td></tr>
+<tr><td>PSE_ADV · advances</td><td>75 count</td><td>—</td><td>—</td><td>Reported</td><td>20260904<details><summary>Timestamps</summary>Observed: 2026-09-07T12:32:39.398206+08:00<br>Fetched: 2026-09-07T12:32:39.398206+08:00</details></td><td><a href="https://frames.pse.com.ph/compositeSector">Source</a></td></tr>
+<tr><td>PSE_DEC · declines</td><td>108 count</td><td>—</td><td>—</td><td>Reported</td><td>20260904<details><summary>Timestamps</summary>Observed: 2026-09-07T12:32:39.398206+08:00<br>Fetched: 2026-09-07T12:32:39.398206+08:00</details></td><td><a href="https://frames.pse.com.ph/compositeSector">Source</a></td></tr>
+<tr><td>PSE_TURNOVER · value turnover</td><td>1,749,327,360.73 PHP</td><td>—</td><td>—</td><td>Reported</td><td>20260904<details><summary>Timestamps</summary>Observed: 2026-09-07T12:32:39.398206+08:00<br>Fetched: 2026-09-07T12:32:39.398206+08:00</details></td><td><a href="https://frames.pse.com.ph/compositeSector">Source</a></td></tr>
+</tbody></table></div>
+</section>
+</main></body></html>


### PR DESCRIPTION
Publish the first daily briefing at `/daily/20260907/`, with market awareness as its first section. The page includes curated market context, USD/PHP and USD/JPY, source links, individual market cutoffs, and missing/proxy/sampled labels.

Only the dated HTML page is added. Private source artifacts are excluded.

Validation: 29 writing/discoverability tests and 8 renderer tests pass. The full site suite retains four pre-existing reference-theme failures reproduced on the clean base; no reference pages are changed. Desktop/mobile and public-content checks are completed before merge handoff.
