### PR TITLE
Widen the daily briefing market layout

### DIFF
--- a/daily/20260907/index.html
+++ b/daily/20260907/index.html
@@ -4,7 +4,7 @@
 <title>Daily briefing · 20260907</title>
 <link rel="stylesheet" href="/style.css?v=20260903e">
 <link rel="canonical" href="https://ngpestelos.com/daily/20260907/">
-<style>.daily-briefing .table-wrap{overflow-x:auto}body:has(main.daily-briefing) main.daily-briefing .table-wrap table{min-width:58rem}.daily-briefing td:nth-child(2),.daily-briefing td:nth-child(3),.daily-briefing td:nth-child(4),.daily-briefing td:nth-child(6){font-family:monospace;font-variant-numeric:tabular-nums;white-space:nowrap}@media print{body:has(main.daily-briefing) main.daily-briefing .table-wrap table{min-width:0}.daily-briefing td{white-space:normal!important}}</style>
+<style>body:has(main.daily-briefing) main.daily-briefing{max-width:88rem}.daily-briefing p,.daily-briefing ul,.daily-briefing ol{max-width:70ch}.daily-briefing .table-wrap{overflow-x:auto}body:has(main.daily-briefing) main.daily-briefing .table-wrap table{width:100%;min-width:58rem}body:has(main.daily-briefing) main.daily-briefing th,body:has(main.daily-briefing) main.daily-briefing td{overflow-wrap:normal;word-break:normal}.daily-briefing td:nth-child(2),.daily-briefing td:nth-child(3),.daily-briefing td:nth-child(4),.daily-briefing td:nth-child(6){font-family:monospace;font-variant-numeric:tabular-nums;white-space:nowrap}@media print{body:has(main.daily-briefing) main.daily-briefing{max-width:none}body:has(main.daily-briefing) main.daily-briefing .table-wrap table{min-width:0}.daily-briefing td{white-space:normal!important}}</style>
 </head><body><main class="article daily-briefing">
 <p class="back" id="top"><a href="/">Home</a></p>
 <h1>Daily briefing · 20260907</h1>


### PR DESCRIPTION
Widen the daily briefing to use available desktop space. Market tables now fit across the page, while narrative stays at a readable line length. Smaller screens retain contained table scrolling.

Regenerated the edition from the canonical renderer correction. Only its inline style changes; all text, numbers, dates and source links remain byte-identical outside that style block. Global site styles are unchanged.

Validation: 29 writing/discoverability tests pass. Chrome checked at 2048, 1440, 1280, 768 and 390px, including desktop table overflow and print fit. Four unrelated reference-theme failures remain in the full site suite.
