### PR TITLE
Standardize reference entry category kickers

### DIFF
--- a/reference/agents/index.html
+++ b/reference/agents/index.html
@@ -250,7 +250,7 @@
 <body class="reference">
   <main>
     <p class="back"><a href="/reference/">← Reference</a> · <a href="/">Nestor G Pestelos Jr</a> · <a href="#" onclick="window.print(); return false;">Print this page</a></p>
-    <p class="kicker">Reference Document</p>
+    <p class="kicker">Artificial Intelligence · Autonomous Agents</p>
     <h1>Agents</h1>
     <p class="subtitle">A citable ground-truth reference on Autonomous Agents: MDP formulation, perception-action-reflection loops, tool calling protocols, memory tiers, and multi-agent orchestration.</p>
 

--- a/reference/artificial-intelligence/index.html
+++ b/reference/artificial-intelligence/index.html
@@ -224,7 +224,7 @@
 <body class="reference">
   <main>
     <p class="back"><a href="/reference/">← Reference</a> · <a href="/">Nestor G Pestelos Jr</a> · <a href="#" onclick="window.print(); return false;">Print this page</a></p>
-    <p class="kicker">Reference Document</p>
+    <p class="kicker">Computer Science · Artificial Intelligence</p>
     <h1>Artificial Intelligence</h1>
     <p class="subtitle">A citable reference on Artificial Intelligence (AI): the rational agent paradigm, historical taxonomy, statistical foundation models, and autonomy bounds.</p>
 

--- a/reference/autoregressive/index.html
+++ b/reference/autoregressive/index.html
@@ -231,7 +231,7 @@
 <body class="reference">
   <main>
     <p class="back"><a href="/reference/">← Reference</a> · <a href="/">Nestor G Pestelos Jr</a> · <a href="#" onclick="window.print(); return false;">Print this page</a></p>
-    <p class="kicker">Reference Document</p>
+    <p class="kicker">Machine Learning · Sequence Modeling</p>
     <h1>Autoregressive Models</h1>
     <p class="subtitle">A citable reference on autoregression in machine learning and natural language processing: mathematical formulation, causal masking, sequential inference bottlenecks, and KV caching.</p>
 

--- a/reference/bm25/index.html
+++ b/reference/bm25/index.html
@@ -203,7 +203,7 @@
 <body class="reference">
   <main>
     <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/reference/">Reference</a><span class="print"> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a></span></p>
-    <div class="kicker">Information Retrieval &middot; Ranking Functions</div>
+    <p class="kicker">Information Retrieval &middot; Ranking Functions</p>
     <h1>BM25 (Best Matching 25)</h1>
     <div class="updated">Published September 3, 2026</div>
 

--- a/reference/concurrency/index.html
+++ b/reference/concurrency/index.html
@@ -204,7 +204,7 @@
       <a href="/reference/">&larr; Reference</a> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a>
     </nav>
 
-    <div class="kicker">Reference Entry</div>
+    <p class="kicker">Computer Architecture · Parallel Computing</p>
     <h1>Concurrency (Computer Science)</h1>
     <p class="updated">Reference entry &middot; last updated September 7, 2026</p>
 

--- a/reference/context-engineering/index.html
+++ b/reference/context-engineering/index.html
@@ -239,7 +239,7 @@
 <body class="reference">
   <main>
     <p class="back"><a href="/reference/">← Reference</a> · <a href="/">Nestor G Pestelos Jr</a> · <a href="#" onclick="window.print(); return false;">Print this page</a></p>
-    <p class="kicker">Reference Document</p>
+    <p class="kicker">Artificial Intelligence · Context Management</p>
     <h1>Context Engineering</h1>
     <p class="subtitle">A citable reference on context engineering: the systematic discipline of token budgeting, memory tiering, attention degradation mitigation, prompt caching, and structured payload assembly for LLMs.</p>
 

--- a/reference/context-window/index.html
+++ b/reference/context-window/index.html
@@ -181,7 +181,7 @@
 <body class="reference">
   <main>
     <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/reference/">Reference</a> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a></p>
-    <div class="kicker">Reference Guide</div>
+    <p class="kicker">Artificial Intelligence · Transformer Architecture</p>
     <h1>Context Windows</h1>
     <p class="updated">Published September 3, 2026 &middot; Transformer Architecture &amp; Systems Engineering</p>
 

--- a/reference/deep-neural-networks/index.html
+++ b/reference/deep-neural-networks/index.html
@@ -231,7 +231,7 @@
 <body class="reference">
   <main>
     <p class="back"><a href="/reference/">← Reference</a> · <a href="/">Nestor G Pestelos Jr</a> · <a href="#" onclick="window.print(); return false;">Print this page</a></p>
-    <p class="kicker">Reference Document</p>
+    <p class="kicker">Machine Learning · Deep Learning</p>
     <h1>Deep Neural Networks</h1>
     <p class="subtitle">A citable reference on Deep Neural Networks (DNNs): multi-layer architecture, non-linear activation functions, backpropagation via the chain rule, and hierarchical representation learning.</p>
 

--- a/reference/embeddings/index.html
+++ b/reference/embeddings/index.html
@@ -181,7 +181,7 @@
 <body class="reference">
   <main>
     <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/reference/">Reference</a> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a></p>
-    <div class="kicker">Reference Guide</div>
+    <p class="kicker">Machine Learning · Representation Learning</p>
     <h1>Embeddings</h1>
     <p class="updated">Published September 3, 2026 &middot; Machine Learning &amp; Representation Theory</p>
 

--- a/reference/fine-tuning/index.html
+++ b/reference/fine-tuning/index.html
@@ -181,7 +181,7 @@
 <body class="reference">
   <main>
     <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/reference/">Reference</a> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a></p>
-    <div class="kicker">Reference Guide</div>
+    <p class="kicker">Machine Learning · Model Adaptation</p>
     <h1>Fine-Tuning</h1>
     <p class="updated">Published September 3, 2026 &middot; Machine Learning &amp; Alignment Engineering</p>
 

--- a/reference/large-language-models/index.html
+++ b/reference/large-language-models/index.html
@@ -86,7 +86,7 @@
 <body class="reference">
   <main>
     <p class="back"><a href="/reference/">← Reference</a> · <a href="/">Nestor G Pestelos Jr</a> · <a href="#" onclick="window.print(); return false;">Print this page</a></p>
-    <p class="kicker">Reference Document</p>
+    <p class="kicker">Artificial Intelligence · Language Modeling</p>
     <h1>Large Language Models</h1>
     <p class="subtitle">A citable reference on Large Language Models (LLMs): transformer mechanics, tokenization, context engineering, RAG pipelines, architectural resilience patterns, and evaluation frameworks.</p>
 

--- a/reference/latency/index.html
+++ b/reference/latency/index.html
@@ -204,7 +204,7 @@
       <a href="/reference/">&larr; Reference</a> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a>
     </nav>
 
-    <div class="kicker">Reference Entry</div>
+    <p class="kicker">Systems Engineering · Performance</p>
     <h1>Latency (Systems and Computing)</h1>
     <p class="updated">Reference entry &middot; last updated September 7, 2026</p>
 

--- a/reference/llm-inference/index.html
+++ b/reference/llm-inference/index.html
@@ -82,7 +82,7 @@
 <body class="reference">
   <main>
     <p class="back"><a href="/reference/">← Reference</a> · <a href="/">Nestor G Pestelos Jr</a> · <a href="#" onclick="window.print(); return false;">Print this page</a></p>
-    <p class="kicker">Reference Document</p>
+    <p class="kicker">Artificial Intelligence · Inference</p>
     <h1>LLM Inference</h1>
     <p class="subtitle">A citable reference on Large Language Model inference: the two-phase prefill-decode lifecycle, operational bottlenecks, KV cache management, and high-throughput serving systems.</p>
 

--- a/reference/machine-learning/index.html
+++ b/reference/machine-learning/index.html
@@ -231,7 +231,7 @@
 <body class="reference">
   <main>
     <p class="back"><a href="/reference/">← Reference</a> · <a href="/">Nestor G Pestelos Jr</a> · <a href="#" onclick="window.print(); return false;">Print this page</a></p>
-    <p class="kicker">Reference Document</p>
+    <p class="kicker">Artificial Intelligence · Statistical Learning</p>
     <h1>Machine Learning</h1>
     <p class="subtitle">A citable reference on Machine Learning (ML): empirical risk minimization, supervised, unsupervised, and reinforcement paradigms, optimization, and generalization theorems.</p>
 

--- a/reference/natural-language-processing/index.html
+++ b/reference/natural-language-processing/index.html
@@ -231,7 +231,7 @@
 <body class="reference">
   <main>
     <p class="back"><a href="/reference/">← Reference</a> · <a href="/">Nestor G Pestelos Jr</a> · <a href="#" onclick="window.print(); return false;">Print this page</a></p>
-    <p class="kicker">Reference Document</p>
+    <p class="kicker">Artificial Intelligence · Computational Linguistics</p>
     <h1>Natural Language Processing</h1>
     <p class="subtitle">A citable reference on Natural Language Processing (NLP): linguistic representations, statistical language modeling, tokenization algorithms, sequence-to-sequence mechanisms, and transformers.</p>
 

--- a/reference/online-payments/index.html
+++ b/reference/online-payments/index.html
@@ -281,7 +281,7 @@
 <body class="reference">
   <main>
     <p class="back"><a href="/reference/">← Reference</a> · <a href="/">Nestor G Pestelos Jr</a> · <a href="#" onclick="window.print(); return false;">Print this page</a></p>
-    <p class="kicker">Reference Document</p>
+    <p class="kicker">Financial Technology · Payment Systems</p>
     <h1>Online Payments</h1>
     <p class="subtitle">A citable reference on how electronic money moves: 4-party card flows, CNP fraud mechanics, PCI DSS compliance, Ruby adapter abstractions, and US vs. Philippine interbank settlement rails.</p>
 

--- a/reference/ooda-loop/index.html
+++ b/reference/ooda-loop/index.html
@@ -250,7 +250,7 @@
 <body class="reference">
   <main>
     <p class="back"><a href="/reference/">← Reference</a> · <a href="/">Nestor G Pestelos Jr</a> · <a href="#" onclick="window.print(); return false;">Print this page</a></p>
-    <p class="kicker">Reference Document</p>
+    <p class="kicker">Decision Theory · Cybernetics</p>
     <h1>OODA Loop</h1>
     <p class="subtitle">A citable ground-truth reference on John Boyd's OODA Loop: cybernetic decision theory, Orientation as Schwerpunkt, Destruction and Creation, Implicit Guidance and Control, and agent architectures.</p>
 

--- a/reference/parallelism/index.html
+++ b/reference/parallelism/index.html
@@ -204,7 +204,7 @@
       <a href="/reference/">&larr; Reference</a> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a>
     </nav>
 
-    <div class="kicker">Reference Entry</div>
+    <p class="kicker">Computer Architecture · Parallel Computing</p>
     <h1>Parallelism (Computing)</h1>
     <p class="updated">Reference entry &middot; last updated September 7, 2026</p>
 

--- a/reference/pre-training/index.html
+++ b/reference/pre-training/index.html
@@ -181,7 +181,7 @@
 <body class="reference">
   <main>
     <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/reference/">Reference</a> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a></p>
-    <div class="kicker">Reference Guide</div>
+    <p class="kicker">Machine Learning · Self-Supervised Learning</p>
     <h1>Pre-Training</h1>
     <p class="updated">Published September 3, 2026 &middot; Deep Learning &amp; Language Modeling</p>
 

--- a/reference/prompt-engineering/index.html
+++ b/reference/prompt-engineering/index.html
@@ -250,7 +250,7 @@
 <body class="reference">
   <main>
     <p class="back"><a href="/reference/">← Reference</a> · <a href="/">Nestor G Pestelos Jr</a> · <a href="#" onclick="window.print(); return false;">Print this page</a></p>
-    <p class="kicker">Reference Document</p>
+    <p class="kicker">Artificial Intelligence · Prompt Design</p>
     <h1>Prompt Engineering</h1>
     <p class="subtitle">A citable ground-truth reference on Prompt Engineering: conditioning autoregressive models, in-context learning, reasoning scaffolding (CoT, ToT, ReAct), structured outputs, and prompt security.</p>
 

--- a/reference/prompt-injection/index.html
+++ b/reference/prompt-injection/index.html
@@ -71,7 +71,7 @@
 <body class="reference">
   <main>
     <p class="back"><a href="/reference/">← Reference</a> · <a href="/">Nestor G Pestelos Jr</a> · <a href="#" onclick="window.print(); return false;">Print this page</a></p>
-    <p class="kicker">Reference Document</p>
+    <p class="kicker">Cybersecurity · Language Model Security</p>
     <h1>Prompt Injection</h1>
     <p class="subtitle">A citable reference on prompt injection vulnerabilities: control-plane confusion, direct and indirect attack vectors, blast-radius mitigation, and defensive architectures.</p>
 

--- a/reference/prompt/index.html
+++ b/reference/prompt/index.html
@@ -181,7 +181,7 @@
 <body class="reference">
   <main>
     <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/reference/">Reference</a> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a></p>
-    <div class="kicker">Reference Guide</div>
+    <p class="kicker">Artificial Intelligence · Language Model Inputs</p>
     <h1>Prompts</h1>
     <p class="updated">Published September 3, 2026 &middot; Human-Computer Interaction &amp; Language Modeling</p>
 

--- a/reference/reasoning/index.html
+++ b/reference/reasoning/index.html
@@ -181,7 +181,7 @@
 <body class="reference">
   <main>
     <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/reference/">Reference</a> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a></p>
-    <div class="kicker">Reference Guide</div>
+    <p class="kicker">Artificial Intelligence · Reasoning</p>
     <h1>Reasoning in Language Models</h1>
     <p class="updated">Published September 3, 2026 &middot; Cognitive Science &amp; Artificial Intelligence</p>
 

--- a/reference/test-time-compute/index.html
+++ b/reference/test-time-compute/index.html
@@ -204,7 +204,7 @@
       <a href="/reference/">&larr; Reference</a> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a>
     </nav>
 
-    <div class="kicker">Reference Entry</div>
+    <p class="kicker">Artificial Intelligence · Inference</p>
     <h1>Test-Time Compute</h1>
     <p class="updated">Reference entry &middot; last updated September 7, 2026</p>
 

--- a/reference/transformer-architecture/index.html
+++ b/reference/transformer-architecture/index.html
@@ -82,7 +82,7 @@
 <body class="reference">
   <main>
     <p class="back"><a href="/reference/">← Reference</a> · <a href="/">Nestor G Pestelos Jr</a> · <a href="#" onclick="window.print(); return false;">Print this page</a></p>
-    <p class="kicker">Reference Document</p>
+    <p class="kicker">Machine Learning · Neural Network Architecture</p>
     <h1>Transformer Architecture</h1>
     <p class="subtitle">A citable reference on the Transformer architecture: self-attention formulations, multi-head projection layers, residual normalization, and sequence representations.</p>
 

--- a/reference/vector-search/index.html
+++ b/reference/vector-search/index.html
@@ -181,7 +181,7 @@
 <body class="reference">
   <main>
     <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/reference/">Reference</a> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a></p>
-    <div class="kicker">Reference Guide</div>
+    <p class="kicker">Information Retrieval · Similarity Search</p>
     <h1>Vector Search</h1>
     <p class="updated">Published September 3, 2026 &middot; Information Retrieval &amp; Computational Geometry</p>
 

--- a/reference/x402/index.html
+++ b/reference/x402/index.html
@@ -208,7 +208,7 @@
 <body class="reference">
   <main>
     <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/reference/">Reference</a><span class="print"> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a></span></p>
-    <p class="kicker">Reference</p>
+    <p class="kicker">Financial Technology · Payment Protocols</p>
     <h1>x402 (HTTP 402 Payment Protocol)</h1>
     <p class="updated">Updated September 2026</p>
 

--- a/scripts/test_site_discoverability.py
+++ b/scripts/test_site_discoverability.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 import re
 import unittest
+from html import unescape
 from html.parser import HTMLParser
 import xml.etree.ElementTree as ET
 from datetime import datetime, timedelta
@@ -274,6 +275,21 @@ class SiteDiscoverabilityTests(unittest.TestCase):
 
 
 class ReferenceSeoTests(unittest.TestCase):
+    def test_reference_entries_have_semantic_paragraph_kickers(self):
+        generic_labels = {"reference", "reference entry", "reference document", "reference guide"}
+        for path in sorted(REF.glob("*/index.html")):
+            html = path.read_text(encoding="utf-8")
+            with self.subTest(slug=path.parent.name):
+                kickers = re.findall(
+                    r'<(\w+) class="kicker">(.*?)</\1>', html, re.S
+                )
+                self.assertEqual(len(kickers), 1)
+                tag, content = kickers[0]
+                self.assertEqual(tag, "p")
+                label = " ".join(unescape(re.sub(r"<[^>]+>", "", content)).split())
+                self.assertTrue(label)
+                self.assertNotIn(label.casefold(), generic_labels)
+
     def test_reference_titles_use_middot_not_emdash(self):
         for path in sorted(REF.rglob("index.html")):
             raw = path.read_bytes()


### PR DESCRIPTION
Replace generic document labels with subject categories and normalize entry kickers to paragraphs, retaining existing semantic labels. The existing discoverability suite now rejects missing, generic, duplicate, or non-paragraph kickers.

Validation: regression failed on 27 entries before the fix; all 9 writing-layout and 21 discoverability tests pass at `3c5f4f82d942f8fd2b354821c4f61386c043823c`. Byte comparison confirmed content outside kicker tags is unchanged. The branch incorporates the merged latency Mermaid update, which independently fixed that entry’s kicker.

References #66. The companion `public-reference-pages` skill convention is handled in a separate hermes-config change; this PR contains the site and regression gate only.
