### PR TITLE
feat(reference): add Time Per Output Token, Chunked Prefill, and Speculative Decoding entries

### DIFF
--- a/reference/chunked-prefill/index.html
+++ b/reference/chunked-prefill/index.html
@@ -1,0 +1,298 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Chunked Prefill &middot; Reference &middot; Nestor G Pestelos Jr</title>
+  <meta name="description" content="Chunked prefill is an inference scheduling optimization that slices long prompt prefills into token chunks, interleaving them with decode steps to bound tail inter-token latency.">
+  <meta property="og:title" content="Chunked Prefill &middot; Reference">
+  <meta property="og:description" content="Prefill-decode interference, token budget allocation, mixed batching piggybacking, and tail ITL stabilization in LLM serving.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://ngpestelos.com/reference/chunked-prefill/">
+  <link rel="canonical" href="https://ngpestelos.com/reference/chunked-prefill/">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=20260813f">
+  <link rel="icon" href="/favicon-192.png?v=20260813f" type="image/png" sizes="192x192">
+  <link rel="icon" href="/favicon-32.png?v=20260813f" type="image/png" sizes="32x32">
+  <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
+  <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="stylesheet" href="/style.css?v=20260903e">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css" crossorigin="anonymous">
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"></script>
+  <script>
+    document.addEventListener("DOMContentLoaded", function () {
+      renderMathInElement(document.body, {
+        delimiters: [
+          {left: "$$", right: "$$", display: true},
+          {left: "\\[", right: "\\]", display: true},
+          {left: "\\(", right: "\\)", display: false}
+        ],
+        throwOnError: false
+      });
+    });
+  </script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag("js", new Date());
+    gtag("config", "G-TLBY8P4GG9");
+  </script>
+  <script type="application/ld+json">
+  {"@context":"https://schema.org","@type":"DefinedTerm","name":"Chunked Prefill","description":"Chunked prefill is an LLM inference scheduling technique that slices compute-heavy prompt prefills into smaller token chunks, co-scheduling prefill and decode iterations to eliminate head-of-line blocking.","url":"https://ngpestelos.com/reference/chunked-prefill/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; scroll-behavior: smooth; }
+    body {
+      line-height: 1.6;
+    }
+    main {
+      max-width: 48rem;
+      margin: 0 auto;
+      padding: 1.4rem 1.4rem 4rem;
+    }
+    .back {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .back a { color: var(--link); text-decoration: none; }
+    .back a:hover { text-decoration: underline; }
+    .kicker {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.78rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--mute);
+      margin-bottom: 0.2rem;
+    }
+    h1 {
+      font-size: clamp(1.9rem, 5vw, 2.4rem);
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.4rem;
+      margin-bottom: 0.8rem;
+    }
+    .updated {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.82rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .unattributed {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+      font-style: italic;
+    }
+    .lede { margin-bottom: 1.6rem; }
+    .lede strong:first-child { font-weight: 700; }
+    .toc {
+      background: var(--well);
+      border: 1px solid var(--line);
+      border-radius: 4px;
+      padding: 1.1rem 1.4rem;
+      margin-bottom: 2rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.9rem;
+    }
+    .toc h2 {
+      font-size: 1rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: 0.5rem;
+      color: var(--ink);
+      border-bottom: none;
+      padding-bottom: 0;
+    }
+    .toc ol { padding-left: 1.3rem; }
+    .toc li { margin: 0.2rem 0; }
+    .toc a { color: var(--link); text-decoration: none; }
+    .toc a:hover { text-decoration: underline; }
+    h2 {
+      font-size: 1.5rem;
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.3rem;
+      margin: 2rem 0 0.9rem;
+    }
+    h3 {
+      font-size: 1.15rem;
+      font-weight: 700;
+      margin: 1.4rem 0 0.5rem;
+    }
+    p { margin-bottom: 0.9rem; }
+    a { color: var(--link); }
+    a:visited { color: var(--link-visited); }
+    ul, ol { padding-left: 1.5rem; margin-bottom: 0.9rem; }
+    li { margin-bottom: 0.3rem; }
+    code {
+      font-family: "SF Mono", Consolas, Monaco, monospace;
+      font-size: 0.9em;
+      background: var(--well);
+      padding: 0.1em 0.35em;
+      border-radius: 3px;
+    }
+    .cite {
+      font-size: 0.75em;
+      vertical-align: super;
+      line-height: 0;
+      text-decoration: none;
+    }
+    .cite a { text-decoration: none; }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1rem 0 1.4rem;
+      font-size: 0.92rem;
+    }
+    th, td {
+      border: 1px solid var(--line);
+      padding: 0.5rem 0.7rem;
+      text-align: left;
+    }
+    th {
+      background: var(--well);
+      font-weight: 700;
+    }
+    .diagram-box {
+      background: var(--well);
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      padding: 1.2rem;
+      margin: 1.4rem 0;
+      font-family: "SF Mono", Consolas, Monaco, monospace;
+      font-size: 0.85rem;
+      overflow-x: auto;
+      line-height: 1.45;
+    }
+    #see-also ul, #references ol {
+      padding-left: 1.5rem;
+    }
+    #see-also li, #references li { margin-bottom: 0.5rem; }
+    #references { font-size: 0.92rem; }
+    #references .backlink { margin-right: 0.3rem; text-decoration: none; }
+    .back-to-top {
+      position: fixed;
+      bottom: 2rem;
+      right: 2rem;
+      display: none;
+      padding: 0.5rem 0.8rem;
+      font-size: 0.85rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      background: var(--well);
+      color: var(--ink);
+      border: 1px solid var(--line);
+      border-radius: 4px;
+      cursor: pointer;
+      box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+      z-index: 100;
+    }
+    .back-to-top:hover {
+      background: var(--line);
+    }
+    @media print {
+      .back, .back-to-top { display: none; }
+    }
+  </style>
+</head>
+<body class="reference">
+  <main id="top">
+    <p class="back"><a href="/reference/">&larr; Reference</a> &middot; <a href="/">Nestor G Pestelos Jr</a> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a></p>
+    <p class="kicker">Systems Engineering &middot; Machine Learning</p>
+    <h1>Chunked Prefill</h1>
+    <p class="updated">Reference entry &middot; last updated September 8, 2026</p>
+
+    <p class="lede"><strong>Chunked prefill</strong> is an inference scheduling optimization for large language models that partitions long prompt prefill requests into smaller token chunks across multiple execution iterations. By interleaving chunked prompt evaluation with active token decoding, chunked prefill prevents long input prompts from blocking decode steps, bounding tail inter-token latency without sacrificing GPU compute saturation.</p>
+
+    <nav class="toc" aria-label="Table of contents">
+      <h2>Contents</h2>
+      <ol>
+        <li><a href="#first-principles">1. First Principles: The Prefill-Decode Interference Problem</a></li>
+        <li><a href="#mechanism">2. Mechanism and Token Budget Allocation</a>
+          <ol>
+            <li><a href="#budget-slicing">2.1 Budgeting and Slicing</a></li>
+            <li><a href="#mixed-batching">2.2 Piggybacking and Mixed Batching</a></li>
+          </ol>
+        </li>
+        <li><a href="#tradeoffs">3. Performance Trade-offs: ITL Stability vs. TTFT</a></li>
+        <li><a href="#architecture-disaggregation">4. Systems Architecture and Disaggregation</a></li>
+        <li><a href="#see-also">See also</a></li>
+        <li><a href="#references">References</a></li>
+      </ol>
+    </nav>
+
+    <h2 id="first-principles">1. First Principles: The Prefill-Decode Interference Problem</h2>
+    <p>Serving systems for autoregressive language models handle two fundamentally asymmetric computational phases <span class="cite">[<a href="#ref-1">1</a>]</span>:</p>
+    <ul>
+      <li><strong>Prefill:</strong> Ingests the entire user prompt of length \(N_{\text{prompt}}\). Computes all Key-Value (KV) activations simultaneously using dense matrix multiplications. Operates at high arithmetic intensity and compute saturation, taking tens to hundreds of milliseconds.</li>
+      <li><strong>Decode:</strong> Emits one token at a time autoregressively. Each step loads model weights from memory for a single token per stream, operating at low arithmetic intensity and memory-bandwidth saturation. Each step requires 15 to 30 milliseconds.</li>
+    </ul>
+    <p>In standard <a href="/reference/continuous-batching/">continuous batching</a> systems, the scheduler prioritizes whole requests. When an incoming request carries a long prompt (such as a 16k or 32k token document), the GPU spends hundreds of milliseconds exclusively computing the prefill. During this window, all ongoing decode streams are paused. This head-of-line blocking creates extreme tail latency spikes in <a href="/reference/time-per-output-token/">Inter-Token Latency (ITL)</a>, degrading user streaming experiences.</p>
+
+    <h2 id="mechanism">2. Mechanism and Token Budget Allocation</h2>
+    <h3 id="budget-slicing">2.1 Budgeting and Slicing</h3>
+    <p>Chunked prefill resolves phase contention by setting a maximum token budget \(T_{\text{budget}}\) per iteration step (for instance, 512, 1,024, or 2,048 tokens) <span class="cite">[<a href="#ref-1">1</a>, <a href="#ref-2">2</a>]</span>. When a request arrives with prompt length \(N_{\text{prompt}} > C_{\text{chunk}}\), the scheduler slices the prompt into consecutive chunks:</p>
+    \[C_1, C_2, \dots, C_m \quad \text{where} \quad \sum_{j=1}^m |C_j| = N_{\text{prompt}}\]
+    <p>In each forward pass, the model processes only one chunk \(C_j\) for that request, caching its resulting KV activations into memory before yielding to the next scheduling iteration.</p>
+
+    <h3 id="mixed-batching">2.2 Piggybacking and Mixed Batching</h3>
+    <p>Rather than executing prefill chunks and decode steps in separate batches, chunked prefill co-schedules them in a single mixed batch. The iteration batch satisfies:</p>
+    \[B_{\text{decode}} + \sum_{i} |C_{\text{chunk}, i}| \le T_{\text{budget}}\]
+    <p>This technique (termed "piggybacking" in Sarathi) creates a complementary hardware synergy: the memory-bandwidth-bound decode tokens piggyback on the compute-heavy prefill chunk forward pass <span class="cite">[<a href="#ref-1">1</a>]</span>. Tensor cores remain saturated with chunk GEMM (General Matrix Multiply) operations while weights are streamed to advance decode streams, maximizing aggregate hardware efficiency.</p>
+
+    <h2 id="tradeoffs">3. Performance Trade-offs: ITL Stability vs. TTFT</h2>
+    <p>Chunked prefill introduces a deliberate engineering trade-off between tail inter-token latency and time to first token:</p>
+    <ul>
+      <li><strong>ITL Tail Stabilization:</strong> Because iteration duration is strictly bounded by \(T_{\text{budget}}\), decode streams advance smoothly. High-percentile ITL (P99) drops dramatically, eliminating interactive pauses.</li>
+      <li><strong>TTFT Inflation:</strong> Spreading prompt evaluation across \(m\) scheduling iterations introduces minor overheads and scheduling intervals, slightly increasing overall <a href="/reference/time-to-first-token/">Time to First Token (TTFT)</a> for the incoming long prompt compared to unchunked dedicated execution.</li>
+      <li><strong>Attention Computation Overheads:</strong> Evaluating self-attention across multiple chunks requires attending back to previously cached chunks. While attention mechanisms like FlashAttention support chunked caching, total attention memory transfers increase moderately compared to single-pass full-context attention.</li>
+    </ul>
+
+    <h2 id="architecture-disaggregation">4. Systems Architecture and Disaggregation</h2>
+    <p>Chunked prefill is standard in modern inference engines including vLLM and TensorRT-LLM. In larger multi-node production clusters, chunked prefill coexists with physical disaggregation (such as Splitwise and DistServe) <span class="cite">[<a href="#ref-3">3</a>, <a href="#ref-4">4</a>]</span>. While disaggregated serving assigns separate GPU pools to prefill and decode workloads, chunked prefill remains essential within homogeneous clusters and within prefill workers handling variable context lengths.</p>
+
+    <div id="see-also">
+      <h2>See also</h2>
+      <ul>
+        <li><a href="/reference/time-per-output-token/">Time Per Output Token</a> &middot; Inter-token latency and decode memory-bandwidth limits.</li>
+        <li><a href="/reference/time-to-first-token/">Time to First Token</a> &middot; Prompt prefill latency and interactive metrics.</li>
+        <li><a href="/reference/continuous-batching/">Continuous Batching</a> &middot; Iteration-level scheduling in generative model serving.</li>
+        <li><a href="/reference/speculative-decoding/">Speculative Decoding</a> &middot; Accelerating token emission through parallel draft verification.</li>
+        <li><a href="/reference/latency/">Latency (Systems and Computing)</a> &middot; Queuing delays and structural latency components.</li>
+      </ul>
+    </div>
+
+    <div id="references">
+      <h2>References</h2>
+      <ol>
+        <li id="ref-1"><a class="backlink" href="#first-principles">&uarr;</a> A. Agrawal et al., "Sarathi: Efficient LLM Inference by Chunked Prefills with Piggybacking," <em>arXiv preprint arXiv:2308.16369</em>, 2023. Free full text: <a href="https://arxiv.org/abs/2308.16369">https://arxiv.org/abs/2308.16369</a></li>
+        <li id="ref-2"><a class="backlink" href="#budget-slicing">&uarr;</a> A. Agrawal et al., "Taming Throughput-Latency Tradeoff in LLM Inference with Sarathi-Serve," in <em>Proceedings of the 18th USENIX Symposium on Operating Systems Design and Implementation (OSDI)</em>, 2024, pp. 117&ndash;134. Free full text: <a href="https://www.usenix.org/conference/osdi24/presentation/agrawal">https://www.usenix.org/conference/osdi24/presentation/agrawal</a></li>
+        <li id="ref-3"><a class="backlink" href="#architecture-disaggregation">&uarr;</a> Y. Zhong et al., "DistServe: Disaggregating Prefill and Decoding for Goodput-optimized Large Language Model Serving," in <em>Proceedings of the 18th USENIX Symposium on Operating Systems Design and Implementation (OSDI)</em>, 2024, pp. 193&ndash;210. Free full text: <a href="https://www.usenix.org/conference/osdi24/presentation/zhong">https://www.usenix.org/conference/osdi24/presentation/zhong</a></li>
+        <li id="ref-4"><a class="backlink" href="#architecture-disaggregation">&uarr;</a> P. Patel et al., "Splitwise: Efficient Generative LLM Serving Using Phase Separation," in <em>Proceedings of the 51st Annual International Symposium on Computer Architecture (ISCA)</em>, 2024, pp. 1008&ndash;1024. Free full text: <a href="https://arxiv.org/abs/2311.18677">https://arxiv.org/abs/2311.18677</a></li>
+        <li id="ref-5"><a class="backlink" href="#first-principles">&uarr;</a> W. Kwon et al., "Efficient Memory Management for Large Language Model Serving with PagedAttention," in <em>Proceedings of the 29th ACM Symposium on Operating Systems Principles (SOSP)</em>, 2023, pp. 611&ndash;626. Free full text: <a href="https://arxiv.org/abs/2309.06180">https://arxiv.org/abs/2309.06180</a></li>
+      </ol>
+    </div>
+  </main>
+
+  <button id="backToTop" class="back-to-top" aria-label="Back to top">Back to top</button>
+  <script>
+    const btt = document.getElementById("backToTop");
+    window.addEventListener("scroll", () => {
+      if (window.scrollY > 300) {
+        btt.style.display = "block";
+      } else {
+        btt.style.display = "none";
+      }
+    });
+    btt.addEventListener("click", () => {
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    });
+  </script>
+</body>
+</html>

--- a/reference/index.html
+++ b/reference/index.html
@@ -227,6 +227,7 @@
         <h2 class="letter-heading">C</h2>
         <ul>
         <li><a href="/reference/chiquito/">Chiquito (Actor)</a></li>
+        <li><a href="/reference/chunked-prefill/">Chunked Prefill</a></li>
         <li><a href="/reference/computer-vision/">Computer Vision</a></li>
         <li><a href="/reference/concurrency/">Concurrency</a></li>
         <li><a href="/reference/consciousness/">Consciousness</a></li>
@@ -383,6 +384,7 @@
         <li><a href="/reference/softmax/">Softmax Function</a></li>
         <li><a href="/reference/sonke-ahrens/">Sönke Ahrens</a></li>
         <li><a href="/reference/spaced-repetition/">Spaced Repetition</a></li>
+        <li><a href="/reference/speculative-decoding/">Speculative Decoding</a></li>
         <li><a href="/reference/steelmanning/">Steelmanning</a></li>
         <li><a href="/reference/subvocalization/">Subvocalization in Reading</a></li>
         <li><a href="/reference/supervised-learning/">Supervised Learning</a></li>
@@ -397,6 +399,7 @@
         <li><a href="/reference/theory-of-constraints/">Theory of Constraints</a></li>
         <li><a href="/reference/throughput/">Throughput</a></li>
         <li><a href="/reference/tiago-forte/">Tiago Forte</a></li>
+        <li><a href="/reference/time-per-output-token/">Time Per Output Token</a></li>
         <li><a href="/reference/time-to-first-token/">Time to First Token</a></li>
         <li><a href="/reference/toctou-race-condition/">TOCTOU Race Condition</a></li>
         <li><a href="/reference/tokens/">Tokens and Tokenization</a></li>

--- a/reference/latency/index.html
+++ b/reference/latency/index.html
@@ -340,15 +340,18 @@
     <p>In large language model serving, latency divides into two distinct operational phases <span class="cite">[<a href="#ref-7">7</a>]</span>:</p>
     <ul>
       <li><strong><a href="/reference/time-to-first-token/">Time to First Token (TTFT)</a>:</strong> The latency required to ingest the input prompt and run the initial matrix multiplications (the prefill phase). Bound primarily by compute and memory bandwidth across total prompt length.</li>
-      <li><strong>Inter-Token Latency (ITL) / Time Per Output Token (TPOT):</strong> The elapsed time to emit each subsequent token (the decode phase). Because autoregressive decoding emits one token at a time, each step requires reloading model weights from High Bandwidth Memory (HBM), making ITL memory-bandwidth bound.</li>
+      <li><strong><a href="/reference/time-per-output-token/">Inter-Token Latency (ITL) / Time Per Output Token (TPOT)</a>:</strong> The elapsed time to emit each subsequent token (the decode phase). Because autoregressive decoding emits one token at a time, each step requires reloading model weights from High Bandwidth Memory (HBM), making ITL memory-bandwidth bound.</li>
     </ul>
-    <p>Techniques like continuous batching, chunked prefill, and speculative decoding specifically balance the trade-off between maximizing server throughput and minimizing per-user generation latency.</p>
+    <p>Techniques like <a href="/reference/continuous-batching/">continuous batching</a>, <a href="/reference/chunked-prefill/">chunked prefill</a>, and <a href="/reference/speculative-decoding/">speculative decoding</a> specifically balance the trade-off between maximizing server throughput and minimizing per-user generation latency.</p>
 
     <div id="see-also">
       <h2>See also</h2>
       <ul>
         <li><a href="/reference/throughput/">Throughput</a> &middot; Volumetric capacity, Little's Law, and load saturation curves.</li>
         <li><a href="/reference/time-to-first-token/">Time to First Token</a> &middot; Prefill latency metrics in generative model inference.</li>
+        <li><a href="/reference/time-per-output-token/">Time Per Output Token</a> &middot; Inter-token generation latency and decode memory-bandwidth limits.</li>
+        <li><a href="/reference/chunked-prefill/">Chunked Prefill</a> &middot; Interleaving prompt evaluations to eliminate decode latency spikes.</li>
+        <li><a href="/reference/speculative-decoding/">Speculative Decoding</a> &middot; Parallel draft token verification accelerating generation velocity.</li>
         <li><a href="/reference/continuous-batching/">Continuous Batching</a> &middot; Dynamic iteration-level scheduling balancing throughput and queuing latency.</li>
         <li><a href="/reference/parallelism/">Parallelism (Computing)</a> &middot; Physical simultaneity and hardware acceleration models.</li>
         <li><a href="/reference/concurrency/">Concurrency (Computer Science)</a> &middot; Managing overlapping task executions and asynchronous event handling.</li>

--- a/reference/speculative-decoding/index.html
+++ b/reference/speculative-decoding/index.html
@@ -1,0 +1,315 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Speculative Decoding &middot; Reference &middot; Nestor G Pestelos Jr</title>
+  <meta name="description" content="Speculative decoding is an exact acceleration technique for autoregressive model inference using an auxiliary draft mechanism verified in parallel by a target model in a single step.">
+  <meta property="og:title" content="Speculative Decoding &middot; Reference">
+  <meta property="og:description" content="Parallel verification vs sequential generation, modified rejection sampling, speedup bounds, Medusa and EAGLE multi-head drafting, and systems trade-offs.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://ngpestelos.com/reference/speculative-decoding/">
+  <link rel="canonical" href="https://ngpestelos.com/reference/speculative-decoding/">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=20260813f">
+  <link rel="icon" href="/favicon-192.png?v=20260813f" type="image/png" sizes="192x192">
+  <link rel="icon" href="/favicon-32.png?v=20260813f" type="image/png" sizes="32x32">
+  <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
+  <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="stylesheet" href="/style.css?v=20260903e">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css" crossorigin="anonymous">
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"></script>
+  <script>
+    document.addEventListener("DOMContentLoaded", function () {
+      renderMathInElement(document.body, {
+        delimiters: [
+          {left: "$$", right: "$$", display: true},
+          {left: "\\[", right: "\\]", display: true},
+          {left: "\\(", right: "\\)", display: false}
+        ],
+        throwOnError: false
+      });
+    });
+  </script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag("js", new Date());
+    gtag("config", "G-TLBY8P4GG9");
+  </script>
+  <script type="application/ld+json">
+  {"@context":"https://schema.org","@type":"DefinedTerm","name":"Speculative Decoding","description":"Speculative decoding is an exact acceleration technique for autoregressive language model inference that uses a small draft model to generate candidate tokens verified in parallel by the target model in a single forward pass.","url":"https://ngpestelos.com/reference/speculative-decoding/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; scroll-behavior: smooth; }
+    body {
+      line-height: 1.6;
+    }
+    main {
+      max-width: 48rem;
+      margin: 0 auto;
+      padding: 1.4rem 1.4rem 4rem;
+    }
+    .back {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .back a { color: var(--link); text-decoration: none; }
+    .back a:hover { text-decoration: underline; }
+    .kicker {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.78rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--mute);
+      margin-bottom: 0.2rem;
+    }
+    h1 {
+      font-size: clamp(1.9rem, 5vw, 2.4rem);
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.4rem;
+      margin-bottom: 0.8rem;
+    }
+    .updated {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.82rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .unattributed {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+      font-style: italic;
+    }
+    .lede { margin-bottom: 1.6rem; }
+    .lede strong:first-child { font-weight: 700; }
+    .toc {
+      background: var(--well);
+      border: 1px solid var(--line);
+      border-radius: 4px;
+      padding: 1.1rem 1.4rem;
+      margin-bottom: 2rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.9rem;
+    }
+    .toc h2 {
+      font-size: 1rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: 0.5rem;
+      color: var(--ink);
+      border-bottom: none;
+      padding-bottom: 0;
+    }
+    .toc ol { padding-left: 1.3rem; }
+    .toc li { margin: 0.2rem 0; }
+    .toc a { color: var(--link); text-decoration: none; }
+    .toc a:hover { text-decoration: underline; }
+    h2 {
+      font-size: 1.5rem;
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.3rem;
+      margin: 2rem 0 0.9rem;
+    }
+    h3 {
+      font-size: 1.15rem;
+      font-weight: 700;
+      margin: 1.4rem 0 0.5rem;
+    }
+    p { margin-bottom: 0.9rem; }
+    a { color: var(--link); }
+    a:visited { color: var(--link-visited); }
+    ul, ol { padding-left: 1.5rem; margin-bottom: 0.9rem; }
+    li { margin-bottom: 0.3rem; }
+    code {
+      font-family: "SF Mono", Consolas, Monaco, monospace;
+      font-size: 0.9em;
+      background: var(--well);
+      padding: 0.1em 0.35em;
+      border-radius: 3px;
+    }
+    .cite {
+      font-size: 0.75em;
+      vertical-align: super;
+      line-height: 0;
+      text-decoration: none;
+    }
+    .cite a { text-decoration: none; }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1rem 0 1.4rem;
+      font-size: 0.92rem;
+    }
+    th, td {
+      border: 1px solid var(--line);
+      padding: 0.5rem 0.7rem;
+      text-align: left;
+    }
+    th {
+      background: var(--well);
+      font-weight: 700;
+    }
+    .diagram-box {
+      background: var(--well);
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      padding: 1.2rem;
+      margin: 1.4rem 0;
+      font-family: "SF Mono", Consolas, Monaco, monospace;
+      font-size: 0.85rem;
+      overflow-x: auto;
+      line-height: 1.45;
+    }
+    #see-also ul, #references ol {
+      padding-left: 1.5rem;
+    }
+    #see-also li, #references li { margin-bottom: 0.5rem; }
+    #references { font-size: 0.92rem; }
+    #references .backlink { margin-right: 0.3rem; text-decoration: none; }
+    .back-to-top {
+      position: fixed;
+      bottom: 2rem;
+      right: 2rem;
+      display: none;
+      padding: 0.5rem 0.8rem;
+      font-size: 0.85rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      background: var(--well);
+      color: var(--ink);
+      border: 1px solid var(--line);
+      border-radius: 4px;
+      cursor: pointer;
+      box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+      z-index: 100;
+    }
+    .back-to-top:hover {
+      background: var(--line);
+    }
+    @media print {
+      .back, .back-to-top { display: none; }
+    }
+  </style>
+</head>
+<body class="reference">
+  <main id="top">
+    <p class="back"><a href="/reference/">&larr; Reference</a> &middot; <a href="/">Nestor G Pestelos Jr</a> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a></p>
+    <p class="kicker">Machine Learning &middot; Systems Engineering</p>
+    <h1>Speculative Decoding</h1>
+    <p class="updated">Reference entry &middot; last updated September 8, 2026</p>
+
+    <p class="lede"><strong>Speculative decoding</strong> (also termed assisted generation or speculative sampling) is an exact acceleration technique for autoregressive language model inference that uses an auxiliary draft mechanism to hypothesize candidate tokens for parallel validation by a larger target model in a single execution step. Because validating multiple tokens concurrently is compute-bound rather than memory-bound, speculative decoding reduces generation latency while provably preserving the target model's output probability distribution.</p>
+
+    <nav class="toc" aria-label="Table of contents">
+      <h2>Contents</h2>
+      <ol>
+        <li><a href="#first-principles">1. First Principles: Parallel Verification vs. Sequential Generation</a></li>
+        <li><a href="#algorithm">2. Algorithmic Formulation and Distribution Preservation</a>
+          <ol>
+            <li><a href="#rejection-sampling">2.1 Modified Rejection Sampling</a></li>
+            <li><a href="#speedup-bounds">2.2 Expected Speedup and Acceptance Rate</a></li>
+          </ol>
+        </li>
+        <li><a href="#drafting-architectures">3. Drafting Architectures</a>
+          <ol>
+            <li><a href="#draft-models">3.1 Auxiliary Draft Models</a></li>
+            <li><a href="#multi-head">3.2 Multi-Head and Non-Neural Drafting</a></li>
+          </ol>
+        </li>
+        <li><a href="#systems-tradeoffs">4. Operating Regimes and Systems Trade-offs</a></li>
+        <li><a href="#see-also">See also</a></li>
+        <li><a href="#references">References</a></li>
+      </ol>
+    </nav>
+
+    <h2 id="first-principles">1. First Principles: Parallel Verification vs. Sequential Generation</h2>
+    <p>Autoregressive text generation requires \(K\) sequential steps to emit \(K\) tokens. Because decoding each token is memory-bandwidth bound, generating \(K\) tokens requires reading the target model's entire parameter weight matrix \(P\) from memory \(K\) times <span class="cite">[<a href="#ref-1">1</a>, <a href="#ref-2">2</a>]</span>. This serial dependency enforces an architectural latency barrier governed by memory bus throughput.</p>
+    <p>However, verifying \(K\) candidate tokens simultaneously requires only a single forward pass of the target model. Evaluating a sequence of length \(K\) performs matrix-matrix operations (GEMM) across the sequence dimension rather than matrix-vector operations (GEMV), unlocking high tensor core arithmetic intensity. Verifying \(K\) candidate tokens takes approximately the same wall-clock time on a modern GPU as generating a single token sequentially.</p>
+    <p>Speculative decoding exploits this asymmetry: a lightweight, fast draft mechanism generates \(K\) candidate tokens at low computational cost, and the large target model inspects all \(K\) candidates in parallel in one forward pass <span class="cite">[<a href="#ref-1">1</a>]</span>.</p>
+
+    <h2 id="algorithm">2. Algorithmic Formulation and Distribution Preservation</h2>
+    <h3 id="rejection-sampling">2.1 Modified Rejection Sampling</h3>
+    <p>A key property of speculative decoding is mathematical exactness: the generated text distribution matches sampling from the target model \(M_{\text{target}}\) exactly, introducing zero degradation in output quality or reasoning capability <span class="cite">[<a href="#ref-1">1</a>, <a href="#ref-2">2</a>]</span>.</p>
+    <p>Let \(q(x)\) denote the token probability distribution from the draft model, and \(p(x)\) denote the true distribution from the target model. For each draft token \(x_i\) conditioned on preceding accepted tokens, the verification step accepts \(x_i\) with probability:</p>
+    \[P(\text{accept } x_i) = \min\left(1, \frac{p(x_i)}{q(x_i)}\right)\]
+    <p>If draft token \(x_i\) is accepted, the process evaluates candidate \(x_{i+1}\). If token \(x_i\) is rejected, speculative execution halts for that iteration. The algorithm draws a replacement token from adjusted distribution \(p'(x)\):</p>
+    \[p'(x) = \frac{\max(0, p(x) - q(x))}{\sum_y \max(0, p(y) - q(y))}\]
+    <p>This rejection sampling formulation guarantees that whether a token is accepted from the draft or sampled from the residual distribution, the marginal probability of emitting token \(x\) equals \(p(x)\) identically.</p>
+
+    <h3 id="speedup-bounds">2.2 Expected Speedup and Acceptance Rate</h3>
+    <p>If the draft model produces \(\gamma\) candidate tokens per iteration and achieves an average per-token acceptance rate \(\alpha \in [0, 1]\), the expected count of generated tokens \(\mathbb{E}[N]\) per verification pass is:</p>
+    \[\mathbb{E}[N] = \frac{1 - \alpha^{\gamma + 1}}{1 - \alpha}\]
+    <p>Let \(c\) represent the latency ratio between one draft step and one target model forward pass (\(c = T_{\text{draft}} / T_{\text{target}} \ll 1\)). The wall-clock speedup \(S\) is expressed as:</p>
+    \[S = \frac{\mathbb{E}[N]}{\gamma \times c + 1} = \frac{1 - \alpha^{\gamma + 1}}{(1 - \alpha)(\gamma \times c + 1)}\]
+    <p>When \(\alpha \approx 0.7\) to \(0.9\) and \(c \le 0.05\), speculative decoding yields a 2x to 3x reduction in <a href="/reference/time-per-output-token/">Time Per Output Token (TPOT)</a>.</p>
+
+    <h2 id="drafting-architectures">3. Drafting Architectures</h2>
+    <h3 id="draft-models">3.1 Auxiliary Draft Models</h3>
+    <p>The standard architecture pairs a small model from the same family with the large target model (for example, a 7B parameter draft model proposing tokens for a 70B parameter target model) <span class="cite">[<a href="#ref-1">1</a>]</span>. Both models share the same vocabulary and tokenization scheme, allowing straightforward probability mapping.</p>
+
+    <h3 id="multi-head">3.2 Multi-Head and Non-Neural Drafting</h3>
+    <p>Modern serving frameworks also support draft mechanisms that eliminate secondary models:</p>
+    <ul>
+      <li><strong>Multi-Head Speculation (Medusa):</strong> Several lightweight feed-forward heads are trained on top of the target model's final hidden state, predicting subsequent tokens \(t+1, t+2, \dots\) simultaneously without running a secondary model <span class="cite">[<a href="#ref-3">3</a>]</span>.</li>
+      <li><strong>Feature-Recurrent Drafting (EAGLE):</strong> Extends multi-head prediction by feeding target transformer feature vectors into a single transformer decoder layer, capturing contextual representations with high acceptance accuracy <span class="cite">[<a href="#ref-4">4</a>]</span>.</li>
+      <li><strong>Prompt Lookup / N-Gram Matching:</strong> Reuses matching token n-grams from the input context without neural execution. Effective in summarization, translation, and code editing where output strings heavily repeat prompt text.</li>
+    </ul>
+
+    <h2 id="systems-tradeoffs">4. Operating Regimes and Systems Trade-offs</h2>
+    <p>Speculative decoding operates most effectively under specific system constraints:</p>
+    <ul>
+      <li><strong>Low Concurrency Regimes:</strong> Speculative decoding provides maximum acceleration at small batch sizes (concurrency = 1 to 4), where the GPU is memory-bandwidth bound. At very large batch sizes, target model execution is already compute-saturated, reducing the efficiency of speculative verification.</li>
+      <li><strong>Entropy Dependence:</strong> Acceptance rate \(\alpha\) depends on output entropy. Predictable syntax (JSON structures, code boilerplate, factual names) yields \(\alpha > 0.85\), producing dramatic acceleration. High-entropy creative text or dense mathematical reasoning yields lower acceptance rates (\(\alpha < 0.5\)), attenuating speedup.</li>
+      <li><strong>Memory Footprint:</strong> Running a dual-model setup requires loading both draft and target weights into accelerator memory, slightly reducing available KV cache capacity.</li>
+    </ul>
+
+    <div id="see-also">
+      <h2>See also</h2>
+      <ul>
+        <li><a href="/reference/time-per-output-token/">Time Per Output Token</a> &middot; Inter-token generation latency in autoregressive serving.</li>
+        <li><a href="/reference/time-to-first-token/">Time to First Token</a> &middot; Prompt prefill duration and interactive response timing.</li>
+        <li><a href="/reference/latency/">Latency (Systems and Computing)</a> &middot; Fundamental delay models and tail latency dynamics.</li>
+        <li><a href="/reference/throughput/">Throughput</a> &middot; Amdahl's Law and hardware saturation curves.</li>
+        <li><a href="/reference/continuous-batching/">Continuous Batching</a> &middot; Iteration-level scheduling algorithms.</li>
+        <li><a href="/reference/chunked-prefill/">Chunked Prefill</a> &middot; Mitigating prefill-decode interference.</li>
+      </ul>
+    </div>
+
+    <div id="references">
+      <h2>References</h2>
+      <ol>
+        <li id="ref-1"><a class="backlink" href="#first-principles">&uarr;</a> Y. Leviathan, M. Kalman, and Y. Matias, "Fast Inference from Transformers via Speculative Decoding," in <em>Proceedings of the 40th International Conference on Machine Learning (ICML)</em>, 2023, pp. 19274&ndash;19286. Free full text: <a href="https://arxiv.org/abs/2211.17192">https://arxiv.org/abs/2211.17192</a></li>
+        <li id="ref-2"><a class="backlink" href="#first-principles">&uarr;</a> C. Chen et al., "Accelerating Large Language Model Decoding with Speculative Sampling," <em>arXiv preprint arXiv:2302.01318</em>, 2023. Free full text: <a href="https://arxiv.org/abs/2302.01318">https://arxiv.org/abs/2302.01318</a></li>
+        <li id="ref-3"><a class="backlink" href="#multi-head">&uarr;</a> T. Cai et al., "Medusa: Simple LLM Inference Acceleration Framework with Multiple Decoding Heads," in <em>Proceedings of the 41st International Conference on Machine Learning (ICML)</em>, 2024. Free full text: <a href="https://arxiv.org/abs/2401.10774">https://arxiv.org/abs/2401.10774</a></li>
+        <li id="ref-4"><a class="backlink" href="#multi-head">&uarr;</a> Y. Li et al., "EAGLE: Speculative Sampling Requires Rethinking Feature Uncertainty," in <em>Proceedings of the 41st International Conference on Machine Learning (ICML)</em>, 2024. Free full text: <a href="https://arxiv.org/abs/2401.15077">https://arxiv.org/abs/2401.15077</a></li>
+        <li id="ref-5"><a class="backlink" href="#first-principles">&uarr;</a> R. Pope et al., "Efficiently Scaling Transformer Inference," in <em>Proceedings of Machine Learning and Systems (MLSys)</em>, vol. 5, 2023, pp. 606&ndash;624. Free full text: <a href="https://proceedings.mlsys.org/paper_files/paper/2023/file/523f66f8510f27eb6f29633e73507d4c-Paper-Conference.pdf">https://proceedings.mlsys.org/paper_files/paper/2023/file/523f66f8510f27eb6f29633e73507d4c-Paper-Conference.pdf</a></li>
+      </ol>
+    </div>
+  </main>
+
+  <button id="backToTop" class="back-to-top" aria-label="Back to top">Back to top</button>
+  <script>
+    const btt = document.getElementById("backToTop");
+    window.addEventListener("scroll", () => {
+      if (window.scrollY > 300) {
+        btt.style.display = "block";
+      } else {
+        btt.style.display = "none";
+      }
+    });
+    btt.addEventListener("click", () => {
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    });
+  </script>
+</body>
+</html>

--- a/reference/time-per-output-token/index.html
+++ b/reference/time-per-output-token/index.html
@@ -1,0 +1,304 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Time Per Output Token &middot; Reference &middot; Nestor G Pestelos Jr</title>
+  <meta name="description" content="Time Per Output Token (TPOT), also known as Inter-Token Latency (ITL), is the duration required to generate each token during autoregressive decode. Memory bandwidth, roofline model, and acceleration.">
+  <meta property="og:title" content="Time Per Output Token &middot; Reference">
+  <meta property="og:description" content="Memory-bandwidth bottlenecks in autoregressive decode, arithmetic intensity, TPOT vs ITL, batch size trade-offs, and acceleration techniques.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://ngpestelos.com/reference/time-per-output-token/">
+  <link rel="canonical" href="https://ngpestelos.com/reference/time-per-output-token/">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=20260813f">
+  <link rel="icon" href="/favicon-192.png?v=20260813f" type="image/png" sizes="192x192">
+  <link rel="icon" href="/favicon-32.png?v=20260813f" type="image/png" sizes="32x32">
+  <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
+  <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="stylesheet" href="/style.css?v=20260903e">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css" crossorigin="anonymous">
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"></script>
+  <script>
+    document.addEventListener("DOMContentLoaded", function () {
+      renderMathInElement(document.body, {
+        delimiters: [
+          {left: "$$", right: "$$", display: true},
+          {left: "\\[", right: "\\]", display: true},
+          {left: "\\(", right: "\\)", display: false}
+        ],
+        throwOnError: false
+      });
+    });
+  </script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag("js", new Date());
+    gtag("config", "G-TLBY8P4GG9");
+  </script>
+  <script type="application/ld+json">
+  {"@context":"https://schema.org","@type":"DefinedTerm","name":"Time Per Output Token","description":"Time Per Output Token (TPOT), also known as Inter-Token Latency (ITL), is the duration required to generate each individual token during autoregressive language model decoding.","url":"https://ngpestelos.com/reference/time-per-output-token/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; scroll-behavior: smooth; }
+    body {
+      line-height: 1.6;
+    }
+    main {
+      max-width: 48rem;
+      margin: 0 auto;
+      padding: 1.4rem 1.4rem 4rem;
+    }
+    .back {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .back a { color: var(--link); text-decoration: none; }
+    .back a:hover { text-decoration: underline; }
+    .kicker {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.78rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--mute);
+      margin-bottom: 0.2rem;
+    }
+    h1 {
+      font-size: clamp(1.9rem, 5vw, 2.4rem);
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.4rem;
+      margin-bottom: 0.8rem;
+    }
+    .updated {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.82rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .unattributed {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+      font-style: italic;
+    }
+    .lede { margin-bottom: 1.6rem; }
+    .lede strong:first-child { font-weight: 700; }
+    .toc {
+      background: var(--well);
+      border: 1px solid var(--line);
+      border-radius: 4px;
+      padding: 1.1rem 1.4rem;
+      margin-bottom: 2rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.9rem;
+    }
+    .toc h2 {
+      font-size: 1rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: 0.5rem;
+      color: var(--ink);
+      border-bottom: none;
+      padding-bottom: 0;
+    }
+    .toc ol { padding-left: 1.3rem; }
+    .toc li { margin: 0.2rem 0; }
+    .toc a { color: var(--link); text-decoration: none; }
+    .toc a:hover { text-decoration: underline; }
+    h2 {
+      font-size: 1.5rem;
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.3rem;
+      margin: 2rem 0 0.9rem;
+    }
+    h3 {
+      font-size: 1.15rem;
+      font-weight: 700;
+      margin: 1.4rem 0 0.5rem;
+    }
+    p { margin-bottom: 0.9rem; }
+    a { color: var(--link); }
+    a:visited { color: var(--link-visited); }
+    ul, ol { padding-left: 1.5rem; margin-bottom: 0.9rem; }
+    li { margin-bottom: 0.3rem; }
+    code {
+      font-family: "SF Mono", Consolas, Monaco, monospace;
+      font-size: 0.9em;
+      background: var(--well);
+      padding: 0.1em 0.35em;
+      border-radius: 3px;
+    }
+    .cite {
+      font-size: 0.75em;
+      vertical-align: super;
+      line-height: 0;
+      text-decoration: none;
+    }
+    .cite a { text-decoration: none; }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1rem 0 1.4rem;
+      font-size: 0.92rem;
+    }
+    th, td {
+      border: 1px solid var(--line);
+      padding: 0.5rem 0.7rem;
+      text-align: left;
+    }
+    th {
+      background: var(--well);
+      font-weight: 700;
+    }
+    .diagram-box {
+      background: var(--well);
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      padding: 1.2rem;
+      margin: 1.4rem 0;
+      font-family: "SF Mono", Consolas, Monaco, monospace;
+      font-size: 0.85rem;
+      overflow-x: auto;
+      line-height: 1.45;
+    }
+    #see-also ul, #references ol {
+      padding-left: 1.5rem;
+    }
+    #see-also li, #references li { margin-bottom: 0.5rem; }
+    #references { font-size: 0.92rem; }
+    #references .backlink { margin-right: 0.3rem; text-decoration: none; }
+    .back-to-top {
+      position: fixed;
+      bottom: 2rem;
+      right: 2rem;
+      display: none;
+      padding: 0.5rem 0.8rem;
+      font-size: 0.85rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      background: var(--well);
+      color: var(--ink);
+      border: 1px solid var(--line);
+      border-radius: 4px;
+      cursor: pointer;
+      box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+      z-index: 100;
+    }
+    .back-to-top:hover {
+      background: var(--line);
+    }
+    @media print {
+      .back, .back-to-top { display: none; }
+    }
+  </style>
+</head>
+<body class="reference">
+  <main id="top">
+    <p class="back"><a href="/reference/">&larr; Reference</a> &middot; <a href="/">Nestor G Pestelos Jr</a> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a></p>
+    <p class="kicker">Systems Engineering &middot; Machine Learning</p>
+    <h1>Time Per Output Token</h1>
+    <p class="updated">Reference entry &middot; last updated September 8, 2026</p>
+
+    <p class="lede"><strong>Time Per Output Token (TPOT)</strong>, also measured as <strong>Inter-Token Latency (ITL)</strong>, is the time elapsed between emitting successive tokens during the autoregressive decode phase of a large language model. While <a href="/reference/time-to-first-token/">Time to First Token (TTFT)</a> dictates initial interactive response delay, TPOT governs generation velocity and human-perceived streaming smoothness across multi-token responses.</p>
+
+    <nav class="toc" aria-label="Table of contents">
+      <h2>Contents</h2>
+      <ol>
+        <li><a href="#first-principles">1. First Principles: Memory-Bandwidth Bottlenecks in Autoregressive Decode</a></li>
+        <li><a href="#formulations">2. Formulations and Measurement</a>
+          <ol>
+            <li><a href="#tpot-vs-itl">2.1 TPOT vs. Inter-Token Latency</a></li>
+            <li><a href="#latency-composition">2.2 End-to-End Latency Composition</a></li>
+          </ol>
+        </li>
+        <li><a href="#batch-throughput-tradeoff">3. The Batch Size and Throughput Trade-off</a></li>
+        <li><a href="#mitigations">4. Engineering Strategies to Reduce TPOT</a></li>
+        <li><a href="#see-also">See also</a></li>
+        <li><a href="#references">References</a></li>
+      </ol>
+    </nav>
+
+    <h2 id="first-principles">1. First Principles: Memory-Bandwidth Bottlenecks in Autoregressive Decode</h2>
+    <p>Autoregressive transformer inference proceeds in two fundamentally distinct execution regimes: prefill and decode <span class="cite">[<a href="#ref-1">1</a>]</span>. The prefill phase evaluates prompt tokens in parallel, achieving high arithmetic intensity (floating-point operations performed per byte of data loaded from memory). In contrast, the decode phase is strictly memory-bandwidth bound.</p>
+    <p>During decoding, each forward pass generates exactly one new token per sequence. To emit that token, the hardware execution units must stream the entire model parameter weight matrix \(P\) from High Bandwidth Memory (HBM) into on-chip static RAM (SRAM) and register files <span class="cite">[<a href="#ref-2">2</a>]</span>. For a model with \(P\) parameters stored in 16-bit precision (2 bytes per parameter), loading weights requires reading \(2P\) bytes. The matrix-vector arithmetic performs approximately \(2P\) floating-point operations (FLOPs). The arithmetic intensity \(I_{\text{decode}}\) for batch size \(B = 1\) is therefore:</p>
+    \[I_{\text{decode}} \approx \frac{2P \text{ FLOPs}}{2P \text{ bytes}} = 1 \text{ FLOP/byte}\]
+    <p>Modern accelerator hardware (such as an NVIDIA H100 GPU) provides approximately 3.35 TB/sec of memory bandwidth and up to 1,979 TFLOPs of FP16 tensor core compute. A processor capable of nearly 2,000 trillion operations per second but limited to 3.35 trillion bytes per second has a hardware balance point above 150 FLOPs/byte <span class="cite">[<a href="#ref-3">3</a>]</span>. At 1 FLOP/byte, the compute units spend over 98% of their cycles idle, waiting for memory controllers to stream weights. TPOT is therefore determined almost entirely by parameter count and memory bandwidth rather than peak arithmetic capability.</p>
+
+    <h2 id="formulations">2. Formulations and Measurement</h2>
+    <h3 id="tpot-vs-itl">2.1 TPOT vs. Inter-Token Latency</h3>
+    <p>In systems benchmarks, <strong>Time Per Output Token (TPOT)</strong> is defined as the mean duration spent per output token over the entire generation sequence:</p>
+    \[\text{TPOT} = \frac{T_{\text{total}} - \text{TTFT}}{N_{\text{out}} - 1}\]
+    <p>where \(T_{\text{total}}\) is total elapsed request latency, \(\text{TTFT}\) is time to first token, and \(N_{\text{out}}\) is the total count of emitted tokens. TPOT is often inverted to describe single-stream generation throughput:</p>
+    \[\text{Tokens Per Second (TPS)} = \frac{1}{\text{TPOT}}\]
+    <p>While TPOT measures sequence-wide averages, <strong>Inter-Token Latency (ITL)</strong> evaluates instantaneous delay between consecutive individual tokens \(t_k\) and \(t_{k-1}\):</p>
+    \[\text{ITL}_k = \tau(t_k) - \tau(t_{k-1})\]
+    <p>Per-token ITL exposes latency jitter caused by iteration-level scheduling, memory paging, and prefill interference. High-percentile ITL (P90, P99) reflects pauses or hitching that degrade human reading experience, even when average TPOT appears satisfactory.</p>
+
+    <h3 id="latency-composition">2.2 End-to-End Latency Composition</h3>
+    <p>Total request response duration decomposes cleanly into prefill latency and cumulative decode latency:</p>
+    \[T_{\text{total}} = \text{TTFT} + \sum_{k=2}^{N_{\text{out}}} \text{ITL}_k \approx \text{TTFT} + (N_{\text{out}} - 1) \times \text{TPOT}\]
+    <p>For conversational workloads where output lengths reach hundreds of tokens, cumulative decode time dominates end-to-end response latency.</p>
+
+    <h2 id="batch-throughput-tradeoff">3. The Batch Size and Throughput Trade-off</h2>
+    <p>Serving systems batch multiple concurrent client requests to overcome memory-bandwidth starvation <span class="cite">[<a href="#ref-1">1</a>]</span>. When batch size increases from 1 to \(B\), the accelerator reads model weights once from HBM and reuses them across all \(B\) tokens in parallel. Arithmetic intensity scales linearly with batch size:</p>
+    \[I(B) \approx \frac{B \times 2P}{2P + B \times 2 \times S_{\text{KV}}} \approx B \text{ FLOPs/byte}\]
+    <p>where \(S_{\text{KV}}\) represents per-token Key-Value (KV) cache memory. Larger batch sizes increase total cluster throughput (tokens served per second per dollar). However, larger batches increase cache memory contention and lengthen each iteration step, gradually degrading per-user TPOT. Serving architectures operate on an efficient frontier balancing hardware cost against per-stream generation latency.</p>
+
+    <h2 id="mitigations">4. Engineering Strategies to Reduce TPOT</h2>
+    <p>Engineers employ several hardware and algorithmic techniques to lower TPOT and improve generation responsiveness:</p>
+    <ul>
+      <li><strong><a href="/reference/speculative-decoding/">Speculative Decoding</a>:</strong> A small, fast draft model guesses candidate tokens, which the larger target model verifies in a single forward pass. Because verification parallelizes across speculative tokens, effective TPOT drops without changing output quality <span class="cite">[<a href="#ref-4">4</a>]</span>.</li>
+      <li><strong>Weight Quantization:</strong> Compressing weights from FP16 to INT8, INT4, or FP4 cuts byte transfer volume by 50% to 75%, directly reducing weight loading duration per decode iteration.</li>
+      <li><strong><a href="/reference/chunked-prefill/">Chunked Prefill</a>:</strong> Slicing compute-dense prompt evaluations into smaller pieces prevents incoming queries from interrupting decode iterations, eliminating P99 ITL spikes.</li>
+      <li><strong>Disaggregated Serving:</strong> Physically separating prefill nodes from decode nodes (such as Splitwise and DistServe) isolates memory-bandwidth-bound decode clusters from compute-bound prefill workloads <span class="cite">[<a href="#ref-5">5</a>]</span>.</li>
+    </ul>
+
+    <div id="see-also">
+      <h2>See also</h2>
+      <ul>
+        <li><a href="/reference/time-to-first-token/">Time to First Token</a> &middot; Prompt prefill duration and interactive response latency.</li>
+        <li><a href="/reference/latency/">Latency (Systems and Computing)</a> &middot; Queuing models, delay decomposition, and tail amplification.</li>
+        <li><a href="/reference/throughput/">Throughput</a> &middot; Volumetric capacity and batch saturation dynamics.</li>
+        <li><a href="/reference/continuous-batching/">Continuous Batching</a> &middot; Dynamic iteration-level scheduling.</li>
+        <li><a href="/reference/chunked-prefill/">Chunked Prefill</a> &middot; Interleaving prompt chunks to stabilize inter-token latency.</li>
+        <li><a href="/reference/speculative-decoding/">Speculative Decoding</a> &middot; Parallel draft validation accelerating decode steps.</li>
+      </ul>
+    </div>
+
+    <div id="references">
+      <h2>References</h2>
+      <ol>
+        <li id="ref-1"><a class="backlink" href="#first-principles">&uarr;</a> R. Pope et al., "Efficiently Scaling Transformer Inference," in <em>Proceedings of Machine Learning and Systems (MLSys)</em>, vol. 5, 2023, pp. 606&ndash;624. Free full text: <a href="https://proceedings.mlsys.org/paper_files/paper/2023/file/523f66f8510f27eb6f29633e73507d4c-Paper-Conference.pdf">https://proceedings.mlsys.org/paper_files/paper/2023/file/523f66f8510f27eb6f29633e73507d4c-Paper-Conference.pdf</a></li>
+        <li id="ref-2"><a class="backlink" href="#first-principles">&uarr;</a> W. Kwon et al., "Efficient Memory Management for Large Language Model Serving with PagedAttention," in <em>Proceedings of the 29th ACM Symposium on Operating Systems Principles (SOSP)</em>, 2023, pp. 611&ndash;626. Free full text: <a href="https://arxiv.org/abs/2309.06180">https://arxiv.org/abs/2309.06180</a></li>
+        <li id="ref-3"><a class="backlink" href="#first-principles">&uarr;</a> S. Williams, A. Waterman, and D. Patterson, "Roofline: An Insightful Visual Performance Model for Multicore Architectures," <em>Communications of the ACM</em>, vol. 52, no. 4, 2009, pp. 65&ndash;76.</li>
+        <li id="ref-4"><a class="backlink" href="#mitigations">&uarr;</a> Y. Leviathan, M. Kalman, and Y. Matias, "Fast Inference from Transformers via Speculative Decoding," in <em>Proceedings of the 40th International Conference on Machine Learning (ICML)</em>, 2023, pp. 19274&ndash;19286. Free full text: <a href="https://arxiv.org/abs/2211.17192">https://arxiv.org/abs/2211.17192</a></li>
+        <li id="ref-5"><a class="backlink" href="#mitigations">&uarr;</a> P. Patel et al., "Splitwise: Efficient Generative LLM Serving Using Phase Separation," in <em>Proceedings of the 51st Annual International Symposium on Computer Architecture (ISCA)</em>, 2024, pp. 1008&ndash;1024. Free full text: <a href="https://arxiv.org/abs/2311.18677">https://arxiv.org/abs/2311.18677</a></li>
+      </ol>
+    </div>
+  </main>
+
+  <button id="backToTop" class="back-to-top" aria-label="Back to top">Back to top</button>
+  <script>
+    const btt = document.getElementById("backToTop");
+    window.addEventListener("scroll", () => {
+      if (window.scrollY > 300) {
+        btt.style.display = "block";
+      } else {
+        btt.style.display = "none";
+      }
+    });
+    btt.addEventListener("click", () => {
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    });
+  </script>
+</body>
+</html>

--- a/reference/time-to-first-token/index.html
+++ b/reference/time-to-first-token/index.html
@@ -254,7 +254,7 @@
     <p>TTFT measures the duration required to complete network ingress, queuing, and the entire prefill phase.</p>
 
     <h2 id="tpot-definition">Time Per Output Token (TPOT)</h2>
-    <p>While TTFT evaluates initial response delay, <strong>Time Per Output Token (TPOT)</strong> measures the generation speed of subsequent tokens:<span class="cite">[<a href="#ref2">2</a>]</span></p>
+    <p>While TTFT evaluates initial response delay, <strong><a href="/reference/time-per-output-token/">Time Per Output Token (TPOT)</a></strong> measures the generation speed of subsequent tokens:<span class="cite">[<a href="#ref2">2</a>]</span></p>
     \[\text{TPOT} = \frac{\text{Total Latency} - \text{TTFT}}{N_{\text{out}} - 1}\]
     <p>where \(N_{\text{out}}\) is the count of generated output tokens. The inverse of TPOT represents generation throughput per user stream (in tokens per second). Total end-to-end latency \(T_{\text{total}}\) is expressed as:<span class="cite">[<a href="#ref2">2</a>]</span></p>
     \[T_{\text{total}} = \text{TTFT} + (N_{\text{out}} - 1) \times \text{TPOT}\]
@@ -270,12 +270,16 @@
     <p>Systems employ distinct architectural patterns to minimize TTFT:<span class="cite">[<a href="#ref1">1</a>]</span></p>
     <ul>
       <li><strong>Prompt caching</strong>: Storing pre-computed KV cache activations for static prefixes (such as system instructions, tool definitions, and few-shot examples). Reused prefixes bypass prefill computation, reducing TTFT by 50% to 90%.<span class="cite">[<a href="#ref5">5</a>]</span></li>
-      <li><strong>Chunked prefill</strong>: Splitting long prompt prefill tasks into smaller token chunks that are interleaved into decode batches, preventing head-of-line blocking for concurrent users.</li>
-      <li><strong>Speculative decoding</strong>: Using a lightweight draft model to speculate multiple tokens in parallel, which a larger model verifies in a single forward pass, reducing effective TPOT.<span class="cite">[<a href="#ref6">6</a>]</span></li>
+      <li><strong><a href="/reference/chunked-prefill/">Chunked prefill</a></strong>: Splitting long prompt prefill tasks into smaller token chunks that are interleaved into decode batches, preventing head-of-line blocking for concurrent users.</li>
+      <li><strong><a href="/reference/speculative-decoding/">Speculative decoding</a></strong>: Using a lightweight draft model to speculate multiple tokens in parallel, which a larger model verifies in a single forward pass, reducing effective TPOT.<span class="cite">[<a href="#ref6">6</a>]</span></li>
     </ul>
 
     <h2 id="see-also">See also</h2>
     <ul>
+      <li><a href="/reference/time-per-output-token/">Time Per Output Token</a></li>
+      <li><a href="/reference/chunked-prefill/">Chunked Prefill</a></li>
+      <li><a href="/reference/speculative-decoding/">Speculative Decoding</a></li>
+      <li><a href="/reference/continuous-batching/">Continuous Batching</a></li>
       <li><a href="/reference/throughput/">Throughput</a></li>
       <li><a href="/reference/tokens/">Tokens and Tokenization</a></li>
       <li><a href="/reference/autoregressive/">Autoregressive Models</a></li>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -566,6 +566,21 @@
     <priority>0.5</priority>
   </url>
   <url>
+    <loc>https://ngpestelos.com/reference/chunked-prefill/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://ngpestelos.com/reference/speculative-decoding/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://ngpestelos.com/reference/time-per-output-token/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
     <loc>https://ngpestelos.com/reference/theory-of-constraints/</loc>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>


### PR DESCRIPTION
## Summary
Adds three new reference encyclopedia entries for core LLM serving latency concepts referenced on the Latency and Time to First Token pages:

1. **Time Per Output Token (TPOT)** (`/reference/time-per-output-token/`):
   - First principles: Memory-bandwidth bottlenecks in autoregressive decode, Roofline model, and arithmetic intensity ( \text{ FLOP/byte}$).
   - Formulations: Sequence-level TPOT vs. instantaneous Inter-Token Latency (ITL).
   - Systems trade-offs: Batch size scaling vs. per-stream latency degradation.
   - Acceleration: Speculative decoding, quantization, chunked prefill, and phase disaggregation.

2. **Chunked Prefill** (`/reference/chunked-prefill/`):
   - First principles: Prefill-decode phase asymmetry and head-of-line blocking on long prompts.
   - Mechanism: Token budget allocation ({\text{budget}}$) and mixed-batch piggybacking (Sarathi).
   - Trade-offs: Bounding tail ITL (P99 stabilization) vs. modest TTFT inflation.
   - Systems: Co-scheduling vs. physical disaggregation (Splitwise, DistServe).

3. **Speculative Decoding** (`/reference/speculative-decoding/`):
   - First principles: Asymmetry of parallel candidate verification ((1)$ forward passes) vs. sequential emission ((K)$).
   - Mathematics: Modified rejection sampling provably preserving the target model output probability distribution.
   - Architectures: Auxiliary draft models vs. multi-head draft heads (Medusa, EAGLE).
   - Regimes: Low concurrency acceleration vs. high batch compute saturation.

- **Cross-Linking**: Updated `/reference/latency/` and `/reference/time-to-first-token/` with inline reciprocal links and See Also references.
- **Discoverability**: Registered under C, S, and T in `/reference/index.html` and added to `/sitemap.xml`.

## Verification
- Layout & SEO tests: `python3 scripts/test_writing_layout.py && python3 scripts/test_site_discoverability.py` (29 passed).
- All 3 pages start with a dedicated `First Principles` section 1 (`<h2 id="first-principles">`).
- Zero em-dashes in prose; KaTeX delimiters double-escaped on disk (`\\(`, `\\[`); XML valid.