### PR TITLE
Clarify agents and move POMDP to its own reference

### DIFF
--- a/reference/agents-before-pomdp-20260908/index.html
+++ b/reference/agents-before-pomdp-20260908/index.html
@@ -3,13 +3,13 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>AI Agents (LLM-Based) · Reference · Nestor G Pestelos Jr</title>
+  <title>AI Agents (LLM-Based), archived 20260908 · Reference · Nestor G Pestelos Jr</title>
   <meta name="description" content="LLM-based agents: definitions, execution patterns, tool boundaries, memory, and multi-agent trade-offs.">
-  <meta property="og:title" content="AI Agents (LLM-Based) · Reference">
+  <meta property="og:title" content="AI Agents (LLM-Based), archived 20260908 · Reference">
   <meta property="og:description" content="LLM-based agents: definitions, execution patterns, tool boundaries, memory, and multi-agent trade-offs.">
   <meta property="og:type" content="article">
-  <meta property="og:url" content="https://ngpestelos.com/reference/agents/">
-  <link rel="canonical" href="https://ngpestelos.com/reference/agents/">
+  <meta property="og:url" content="https://ngpestelos.com/reference/agents-before-pomdp-20260908/">
+  <link rel="canonical" href="https://ngpestelos.com/reference/agents-before-pomdp-20260908/">
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=20260813f">
   <link rel="icon" href="/favicon-192.png?v=20260813f" type="image/png" sizes="192x192">
   <link rel="icon" href="/favicon-32.png?v=20260813f" type="image/png" sizes="32x32">
@@ -205,23 +205,24 @@
     }
   </style>
   <script type="application/ld+json">
-{"@context":"https://schema.org","@type":"DefinedTerm","name":"AI Agents (LLM-Based)","description":"LLM-based agents: definitions, execution patterns, tool boundaries, memory, and multi-agent trade-offs.","url":"https://ngpestelos.com/reference/agents/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"AI Agents (LLM-Based), archived 20260908","description":"LLM-based agents: definitions, execution patterns, tool boundaries, memory, and multi-agent trade-offs.","url":"https://ngpestelos.com/reference/agents-before-pomdp-20260908/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
   </script>
 </head>
 <body class="reference">
   <main>
     <p class="back"><a href="/reference/">← Reference</a> · <a href="/">Nestor G Pestelos Jr</a> · <a href="#" onclick="window.print(); return false;">Print this page</a></p>
     <p class="kicker">Artificial Intelligence · Autonomous Agents</p>
-    <h1>AI Agents (LLM-Based)</h1>
+    <h1>AI Agents (LLM-Based), archived 20260908</h1>
+    <p class="updated">Archived before the POMDP extraction on 20260908. <a href="/reference/agents/">Read the current entry</a>.</p>
     <p class="subtitle">Definitions, execution patterns, tool boundaries, memory, and multi-agent trade-offs.</p>
     <p class="updated">Reference entry &middot; last updated 20260908</p>
-    <p><em><a href="/reference/agents-before-pomdp-20260908/">Previous version (before the POMDP extraction, 20260908)</a>.</em></p>
+    <p><em><a href="/reference/agents-20260908/">Previous version (before the 20260908 revision)</a>.</em></p>
     <p><strong>An LLM-based AI agent</strong> is a system in which a language model selects actions and uses their results to pursue a task. Its host controls which tools and permissions are available. <span class="cite">[<a href="#ref1">1</a>]</span></p>
 
     <nav class="toc" aria-label="Contents">
       <strong>Contents</strong>
       <ol>
-        <li><a href="#first-principles">First Principles: Choosing the Next Action</a></li>
+        <li><a href="#first-principles">First Principles: Scope &amp; Model</a></li>
         <li><a href="#core-subsystems">Agent Subsystems</a></li>
         <li><a href="#execution-loops">Execution Patterns</a></li>
         <li><a href="#tool-calling">Tool Calling &amp; Sandboxing</a></li>
@@ -234,18 +235,20 @@
     </nav>
 
     <span id="definition"></span>
-    <h2 id="first-principles">1. First Principles: Choosing the Next Action</h2>
-    <p>This entry covers tool-using LLM systems. A <strong>workflow</strong> follows steps set in code. An <strong>agent</strong> lets the model choose the next action from the information available. A system can combine both. Explicit plans and persistent memory are optional. <span class="cite">[<a href="#ref1">1</a>]</span></p>
-    <p>For example, an agent given the task “fix a failing test” might:</p>
-    <ol>
-      <li>Read the failure message.</li>
-      <li>Choose a source file to inspect.</li>
-      <li>Edit the suspected cause and run the test.</li>
-      <li>Use the result to decide whether to investigate further or finish.</li>
-    </ol>
-    <p>The model chooses each next step from what it finds; the host software executes permitted tool calls and returns their results. The host also enforces limits on what the agent can do. <span class="cite">[<a href="#ref1">1</a>, <a href="#ref7">7</a>]</span></p>
-    <p>The agent has <strong>observations</strong>, such as file contents and test output. The <strong>state</strong> is the underlying situation, including code and environment details it may not have inspected. A failure message gives evidence about a bug without revealing its cause.</p>
-    <p>A <a href="/reference/pomdp/">partially observable Markov decision process (POMDP)</a> formalizes decisions under incomplete information. It is an optional mathematical model for this loop; building an agent does not require a POMDP solver. <span class="cite">[<a href="#ref2">2</a>]</span></p>
+    <h2 id="first-principles">1. First Principles: Scope &amp; Model</h2>
+    <p>This entry covers tool-using LLM systems. Following Anthropic's distinction, a <strong>workflow</strong> follows predefined control paths; an <strong>agent</strong> lets the model choose its next steps. A system can combine both. Explicit plans and persistent memory are optional design choices. <span class="cite">[<a href="#ref1">1</a>]</span></p>
+    <p>A partially observable Markov decision process (POMDP) can model action selection under incomplete information. It assumes the state captures what determines subsequent transitions and rewards. The stationary model below also assumes these rules do not change over time. <span class="cite">[<a href="#ref2">2</a>]</span></p>
+    $$\mathcal{M} = \langle \mathcal{S}, \mathcal{A}, \mathcal{O}, \mathcal{T}, \mathcal{Z}, \mathcal{R}, \gamma \rangle$$
+    <ul>
+      <li>\(\mathcal{S}\): states; \(\mathcal{A}\): available actions; \(\mathcal{O}\): observations.</li>
+      <li>\(\mathcal{T}(s_{t+1} \mid s_t,a_t)\): transition probabilities.</li>
+      <li>\(\mathcal{Z}(o_{t+1} \mid s_{t+1},a_t)\): observation probabilities.</li>
+      <li>\(\mathcal{R}(s_t,a_t)\): expected reward.</li>
+      <li>\(\gamma \in [0,1]\): discount factor for a finite horizon \(H\).</li>
+    </ul>
+    <p>An initial state distribution completes the model. A policy maps available history \(h_t\) to actions. One objective is:</p>
+    $$\pi^* = \arg\max_\pi \mathbb{E}_{\pi}\left[\sum_{t=0}^{H}\gamma^t\mathcal{R}(s_t,a_t)\right]$$
+    <p>This is a modeling objective. An LLM tool loop need not compute transition probabilities, update a belief distribution, or solve this optimization at runtime.</p>
 
     <h2 id="core-subsystems">2. Agent Subsystems</h2>
     <p class="unattributed">The four-part grouping below is this entry's organizational model. Implementations can combine or omit parts.</p>
@@ -377,7 +380,6 @@
         <li><a href="/writing/ai-writes-code-plan-becomes-work/">When the AI Writes the Code, the Plan Becomes the Work</a></li>
         <li><a href="/writing/agent-didnt-get-dumber-chat-got-contaminated/">The Agent Didn't Get Dumber, the Chat Got Contaminated</a></li>
         <li><a href="/writing/debug-system-not-prompt/">Debug the System Not the Prompt</a></li>
-        <li><a href="/reference/pomdp/">POMDPs for AI Agents</a></li>
         <li><a href="/reference/ooda-loop/">OODA Loop</a></li>
         <li><a href="/reference/context-engineering/">Context Engineering</a></li>
         <li><a href="/reference/prompt-engineering/">Prompt Engineering</a></li>

--- a/reference/concurrency/index.html
+++ b/reference/concurrency/index.html
@@ -198,7 +198,7 @@
     }
   </style>
 </head>
-<body>
+<body class="reference">
   <main>
     <nav class="back" aria-label="Breadcrumb">
       <a href="/reference/">&larr; Reference</a> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a>

--- a/reference/index.html
+++ b/reference/index.html
@@ -353,6 +353,7 @@
         <li><a href="/reference/perception/">Perception</a></li>
         <li><a href="/reference/personal-knowledge-management/">Personal Knowledge Management</a></li>
         <li><a href="/reference/plan-approve-execute/">Plan-Approve-Execute</a></li>
+        <li><a href="/reference/pomdp/">POMDPs for AI Agents</a></li>
         <li><a href="/reference/pre-training/">Pre-Training</a></li>
         <li><a href="/reference/prompt/">Prompt</a></li>
         <li><a href="/reference/prompt-caching/">Prompt Caching</a></li>

--- a/reference/parallelism/index.html
+++ b/reference/parallelism/index.html
@@ -198,7 +198,7 @@
     }
   </style>
 </head>
-<body>
+<body class="reference">
   <main>
     <nav class="back" aria-label="Breadcrumb">
       <a href="/reference/">&larr; Reference</a> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a>

--- a/reference/pomdp/index.html
+++ b/reference/pomdp/index.html
@@ -1,0 +1,314 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>POMDPs for AI Agents · Reference · Nestor G Pestelos Jr</title>
+  <meta name="description" content="Partially observable Markov decision processes for AI agents, explained through debugging: states, observations, rewards, policies, and assumptions.">
+  <meta property="og:title" content="POMDPs for AI Agents · Reference">
+  <meta property="og:description" content="Partially observable Markov decision processes for AI agents, explained through debugging: states, observations, rewards, policies, and assumptions.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://ngpestelos.com/reference/pomdp/">
+  <link rel="canonical" href="https://ngpestelos.com/reference/pomdp/">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=20260813f">
+  <link rel="icon" href="/favicon-192.png?v=20260813f" type="image/png" sizes="192x192">
+  <link rel="icon" href="/favicon-32.png?v=20260813f" type="image/png" sizes="32x32">
+  <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
+  <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="stylesheet" href="/style.css?v=20260903e">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TLBY8P4GG9');
+  </script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css" crossorigin="anonymous">
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
+    onload="renderMathInElement(document.body, {
+      delimiters: [
+        {left: '$$', right: '$$', display: true},
+        {left: '$', right: '$', display: false},
+        {left: '\\[', right: '\\]', display: true},
+        {left: '\\(', right: '\\)', display: false}
+      ]
+    });"></script>
+  <style>
+    
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; scroll-behavior: smooth; }
+    body {
+      line-height: 1.6;
+    }
+    main {
+      max-width: 48rem;
+      margin: 0 auto;
+      padding: 1.4rem 1.4rem 4rem;
+    }
+    .back {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .back a { color: var(--link); text-decoration: none; }
+    .back a:hover { text-decoration: underline; }
+    .kicker {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.78rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--mute);
+      margin-bottom: 0.2rem;
+    }
+    h1 {
+      font-size: clamp(1.9rem, 5vw, 2.4rem);
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.4rem;
+      margin-bottom: 0.8rem;
+    }
+    .subtitle {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 1rem;
+      color: var(--mute);
+      margin-bottom: 1.6rem;
+      line-height: 1.5;
+    }
+    .toc {
+      background: var(--well);
+      border: 1px solid var(--line);
+      border-radius: 4px;
+      padding: 1.1rem 1.4rem;
+      margin-bottom: 2rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.9rem;
+    }
+    .toc a { color: var(--link); }
+    h2 {
+      font-size: 1.45rem;
+      font-weight: 700;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.3rem;
+      margin-top: 2.2rem;
+      margin-bottom: 0.9rem;
+      color: var(--ink);
+    }
+    h3 {
+      font-size: 1.15rem;
+      font-weight: 700;
+      margin-top: 1.4rem;
+      margin-bottom: 0.3rem;
+      color: var(--ink);
+    }
+    p { margin-bottom: 1rem; }
+    ul, ol { margin-bottom: 1rem; padding-left: 1.5rem; }
+    li { margin-bottom: 0.4rem; }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1.2rem 0 1.8rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.88rem;
+    }
+    th, td {
+      border: 1px solid var(--line);
+      padding: 0.55rem 0.75rem;
+      text-align: left;
+      vertical-align: top;
+    }
+    th { background: var(--well); font-weight: 600; }
+    code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.88em;
+      background: #f1f3f5;
+      padding: 0.15em 0.35em;
+      border-radius: 3px;
+    }
+    pre {
+      background: var(--well);
+      border: 1px solid var(--line);
+      border-radius: 4px;
+      padding: 0.9rem 1.1rem;
+      margin: 1rem 0 1.4rem;
+      overflow-x: auto;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.86rem;
+      line-height: 1.45;
+    }
+    .table-scroll { max-width: 100%; overflow-x: auto; }
+    .table-scroll:focus-visible { outline: 2px solid var(--link); outline-offset: 2px; }
+    .katex-display { max-width: 100%; overflow-x: auto; overflow-y: hidden; }
+    .cite { font-size: 0.75em; vertical-align: super; }
+    .updated, .unattributed { color: var(--mute); font-size: 0.9rem; }
+    .unattributed { font-style: italic; }
+    footer {
+      border-top: 1px solid var(--line);
+      margin-top: 3rem;
+      padding-top: 1.4rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+    }
+    footer h3 { font-size: 0.95rem; margin-top: 0; margin-bottom: 0.5rem; }
+    @media print {
+      .back {font-family:"Segoe UI", Helvetica, Arial, sans-serif;display: none;}
+    }
+      .back-to-top {
+      position: fixed;
+      bottom: 1.5rem;
+      right: 1.5rem;
+      width: 2.6rem;
+      height: 2.6rem;
+      border-radius: 50%;
+      background: var(--bg);
+      color: var(--ink);
+      border: 1px solid var(--line);
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      opacity: 0;
+      visibility: hidden;
+      transform: translateY(8px);
+      transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease, background 0.15s ease, border-color 0.15s ease;
+      z-index: 100;
+    }
+    .back-to-top.visible {
+      opacity: 1;
+      visibility: visible;
+      transform: translateY(0);
+    }
+    .back-to-top:hover {
+      background: var(--well);
+      border-color: var(--link);
+      color: var(--link);
+    }
+    .back-to-top:focus-visible {
+      outline: 2px solid var(--link);
+      outline-offset: 2px;
+    }
+    @media print {
+      .back-to-top { display: none !important; }
+    }
+  </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"POMDPs for AI Agents","description":"Partially observable Markov decision processes for AI agents, explained through debugging: states, observations, rewards, policies, and assumptions.","url":"https://ngpestelos.com/reference/pomdp/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
+</head>
+<body class="reference">
+  <main>
+    <p class="back"><a href="/reference/">← Reference</a> · <a href="/">Nestor G Pestelos Jr</a> · <a href="#" onclick="window.print(); return false;">Print this page</a></p>
+    <p class="kicker">Artificial Intelligence · Decision Models</p>
+    <h1>POMDPs for AI Agents</h1>
+    <p class="updated">Reference entry &middot; last updated 20260908</p>
+    <p>A <strong>partially observable Markov decision process (POMDP)</strong> is a mathematical model for choosing actions when the underlying state is only partly observed. It describes how actions change the state, what evidence becomes available, and which outcomes earn rewards. <span class="cite">[<a href="#ref1">1</a>]</span></p>
+
+    <nav class="toc" aria-label="Contents">
+      <strong>Contents</strong>
+      <ol>
+        <li><a href="#first-principles">First Principles: State and Observation</a></li>
+        <li><a href="#reward-policy">Reward and Policy</a></li>
+        <li><a href="#formal-model">The Mathematical Model</a></li>
+        <li><a href="#limits">Assumptions and Limits</a></li>
+        <li><a href="#references">References</a></li>
+        <li><a href="#see-also">See Also</a></li>
+      </ol>
+    </nav>
+
+    <h2 id="first-principles">1. First Principles: State and Observation</h2>
+    <p>The <strong>state</strong> is the underlying situation. An <strong>observation</strong> is evidence available to the agent about that situation. Different states can produce the same observation, so the agent may have to act before it knows which state it is in. <span class="cite">[<a href="#ref1">1</a>]</span></p>
+    <p>For an illustrative debugging task, an agent is asked to fix a failing test. It sees an error message but has not yet inspected the code or environment that caused it.</p>
+    <ol>
+      <li>It reads a source file to narrow down possible causes.</li>
+      <li>It edits the code and runs the test.</li>
+      <li>The result provides new evidence for its next decision.</li>
+    </ol>
+    <p>Reading a file can give the agent more information without changing the code. Editing changes the code, but the effect still needs checking. Both are actions in this model.</p>
+    <div class="table-scroll" role="region" aria-label="Debugging example" tabindex="0">
+      <table>
+        <thead><tr><th>Concept</th><th>Debugging example</th></tr></thead>
+        <tbody>
+          <tr><td>State</td><td>Code and relevant environment details, including the cause of the failure.</td></tr>
+          <tr><td>Action</td><td>Read a file, edit code, run a test, or finish.</td></tr>
+          <tr><td>Observation</td><td>Returned file contents, a tool error, or test output.</td></tr>
+          <tr><td>Transition</td><td>How an action changes the state, such as an edit changing the code.</td></tr>
+          <tr><td>Observation model</td><td>How likely a tool result is, given the resulting state and the action.</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <h2 id="reward-policy">2. Reward and Policy</h2>
+    <p>A <strong>reward</strong> is a numerical score specified by the model designer. It expresses which outcomes the objective favors and can include costs. The reward function gives the expected immediate reward for an action in a state. <span class="cite">[<a href="#ref2">2</a>]</span></p>
+    <p>One illustrative debugging objective could award 100 points once, when the agent finishes with a correct fix, and subtract one point per tool call. These invented scores express a preference for a correct fix with fewer calls. They are not scores that every coding agent computes.</p>
+    <p>The score must match the intended task. Rewarding a passing test alone can favor deleting the test or weakening its assertion. Even an unchanged passing test provides evidence within its coverage; it does not prove that the program is correct.</p>
+    <p>A <strong>policy</strong> is a rule for choosing the next action from the available history. In the example, a policy might choose another inspection after a failure or a broader test run after a pass. An action can have value because it gathers information that improves later choices. <span class="cite">[<a href="#ref1">1</a>]</span></p>
+
+    <h2 id="formal-model">3. The Mathematical Model</h2>
+    <p>In a stationary POMDP, the transition, observation, and reward rules stay fixed over time. One notation is:</p>
+    $$\mathcal{M} = \langle \mathcal{S},\mathcal{A},\mathcal{O},\mathcal{T},\mathcal{Z},\mathcal{R},b_0 \rangle$$
+    <ul>
+      <li>\(\mathcal{S}\): possible states; \(\mathcal{A}\): available actions; \(\mathcal{O}\): possible observations.</li>
+      <li>\(\mathcal{T}(s_{t+1}\mid s_t,a_t)\): probability of the next state after an action.</li>
+      <li>\(\mathcal{Z}(o_{t+1}\mid s_{t+1},a_t)\): probability of an observation given the resulting state and action.</li>
+      <li>\(\mathcal{R}(s_t,a_t)\): expected immediate reward.</li>
+      <li>\(b_0(s)\): initial probability distribution over states, given the information available before the first action.</li>
+    </ul>
+    <p>At step \(t\), the policy selects an action using the available history \(h_t\). The system moves to a new state and produces an observation. A belief distribution can summarize the agent's uncertainty over states and be updated after each action and observation. <span class="cite">[<a href="#ref1">1</a>]</span></p>
+    <p>For a finite horizon of \(H\) decisions, at steps \(0\) through \(H-1\), one objective is:</p>
+    $$\pi^* = \arg\max_\pi \mathbb{E}_{\pi,b_0}\left[\sum_{t=0}^{H-1}\gamma^t\mathcal{R}(s_t,a_t)\right]$$
+    <p>This chooses the policy with the highest expected total reward over those steps. The expectation accounts for uncertainty in the initial state, transitions, observations, and any randomized action choices. <span class="cite">[<a href="#ref2">2</a>]</span></p>
+    <ul>
+      <li><strong>Horizon \(H\):</strong> the number of decisions considered. The best action may depend on how many steps remain.</li>
+      <li><strong>Discount factor \(\gamma\in[0,1]\):</strong> the weight on later rewards. With \(\gamma=1\), all steps have equal weight. Smaller values favor earlier rewards.</li>
+    </ul>
+    <p>The horizon and discount factor specify this objective. No separate terminal reward is assumed here. A task that finishes early can enter a terminal state with zero rewards afterward. <span class="cite">[<a href="#ref2">2</a>]</span></p>
+
+    <h2 id="limits">4. Assumptions and Limits</h2>
+    <ul>
+      <li><strong>Markov state:</strong> the state must capture what determines the next-state probabilities and expected reward. Earlier history adds no further information once that state and the action are known.</li>
+      <li><strong>Stationary rules:</strong> the transition, observation, and reward rules above stay fixed over time. A changing environment needs a richer state or a model with time-dependent rules.</li>
+    </ul>
+    <p>These are assumptions about the model, not guarantees about a software project. Missing environment details can make the chosen state description inadequate. <span class="cite">[<a href="#ref2">2</a>]</span></p>
+    <p>An LLM agent can choose tools and use their results without computing transition probabilities, maintaining a belief distribution, or solving the equation at runtime. The POMDP describes a decision problem; the implementation may use a language model to choose its next action. Its host controls tool execution, permissions, and stopping limits. <span class="cite">[<a href="#ref3">3</a>]</span></p>
+
+    <footer id="sources">
+      <h2 id="references">5. References</h2>
+      <ol>
+        <li id="ref1">Anthony R. Cassandra. <a href="https://www.pomdp.org/tutorial/pomdp-background.html">Background on POMDPs</a>. Author's tutorial on partial observations, observation models, and belief states.</li>
+        <li id="ref2">David L. Poole and Alan K. Mackworth. <a href="https://artint.info/3e/html/ArtInt3e.Ch12.S5.html">Artificial Intelligence: Foundations of Computational Agents, 3rd edition, §12.5: Decision Processes</a>. Rewards, horizons, discounting, and partially observable decision processes.</li>
+        <li id="ref3">Anthropic. <a href="https://www.anthropic.com/engineering/building-effective-agents">Building effective agents</a> (2024). Practical agent loops and tool use.</li>
+      </ol>
+      <h2 id="see-also">6. See Also</h2>
+      <ul>
+        <li><a href="/reference/agents/">AI Agents (LLM-Based)</a></li>
+        <li><a href="/reference/agent-harness/">Agent Harness</a></li>
+        <li><a href="/eli5/agents/">ELI5: How Do AI Agents Work?</a></li>
+      </ul>
+    </footer>
+  </main>
+  <button id="backToTop" class="back-to-top" aria-label="Back to top" title="Back to top">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M18 15l-6-6-6 6"/>
+    </svg>
+  </button>
+
+  <script>
+    const btt = document.getElementById('backToTop');
+    window.addEventListener('scroll', () => {
+      if (window.scrollY > 250) {
+        btt.classList.add('visible');
+      } else {
+        btt.classList.remove('visible');
+      }
+    }, { passive: true });
+    btt.addEventListener('click', () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  </script>
+</body>
+</html>

--- a/reference/test-time-compute/index.html
+++ b/reference/test-time-compute/index.html
@@ -198,7 +198,7 @@
     }
   </style>
 </head>
-<body>
+<body class="reference">
   <main>
     <nav class="back" aria-label="Breadcrumb">
       <a href="/reference/">&larr; Reference</a> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1100,4 +1100,9 @@
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
+  <url>
+    <loc>https://ngpestelos.com/reference/pomdp/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
The agents opening introduced POMDP notation before explaining the tool loop. It now starts with a failing-test example, distinguishes observations from state, and links to a separate POMDP reference.

The new page explains reward and policy before the equations. The exact prior agents body is preserved as a dated snapshot. Reference navigation, reciprocal links, and the sitemap are updated.

A separate commit restores three missing reference theme classes on Concurrency, Parallelism, and Test-Time Compute, which caused the existing suite to fail before this change.

Validation: all 36 site tests passed at a8ee36f3cfc2c3d83780acb12a76b09c6074fd30. Desktop/mobile HTTP rendering, KaTeX, links, metadata, archive fidelity, and two independent prose reads passed.

Preview: [Agents](https://refactor-agents-pomdp.ngpestelos-com.pages.dev/reference/agents/) · [POMDP](https://refactor-agents-pomdp.ngpestelos-com.pages.dev/reference/pomdp/).
