### PR TITLE
Add volts, watts, and amps reference pages

### DIFF
--- a/reference/amps/index.html
+++ b/reference/amps/index.html
@@ -1,0 +1,304 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Amps (Electric Current) &middot; Reference &middot; Nestor G Pestelos Jr</title>
+  <meta name="description" content="The ampere measures electric current: charge flow per second. Definitions, DC calculations, and amp-hours.">
+  <meta property="og:title" content="Amps (Electric Current) · Reference">
+  <meta property="og:description" content="The ampere measures electric current: charge flow per second. Definitions, DC calculations, and amp-hours.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://ngpestelos.com/reference/amps/">
+  <link rel="canonical" href="https://ngpestelos.com/reference/amps/">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=20260813f">
+  <link rel="icon" href="/favicon-192.png?v=20260813f" type="image/png" sizes="192x192">
+  <link rel="icon" href="/favicon-32.png?v=20260813f" type="image/png" sizes="32x32">
+  <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
+  <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="stylesheet" href="/style.css?v=20260903e">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TLBY8P4GG9');
+  </script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css" crossorigin="anonymous">
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
+    onload="renderMathInElement(document.body, {
+      delimiters: [
+        {left: '$$', right: '$$', display: true},
+        {left: '\\[', right: '\\]', display: true},
+        {left: '\\(', right: '\\)', display: false}
+      ]
+    });"></script>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; scroll-behavior: smooth; }
+    body {
+      line-height: 1.6;
+    }
+    main {
+      max-width: 48rem;
+      margin: 0 auto;
+      padding: 1.4rem 1.4rem 4rem;
+    }
+    .back {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .back a { color: var(--link); text-decoration: none; }
+    .back a:hover { text-decoration: underline; }
+    .kicker {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.78rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--mute);
+      margin-bottom: 0.2rem;
+    }
+    h1 {
+      font-size: clamp(1.9rem, 5vw, 2.4rem);
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.4rem;
+      margin-bottom: 0.8rem;
+    }
+    .updated {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.82rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .unattributed {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+      font-style: italic;
+    }
+    .lede { margin-bottom: 1.6rem; }
+    .lede strong:first-child { font-weight: 700; }
+    .subtitle {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 1rem;
+      color: var(--mute);
+      margin-bottom: 1.6rem;
+      line-height: 1.5;
+    }
+    .toc {
+      background: var(--well);
+      border: 1px solid var(--line);
+      border-radius: 4px;
+      padding: 1.1rem 1.4rem;
+      margin-bottom: 2rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.9rem;
+    }
+    .toc h2 {
+      font-size: 1rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: 0.5rem;
+      color: var(--ink);
+      border-bottom: none;
+      padding-bottom: 0;
+      margin-top: 0;
+    }
+    .toc ol {
+      padding-left: 1.3rem;
+      margin-bottom: 0;
+    }
+    .toc ol ol {
+      padding-left: 1.2rem;
+      margin-top: 0.15rem;
+    }
+    .toc li { margin: 0.25rem 0; }
+    .toc a { color: var(--link); text-decoration: none; }
+    .toc a:hover { text-decoration: underline; }
+    h2 {
+      font-size: 1.45rem;
+      font-weight: 700;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.3rem;
+      margin-top: 2.2rem;
+      margin-bottom: 0.9rem;
+      color: var(--ink);
+    }
+    h3 {
+      font-size: 1.15rem;
+      font-weight: 700;
+      margin-top: 1.4rem;
+      margin-bottom: 0.3rem;
+      color: var(--ink);
+    }
+    p { margin-bottom: 1rem; }
+    ul, ol { margin-bottom: 1rem; padding-left: 1.5rem; }
+    li { margin-bottom: 0.4rem; }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1.2rem 0 1.8rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.88rem;
+    }
+    th, td {
+      border: 1px solid var(--line);
+      padding: 0.55rem 0.75rem;
+      text-align: left;
+      vertical-align: top;
+    }
+    th { background: var(--well); font-weight: 600; }
+    code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.88em;
+      background: #f1f3f5;
+      padding: 0.15em 0.35em;
+      border-radius: 3px;
+    }
+    .cite {
+      font-size: 0.75em;
+      vertical-align: super;
+      line-height: 0;
+      text-decoration: none;
+    }
+    .cite a { text-decoration: none; }
+    .formula-box {
+      text-align: center;
+      margin: 1.2rem 0;
+      background: var(--well);
+      padding: 0.8rem;
+      border-radius: 4px;
+      border: 1px solid var(--line);
+      overflow-x: auto;
+    }
+    #references {
+      font-size: 0.92rem;
+    }
+    #references ol {
+      padding-left: 1.5rem;
+    }
+    #references li {
+      margin-bottom: 0.5rem;
+    }
+    #references .backlink {
+      margin-right: 0.3rem;
+    }
+    footer.meta {
+      border-top: 1px solid var(--line);
+      margin-top: 3rem;
+      padding-top: 1.4rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+    }
+    footer.meta a { color: var(--link); }
+    @media print {
+      .back {font-family:"Segoe UI", Helvetica, Arial, sans-serif;display: none;}
+    }
+    .back-to-top {
+      position: fixed;
+      bottom: 1.5rem;
+      right: 1.5rem;
+      width: 2.6rem;
+      height: 2.6rem;
+      border-radius: 50%;
+      background: var(--bg);
+      color: var(--ink);
+      border: 1px solid var(--line);
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      opacity: 0;
+      visibility: hidden;
+      transform: translateY(8px);
+      transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease, background 0.15s ease, border-color 0.15s ease;
+      z-index: 100;
+    }
+    .back-to-top.visible {
+      opacity: 1;
+      visibility: visible;
+      transform: translateY(0);
+    }
+    .back-to-top:hover {
+      background: var(--well);
+      border-color: var(--link);
+      color: var(--link);
+    }
+    .back-to-top:focus-visible {
+      outline: 2px solid var(--link);
+      outline-offset: 2px;
+    }
+    @media print {
+      .back-to-top { display: none !important; }
+    }
+  </style>
+
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"DefinedTerm","name":"Amps (Electric Current)","description":"The ampere measures electric current: charge flow per second. Definitions, DC calculations, and amp-hours.","url":"https://ngpestelos.com/reference/amps/","inDefinedTermSet":"https://ngpestelos.com/reference/"}</script>
+</head>
+<body class="reference">
+<main id="top">
+<p class="back"><a href="/reference/">&larr; Reference</a> &middot; <a href="/">Home</a> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a></p>
+<p class="kicker">Physics &middot; Electricity</p>
+<h1>Amps (Electric Current)</h1>
+<p class="updated">Reference entry &middot; last updated 20260908</p>
+
+<p class="lede"><strong>Amps</strong>, short for amperes, measure electric current: the rate at which charge passes through a surface, such as a wire’s cross-section. One ampere (A) equals one coulomb per second.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+<nav class="toc" aria-label="Contents"><div class="toc-title">Contents</div><ol><li><a href="#first-principles">First principles and definitions</a></li><li><a href="#relationships">Current, voltage, and power</a></li><li><a href="#example">Worked DC example</a></li><li><a href="#charge">Amps and amp-hours</a></li><li><a href="#see-also">See also</a></li><li><a href="#references">References</a></li></ol></nav>
+<h2 id="first-principles">1. First principles and definitions</h2>
+<p>Average current is charge passing a point divided by elapsed time. For steady current, \(I=Q/t\), where Q is charge and t is time.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+<div class="formula-box">\[1\,\mathrm{A}=1\,\mathrm{C/s}\]</div>
+<p>The ampere is an SI base unit. Its definition fixes the elementary charge at exactly 1.602176634 × 10<sup>−19</sup> C. A current of 1 A corresponds to about 6.24 × 10<sup>18</sup> elementary charges passing per second.<span class="cite">[<a href="#ref2">2</a>]</span></p>
+<p>Conventional current follows the direction positive charge would move. In a metal wire, electrons drift in the opposite direction.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+<h2 id="relationships">2. Current, voltage, and power</h2>
+<p><a href="/reference/volts/">Voltage</a> measures energy per charge. Current measures charge per second. In steady DC, their product is power in <a href="/reference/watts/">watts</a>. For a resistor obeying Ohm’s law, current equals voltage divided by resistance.<span class="cite">[<a href="#ref3">3</a>]</span></p>
+<div class="formula-box">\[I=P/V,\qquad I=V/R\]</div>
+<h2 id="example">3. Worked DC example</h2>
+<p>Illustrative calculation: a device consuming 24 W at 12 V draws 2 A. That steady current carries 20 C past a point in 10 seconds.</p>
+<div class="formula-box">\[I=24/12=2\,\mathrm{A},\qquad Q=2\times10=20\,\mathrm{C}\]</div>
+<p>A milliampere (mA) is one thousandth of an ampere: 500 mA equals 0.5 A.<span class="cite">[<a href="#ref4">4</a>]</span></p>
+<h2 id="charge">4. Amps and amp-hours</h2>
+<p>An amp-hour (Ah) measures charge. A steady current of 1 A for one hour transfers 3,600 C. Illustrative calculation: 2 A for 3 hours transfers 6 Ah.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+<p>An Ah value alone does not give stored energy. If voltage stays constant, multiplying Ah by V gives Wh. Thus, an idealized 12 V source delivering 6 Ah supplies 72 Wh.<span class="cite">[<a href="#ref3">3</a>]</span></p>
+
+<h2 id="see-also">5. See also</h2>
+<ul><li><a href="/reference/volts/">Volts (Voltage)</a></li><li><a href="/reference/watts/">Watts (Power)</a></li></ul>
+<h2 id="references">6. References</h2>
+<ol>
+<li id="ref1"><a href="https://openstax.org/books/university-physics-volume-2/pages/9-1-electrical-current">OpenStax, University Physics Volume 2, §9.1: Electrical Current (2016)</a></li>
+<li id="ref2"><a href="https://www.nist.gov/si-redefinition/definitions-si-base-units">NIST, Definitions of SI Base Units: Ampere</a></li>
+<li id="ref3"><a href="https://openstax.org/books/university-physics-volume-2/pages/9-5-electrical-energy-and-power">OpenStax, University Physics Volume 2, §9.5: Electrical Energy and Power (2016)</a></li>
+<li id="ref4"><a href="https://www.nist.gov/pml/special-publication-811/nist-guide-si-chapter-4-two-classes-si-units-and-si-prefixes">NIST, The Two Classes of SI Units and the SI Prefixes, Tables 1, 3, and 5</a></li>
+</ol>
+    <footer class="meta">
+      <p><a href="#top">Back to top</a></p>
+    </footer>
+  </main>
+  <button id="backToTop" class="back-to-top" aria-label="Back to top" title="Back to top">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M18 15l-6-6-6 6"/>
+    </svg>
+  </button>
+
+  <script>
+    const btt = document.getElementById('backToTop');
+    window.addEventListener('scroll', () => {
+      if (window.scrollY > 250) {
+        btt.classList.add('visible');
+      } else {
+        btt.classList.remove('visible');
+      }
+    }, { passive: true });
+    btt.addEventListener('click', () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  </script>
+</body>
+</html>

--- a/reference/index.html
+++ b/reference/index.html
@@ -207,6 +207,7 @@
         <li><a href="/reference/agents/">AI Agents (LLM-Based)</a></li>
         <li><a href="/reference/ai-agent-observability/">AI Agent Observability</a></li>
         <li><a href="/reference/amdahls-law/">Amdahl's Law</a></li>
+        <li><a href="/reference/amps/">Amps (Electric Current)</a></li>
         <li><a href="/reference/andy-matuschak/">Andy Matuschak</a></li>
         <li><a href="/reference/annus-mirabilis/">Annus Mirabilis</a></li>
         <li><a href="/reference/artificial-intelligence/">Artificial Intelligence</a></li>
@@ -423,12 +424,14 @@
         <li><a href="/reference/vannevar-bush/">Vannevar Bush</a></li>
         <li><a href="/reference/vector/">Vector (Mathematics and Computing)</a></li>
         <li><a href="/reference/vector-search/">Vector Search</a></li>
+        <li><a href="/reference/volts/">Volts (Voltage)</a></li>
         </ul>
       </div>
 
       <div class="letter-group" id="W">
         <h2 class="letter-heading">W</h2>
         <ul>
+        <li><a href="/reference/watts/">Watts (Power)</a></li>
         <li><a href="/reference/working-memory/">Working Memory</a></li>
         </ul>
       </div>

--- a/reference/volts/index.html
+++ b/reference/volts/index.html
@@ -1,0 +1,302 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Volts (Voltage) &middot; Reference &middot; Nestor G Pestelos Jr</title>
+  <meta name="description" content="The volt measures electric potential difference: energy per charge. Definitions, DC examples, and AC voltage.">
+  <meta property="og:title" content="Volts (Voltage) · Reference">
+  <meta property="og:description" content="The volt measures electric potential difference: energy per charge. Definitions, DC examples, and AC voltage.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://ngpestelos.com/reference/volts/">
+  <link rel="canonical" href="https://ngpestelos.com/reference/volts/">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=20260813f">
+  <link rel="icon" href="/favicon-192.png?v=20260813f" type="image/png" sizes="192x192">
+  <link rel="icon" href="/favicon-32.png?v=20260813f" type="image/png" sizes="32x32">
+  <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
+  <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="stylesheet" href="/style.css?v=20260903e">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TLBY8P4GG9');
+  </script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css" crossorigin="anonymous">
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
+    onload="renderMathInElement(document.body, {
+      delimiters: [
+        {left: '$$', right: '$$', display: true},
+        {left: '\\[', right: '\\]', display: true},
+        {left: '\\(', right: '\\)', display: false}
+      ]
+    });"></script>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; scroll-behavior: smooth; }
+    body {
+      line-height: 1.6;
+    }
+    main {
+      max-width: 48rem;
+      margin: 0 auto;
+      padding: 1.4rem 1.4rem 4rem;
+    }
+    .back {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .back a { color: var(--link); text-decoration: none; }
+    .back a:hover { text-decoration: underline; }
+    .kicker {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.78rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--mute);
+      margin-bottom: 0.2rem;
+    }
+    h1 {
+      font-size: clamp(1.9rem, 5vw, 2.4rem);
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.4rem;
+      margin-bottom: 0.8rem;
+    }
+    .updated {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.82rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .unattributed {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+      font-style: italic;
+    }
+    .lede { margin-bottom: 1.6rem; }
+    .lede strong:first-child { font-weight: 700; }
+    .subtitle {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 1rem;
+      color: var(--mute);
+      margin-bottom: 1.6rem;
+      line-height: 1.5;
+    }
+    .toc {
+      background: var(--well);
+      border: 1px solid var(--line);
+      border-radius: 4px;
+      padding: 1.1rem 1.4rem;
+      margin-bottom: 2rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.9rem;
+    }
+    .toc h2 {
+      font-size: 1rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: 0.5rem;
+      color: var(--ink);
+      border-bottom: none;
+      padding-bottom: 0;
+      margin-top: 0;
+    }
+    .toc ol {
+      padding-left: 1.3rem;
+      margin-bottom: 0;
+    }
+    .toc ol ol {
+      padding-left: 1.2rem;
+      margin-top: 0.15rem;
+    }
+    .toc li { margin: 0.25rem 0; }
+    .toc a { color: var(--link); text-decoration: none; }
+    .toc a:hover { text-decoration: underline; }
+    h2 {
+      font-size: 1.45rem;
+      font-weight: 700;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.3rem;
+      margin-top: 2.2rem;
+      margin-bottom: 0.9rem;
+      color: var(--ink);
+    }
+    h3 {
+      font-size: 1.15rem;
+      font-weight: 700;
+      margin-top: 1.4rem;
+      margin-bottom: 0.3rem;
+      color: var(--ink);
+    }
+    p { margin-bottom: 1rem; }
+    ul, ol { margin-bottom: 1rem; padding-left: 1.5rem; }
+    li { margin-bottom: 0.4rem; }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1.2rem 0 1.8rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.88rem;
+    }
+    th, td {
+      border: 1px solid var(--line);
+      padding: 0.55rem 0.75rem;
+      text-align: left;
+      vertical-align: top;
+    }
+    th { background: var(--well); font-weight: 600; }
+    code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.88em;
+      background: #f1f3f5;
+      padding: 0.15em 0.35em;
+      border-radius: 3px;
+    }
+    .cite {
+      font-size: 0.75em;
+      vertical-align: super;
+      line-height: 0;
+      text-decoration: none;
+    }
+    .cite a { text-decoration: none; }
+    .formula-box {
+      text-align: center;
+      margin: 1.2rem 0;
+      background: var(--well);
+      padding: 0.8rem;
+      border-radius: 4px;
+      border: 1px solid var(--line);
+      overflow-x: auto;
+    }
+    #references {
+      font-size: 0.92rem;
+    }
+    #references ol {
+      padding-left: 1.5rem;
+    }
+    #references li {
+      margin-bottom: 0.5rem;
+    }
+    #references .backlink {
+      margin-right: 0.3rem;
+    }
+    footer.meta {
+      border-top: 1px solid var(--line);
+      margin-top: 3rem;
+      padding-top: 1.4rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+    }
+    footer.meta a { color: var(--link); }
+    @media print {
+      .back {font-family:"Segoe UI", Helvetica, Arial, sans-serif;display: none;}
+    }
+    .back-to-top {
+      position: fixed;
+      bottom: 1.5rem;
+      right: 1.5rem;
+      width: 2.6rem;
+      height: 2.6rem;
+      border-radius: 50%;
+      background: var(--bg);
+      color: var(--ink);
+      border: 1px solid var(--line);
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      opacity: 0;
+      visibility: hidden;
+      transform: translateY(8px);
+      transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease, background 0.15s ease, border-color 0.15s ease;
+      z-index: 100;
+    }
+    .back-to-top.visible {
+      opacity: 1;
+      visibility: visible;
+      transform: translateY(0);
+    }
+    .back-to-top:hover {
+      background: var(--well);
+      border-color: var(--link);
+      color: var(--link);
+    }
+    .back-to-top:focus-visible {
+      outline: 2px solid var(--link);
+      outline-offset: 2px;
+    }
+    @media print {
+      .back-to-top { display: none !important; }
+    }
+  </style>
+
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"DefinedTerm","name":"Volts (Voltage)","description":"The volt measures electric potential difference: energy per charge. Definitions, DC examples, and AC voltage.","url":"https://ngpestelos.com/reference/volts/","inDefinedTermSet":"https://ngpestelos.com/reference/"}</script>
+</head>
+<body class="reference">
+<main id="top">
+<p class="back"><a href="/reference/">&larr; Reference</a> &middot; <a href="/">Home</a> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a></p>
+<p class="kicker">Physics &middot; Electricity</p>
+<h1>Volts (Voltage)</h1>
+<p class="updated">Reference entry &middot; last updated 20260908</p>
+
+<p class="lede"><strong>Volts</strong> measure electric potential difference, also called voltage. One volt (V) equals one joule per coulomb of charge.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+<nav class="toc" aria-label="Contents"><div class="toc-title">Contents</div><ol><li><a href="#first-principles">First principles and definitions</a></li><li><a href="#relationships">Voltage, current, and resistance</a></li><li><a href="#example">Worked DC example</a></li><li><a href="#ac">AC voltage</a></li><li><a href="#see-also">See also</a></li><li><a href="#references">References</a></li></ol></nav>
+<h2 id="first-principles">1. First principles and definitions</h2>
+<p>Charge is measured in coulombs (C), and energy in joules (J). A potential difference describes the change in electric potential energy per unit charge between two points. Voltage therefore requires a reference, such as another terminal or a chosen zero potential.<span class="cite">[<a href="#ref2">2</a>]</span></p>
+<div class="formula-box">\[1\,\mathrm{V}=1\,\mathrm{J/C}\]</div>
+<p><a href="/reference/amps/">Amps</a> measure charge flow per second. <a href="/reference/watts/">Watts</a> measure energy transfer per second. A voltage can exist across an open circuit even when no steady current flows.<span class="cite">[<a href="#ref2">2</a>]</span></p>
+<h2 id="relationships">2. Voltage, current, and resistance</h2>
+<p>For a resistor obeying Ohm’s law, voltage equals current times resistance. Resistance is measured in ohms (Ω). At fixed resistance, doubling voltage doubles current.<span class="cite">[<a href="#ref3">3</a>]</span></p>
+<div class="formula-box">\[V=IR\]</div>
+<p>In steady DC, electrical power is \(P=VI\). Voltage alone does not specify power; current must also be known.<span class="cite">[<a href="#ref3">3</a>]</span></p>
+<h2 id="example">3. Worked DC example</h2>
+<p>Illustrative calculation: a 6 Ω resistor connected across 12 V carries 2 A and dissipates 24 W. Each coulomb passing through it loses 12 J of electric potential energy.</p>
+<div class="formula-box">\[I=12/6=2\,\mathrm{A},\qquad P=12\times2=24\,\mathrm{W}\]</div>
+<h2 id="ac">4. AC voltage</h2>
+<p>An AC voltage changes with time. Its root-mean-square (RMS) value depends on the waveform. For a sine wave, the peak is √2 times the RMS value. An illustrative 230 V RMS sine wave peaks at about 325 V.<span class="cite">[<a href="#ref4">4</a>]</span></p>
+
+<h2 id="see-also">5. See also</h2>
+<ul><li><a href="/reference/watts/">Watts (Power)</a></li><li><a href="/reference/amps/">Amps (Electric Current)</a></li></ul>
+<h2 id="references">6. References</h2>
+<ol>
+<li id="ref1"><a href="https://www.nist.gov/pml/special-publication-811/nist-guide-si-chapter-4-two-classes-si-units-and-si-prefixes">NIST, The Two Classes of SI Units and the SI Prefixes, Tables 1 and 3</a></li>
+<li id="ref2"><a href="https://openstax.org/books/university-physics-volume-2/pages/7-2-electric-potential-and-potential-difference">OpenStax, University Physics Volume 2, §7.2: Electric Potential and Potential Difference (2016)</a></li>
+<li id="ref3"><a href="https://openstax.org/books/university-physics-volume-2/pages/9-5-electrical-energy-and-power">OpenStax, University Physics Volume 2, §9.5: Electrical Energy and Power (2016)</a></li>
+<li id="ref4"><a href="https://openstax.org/books/university-physics-volume-2/pages/15-4-power-in-an-ac-circuit">OpenStax, University Physics Volume 2, §15.4: Power in an AC Circuit (2016)</a></li>
+</ol>
+    <footer class="meta">
+      <p><a href="#top">Back to top</a></p>
+    </footer>
+  </main>
+  <button id="backToTop" class="back-to-top" aria-label="Back to top" title="Back to top">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M18 15l-6-6-6 6"/>
+    </svg>
+  </button>
+
+  <script>
+    const btt = document.getElementById('backToTop');
+    window.addEventListener('scroll', () => {
+      if (window.scrollY > 250) {
+        btt.classList.add('visible');
+      } else {
+        btt.classList.remove('visible');
+      }
+    }, { passive: true });
+    btt.addEventListener('click', () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  </script>
+</body>
+</html>

--- a/reference/watts/index.html
+++ b/reference/watts/index.html
@@ -1,0 +1,305 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Watts (Power) &middot; Reference &middot; Nestor G Pestelos Jr</title>
+  <meta name="description" content="The watt measures power: one joule per second. Electrical power, AC power factor, watts, and watt-hours.">
+  <meta property="og:title" content="Watts (Power) · Reference">
+  <meta property="og:description" content="The watt measures power: one joule per second. Electrical power, AC power factor, watts, and watt-hours.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://ngpestelos.com/reference/watts/">
+  <link rel="canonical" href="https://ngpestelos.com/reference/watts/">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=20260813f">
+  <link rel="icon" href="/favicon-192.png?v=20260813f" type="image/png" sizes="192x192">
+  <link rel="icon" href="/favicon-32.png?v=20260813f" type="image/png" sizes="32x32">
+  <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
+  <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="stylesheet" href="/style.css?v=20260903e">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TLBY8P4GG9');
+  </script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css" crossorigin="anonymous">
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
+    onload="renderMathInElement(document.body, {
+      delimiters: [
+        {left: '$$', right: '$$', display: true},
+        {left: '\\[', right: '\\]', display: true},
+        {left: '\\(', right: '\\)', display: false}
+      ]
+    });"></script>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; scroll-behavior: smooth; }
+    body {
+      line-height: 1.6;
+    }
+    main {
+      max-width: 48rem;
+      margin: 0 auto;
+      padding: 1.4rem 1.4rem 4rem;
+    }
+    .back {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .back a { color: var(--link); text-decoration: none; }
+    .back a:hover { text-decoration: underline; }
+    .kicker {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.78rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--mute);
+      margin-bottom: 0.2rem;
+    }
+    h1 {
+      font-size: clamp(1.9rem, 5vw, 2.4rem);
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.4rem;
+      margin-bottom: 0.8rem;
+    }
+    .updated {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.82rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .unattributed {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+      font-style: italic;
+    }
+    .lede { margin-bottom: 1.6rem; }
+    .lede strong:first-child { font-weight: 700; }
+    .subtitle {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 1rem;
+      color: var(--mute);
+      margin-bottom: 1.6rem;
+      line-height: 1.5;
+    }
+    .toc {
+      background: var(--well);
+      border: 1px solid var(--line);
+      border-radius: 4px;
+      padding: 1.1rem 1.4rem;
+      margin-bottom: 2rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.9rem;
+    }
+    .toc h2 {
+      font-size: 1rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: 0.5rem;
+      color: var(--ink);
+      border-bottom: none;
+      padding-bottom: 0;
+      margin-top: 0;
+    }
+    .toc ol {
+      padding-left: 1.3rem;
+      margin-bottom: 0;
+    }
+    .toc ol ol {
+      padding-left: 1.2rem;
+      margin-top: 0.15rem;
+    }
+    .toc li { margin: 0.25rem 0; }
+    .toc a { color: var(--link); text-decoration: none; }
+    .toc a:hover { text-decoration: underline; }
+    h2 {
+      font-size: 1.45rem;
+      font-weight: 700;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.3rem;
+      margin-top: 2.2rem;
+      margin-bottom: 0.9rem;
+      color: var(--ink);
+    }
+    h3 {
+      font-size: 1.15rem;
+      font-weight: 700;
+      margin-top: 1.4rem;
+      margin-bottom: 0.3rem;
+      color: var(--ink);
+    }
+    p { margin-bottom: 1rem; }
+    ul, ol { margin-bottom: 1rem; padding-left: 1.5rem; }
+    li { margin-bottom: 0.4rem; }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1.2rem 0 1.8rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.88rem;
+    }
+    th, td {
+      border: 1px solid var(--line);
+      padding: 0.55rem 0.75rem;
+      text-align: left;
+      vertical-align: top;
+    }
+    th { background: var(--well); font-weight: 600; }
+    code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.88em;
+      background: #f1f3f5;
+      padding: 0.15em 0.35em;
+      border-radius: 3px;
+    }
+    .cite {
+      font-size: 0.75em;
+      vertical-align: super;
+      line-height: 0;
+      text-decoration: none;
+    }
+    .cite a { text-decoration: none; }
+    .formula-box {
+      text-align: center;
+      margin: 1.2rem 0;
+      background: var(--well);
+      padding: 0.8rem;
+      border-radius: 4px;
+      border: 1px solid var(--line);
+      overflow-x: auto;
+    }
+    #references {
+      font-size: 0.92rem;
+    }
+    #references ol {
+      padding-left: 1.5rem;
+    }
+    #references li {
+      margin-bottom: 0.5rem;
+    }
+    #references .backlink {
+      margin-right: 0.3rem;
+    }
+    footer.meta {
+      border-top: 1px solid var(--line);
+      margin-top: 3rem;
+      padding-top: 1.4rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+    }
+    footer.meta a { color: var(--link); }
+    @media print {
+      .back {font-family:"Segoe UI", Helvetica, Arial, sans-serif;display: none;}
+    }
+    .back-to-top {
+      position: fixed;
+      bottom: 1.5rem;
+      right: 1.5rem;
+      width: 2.6rem;
+      height: 2.6rem;
+      border-radius: 50%;
+      background: var(--bg);
+      color: var(--ink);
+      border: 1px solid var(--line);
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      opacity: 0;
+      visibility: hidden;
+      transform: translateY(8px);
+      transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease, background 0.15s ease, border-color 0.15s ease;
+      z-index: 100;
+    }
+    .back-to-top.visible {
+      opacity: 1;
+      visibility: visible;
+      transform: translateY(0);
+    }
+    .back-to-top:hover {
+      background: var(--well);
+      border-color: var(--link);
+      color: var(--link);
+    }
+    .back-to-top:focus-visible {
+      outline: 2px solid var(--link);
+      outline-offset: 2px;
+    }
+    @media print {
+      .back-to-top { display: none !important; }
+    }
+  </style>
+
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"DefinedTerm","name":"Watts (Power)","description":"The watt measures power: one joule per second. Electrical power, AC power factor, watts, and watt-hours.","url":"https://ngpestelos.com/reference/watts/","inDefinedTermSet":"https://ngpestelos.com/reference/"}</script>
+</head>
+<body class="reference">
+<main id="top">
+<p class="back"><a href="/reference/">&larr; Reference</a> &middot; <a href="/">Home</a> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a></p>
+<p class="kicker">Physics &middot; Electricity</p>
+<h1>Watts (Power)</h1>
+<p class="updated">Reference entry &middot; last updated 20260908</p>
+
+<p class="lede"><strong>Watts</strong> measure power, the rate of energy transfer or conversion. One watt (W) equals one joule per second. The unit applies to electrical, mechanical, and thermal power.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+<nav class="toc" aria-label="Contents"><div class="toc-title">Contents</div><ol><li><a href="#first-principles">First principles and definitions</a></li><li><a href="#electrical">Electrical power</a></li><li><a href="#ac">AC power and volt-amperes</a></li><li><a href="#energy">Watts and watt-hours</a></li><li><a href="#see-also">See also</a></li><li><a href="#references">References</a></li></ol></nav>
+<h2 id="first-principles">1. First principles and definitions</h2>
+<p>Energy is an amount; power describes how fast that amount changes. A device drawing a constant 10 W converts 10 J of electrical energy each second.<span class="cite">[<a href="#ref2">2</a>]</span></p>
+<div class="formula-box">\[1\,\mathrm{W}=1\,\mathrm{J/s}\]</div>
+<h2 id="electrical">2. Electrical power</h2>
+<p>For steady DC, multiply voltage across a device by current through it. <a href="/reference/volts/">Volts</a> measure energy per charge; <a href="/reference/amps/">amps</a> measure charge per second. Their product gives energy per second.<span class="cite">[<a href="#ref2">2</a>]</span></p>
+<div class="formula-box">\[P=VI\]</div>
+<p>Illustrative calculation: a device drawing 2 A at 12 V consumes 24 W. At 24 V, a device consuming the same 24 W draws 1 A. These calculations assume steady DC at the device terminals.</p>
+<h2 id="ac">3. AC power and volt-amperes</h2>
+<p>Instantaneous power is voltage times current at the same instant. For sinusoidal AC, average real power is root-mean-square (RMS) voltage times RMS current times the cosine of their phase difference, φ. That cosine is the power factor for sinusoidal waveforms.<span class="cite">[<a href="#ref3">3</a>]</span></p>
+<div class="formula-box">\[P_{\mathrm{avg}}=V_{\mathrm{rms}}I_{\mathrm{rms}}\cos\varphi\]</div>
+<p>The RMS voltage-current product is apparent power, expressed in volt-amperes (VA). It equals real power in watts when the power factor is 1. Illustrative calculation: 230 V RMS × 2 A RMS gives 460 VA; at a power factor of 0.8, real power is 368 W.<span class="cite">[<a href="#ref5">5</a>]</span></p>
+<h2 id="energy">4. Watts and watt-hours</h2>
+<p>A watt-hour (Wh) measures energy. At constant power, energy in Wh equals power in W multiplied by time in hours. One kilowatt is 1,000 W; one kilowatt-hour is 1,000 Wh.<span class="cite">[<a href="#ref4">4</a>]</span></p>
+<div class="formula-box">\[E=P\,t\]</div>
+<p>Illustrative calculation: a 100 W device running for 3 hours uses 300 Wh, or 0.3 kWh. One watt-hour equals 3,600 J. For changing power, energy is the integral of power over time.<span class="cite">[<a href="#ref2">2</a>]</span></p>
+
+<h2 id="see-also">5. See also</h2>
+<ul><li><a href="/reference/volts/">Volts (Voltage)</a></li><li><a href="/reference/amps/">Amps (Electric Current)</a></li></ul>
+<h2 id="references">6. References</h2>
+<ol>
+<li id="ref1"><a href="https://www.nist.gov/pml/special-publication-811/nist-guide-si-chapter-4-two-classes-si-units-and-si-prefixes">NIST, The Two Classes of SI Units and the SI Prefixes, Tables 1 and 3</a></li>
+<li id="ref2"><a href="https://openstax.org/books/university-physics-volume-2/pages/9-5-electrical-energy-and-power">OpenStax, University Physics Volume 2, §9.5: Electrical Energy and Power (2016)</a></li>
+<li id="ref3"><a href="https://openstax.org/books/university-physics-volume-2/pages/15-4-power-in-an-ac-circuit">OpenStax, University Physics Volume 2, §15.4: Power in an AC Circuit (2016)</a></li>
+<li id="ref4"><a href="https://www.eia.gov/energyexplained/electricity/measuring-electricity.php">U.S. Energy Information Administration, Measuring electricity</a></li>
+<li id="ref5"><a href="https://media.fluke.com/16ed2e6a-cae4-4d6a-ad56-b10800c1cc90_original%20file.pdf">Fluke, 43B Applications Manual, chapter 7, pp. 75 and 77: Apparent Power and Power Factor (PDF)</a></li>
+</ol>
+    <footer class="meta">
+      <p><a href="#top">Back to top</a></p>
+    </footer>
+  </main>
+  <button id="backToTop" class="back-to-top" aria-label="Back to top" title="Back to top">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M18 15l-6-6-6 6"/>
+    </svg>
+  </button>
+
+  <script>
+    const btt = document.getElementById('backToTop');
+    window.addEventListener('scroll', () => {
+      if (window.scrollY > 250) {
+        btt.classList.add('visible');
+      } else {
+        btt.classList.remove('visible');
+      }
+    }, { passive: true });
+    btt.addEventListener('click', () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  </script>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1115,4 +1115,22 @@
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
+  <url>
+    <loc>https://ngpestelos.com/reference/volts/</loc>
+    <lastmod>2026-09-08</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://ngpestelos.com/reference/watts/</loc>
+    <lastmod>2026-09-08</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://ngpestelos.com/reference/amps/</loc>
+    <lastmod>2026-09-08</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
Add linked reference entries for volts, watts, and amps, with first-principles definitions, worked DC examples, AC assumptions, and distinctions between power, energy, and charge. Sources include NIST, OpenStax, EIA, and Fluke. Register all three pages in the reference index and sitemap.

Validation: all 36 existing discoverability, theme, and writing-layout tests pass. Citation anchors, internal links, math delimiters, metadata, and prose checks pass.
