### PR TITLE
Correct MCP and add Chain-of-Thought reference

### DIFF
--- a/reference/chain-of-thought/index.html
+++ b/reference/chain-of-thought/index.html
@@ -1,0 +1,221 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Chain-of-Thought · Reference · Nestor G Pestelos Jr</title>
+  <meta name="description" content="Chain-of-thought prompting: intermediate steps, few-shot and zero-shot variants, self-consistency, correctness, and faithfulness.">
+  <meta property="og:title" content="Chain-of-Thought · Reference">
+  <meta property="og:description" content="Chain-of-thought prompting: intermediate steps, few-shot and zero-shot variants, self-consistency, correctness, and faithfulness.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://ngpestelos.com/reference/chain-of-thought/">
+  <link rel="canonical" href="https://ngpestelos.com/reference/chain-of-thought/">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=20260813f">
+  <link rel="icon" href="/favicon-192.png?v=20260813f" type="image/png" sizes="192x192">
+  <link rel="icon" href="/favicon-32.png?v=20260813f" type="image/png" sizes="32x32">
+  <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
+  <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="stylesheet" href="/style.css?v=20260903e">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TLBY8P4GG9');
+  </script>
+  <style>
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
+    body {
+      line-height: 1.6;
+    }
+    main {
+      max-width: 46rem;
+      margin: 0 auto;
+      padding: 1.4rem 1.4rem 4rem;
+    }
+    .back {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .back a { color: var(--link); text-decoration: none; }
+    .back a:hover { text-decoration: underline; }
+    .kicker {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.78rem;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--mute);
+      margin-bottom: 0.3rem;
+    }
+    h1 {
+      font-size: clamp(1.9rem, 5vw, 2.4rem);
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.4rem;
+      margin-bottom: 1rem;
+    }
+    .updated {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.82rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .lede { margin-bottom: 1.6rem; }
+    .lede strong:first-child { font-weight: 700; }
+    .toc {
+      background: var(--well);
+      border: 1px solid var(--line);
+      border-radius: 4px;
+      padding: 1rem 1.4rem;
+      margin-bottom: 2rem;
+      max-width: 26rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.92rem;
+    }
+    .toc .toc-title {
+      font-weight: 700;
+      margin-bottom: 0.5rem;
+      text-align: center;
+    }
+    .toc ol { padding-left: 1.3rem; }
+    .toc li { margin: 0.2rem 0; }
+    .toc a { color: var(--link); text-decoration: none; }
+    .toc a:hover { text-decoration: underline; }
+    h2 {
+      font-size: 1.5rem;
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.3rem;
+      margin: 2rem 0 0.9rem;
+    }
+    h3 {
+      font-size: 1.15rem;
+      font-weight: 700;
+      margin: 1.3rem 0 0.4rem;
+    }
+    p { margin-bottom: 0.9rem; }
+    ul, ol { margin-bottom: 1rem; padding-left: 1.5rem; }
+    li { margin-bottom: 0.35rem; }
+    a { color: var(--link); }
+    a:visited { color: var(--link-visited); }
+    code {
+      font-family: "SF Mono", Consolas, Monaco, monospace;
+      font-size: 0.9em;
+      background: var(--well);
+      padding: 0.1em 0.35em;
+      border-radius: 3px;
+    }
+    .cite {
+      font-size: 0.75em;
+      vertical-align: super;
+      line-height: 0;
+      text-decoration: none;
+    }
+    .cite a { text-decoration: none; }
+    #see-also ul, #references ol {
+      padding-left: 1.5rem;
+    }
+    #see-also li, #references li { margin-bottom: 0.5rem; }
+    #references { font-size: 0.95rem; }
+    #references .backlink { margin-right: 0.3rem; }
+    @media print {
+      .back {font-family:"Segoe UI", Helvetica, Arial, sans-serif;display: none;}
+    }
+    .back-to-top {
+      position: fixed;
+      bottom: 1.5rem;
+      right: 1.5rem;
+      width: 2.6rem;
+      height: 2.6rem;
+      border-radius: 50%;
+      background: var(--bg);
+      color: var(--ink);
+      border: 1px solid var(--line);
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      opacity: 0;
+      visibility: hidden;
+      transform: translateY(8px);
+      transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease, background 0.15s ease, border-color 0.15s ease;
+      z-index: 100;
+    }
+    .back-to-top.visible {
+      opacity: 1;
+      visibility: visible;
+      transform: translateY(0);
+    }
+    .back-to-top:hover {
+      background: var(--well);
+      border-color: var(--link);
+      color: var(--link);
+    }
+    .back-to-top:focus-visible {
+      outline: 2px solid var(--link);
+      outline-offset: 2px;
+    }
+    @media print {
+      .back-to-top { display: none !important; }
+    }
+  </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Chain-of-Thought","description":"Chain-of-thought prompting: intermediate steps, few-shot and zero-shot variants, self-consistency, correctness, and faithfulness.","url":"https://ngpestelos.com/reference/chain-of-thought/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
+</head>
+<body class="reference">
+  <main id="top">
+    <p class="back"><a href="/reference/">← Reference</a> · <a href="/">Nestor G Pestelos Jr</a> · <a href="#" onclick="window.print(); return false;">Print this page</a></p>
+<p class="kicker">Artificial Intelligence · Language Models</p><h1>Chain-of-Thought</h1>
+<p class="lede"><strong>Chain-of-thought</strong> (CoT) is a sequence of intermediate reasoning steps generated by a language model before its answer. Chain-of-thought prompting asks for this form of response through examples or instructions.<span class="cite">[<a href="#ref1">1</a>]</span><span class="cite">[<a href="#ref2">2</a>]</span></p>
+<p class="updated">Reference entry · last updated 20260909</p>
+<nav class="toc" aria-label="Contents"><p class="toc-title">Contents</p><ol><li><a href="#first-principles">First principles and definitions</a></li><li><a href="#example">Illustrative example</a></li><li><a href="#prompting-variants">Prompting variants</a></li><li><a href="#self-consistency">Self-consistency</a></li><li><a href="#limitations">Correctness and faithfulness</a></li><li><a href="#see-also">See also</a></li><li><a href="#references">References</a></li></ol></nav><h2 id="first-principles">First principles and definitions</h2>
+<p>An <a href="/reference/autoregressive/">autoregressive language model</a> predicts each next token from the preceding context. Generated intermediate steps become context for later steps and the answer. CoT prompting changes that context without updating the model's parameters.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+<h2 id="example">Illustrative example</h2>
+<p>This author-created example shows the response format; it is not a model evaluation.</p>
+<p><strong>Problem:</strong> Three boxes hold four pencils each. Two pencils are removed. How many remain?</p>
+<p><strong>Worked response:</strong> The boxes hold 3 × 4 = 12 pencils. Removing two leaves 12 − 2 = 10 pencils. The answer is 10.</p>
+<h2 id="prompting-variants">Prompting variants</h2>
+<p><strong>Few-shot CoT:</strong> Wei et al. supplied worked examples containing a question, intermediate steps, and an answer. Their experiments found improvements on arithmetic, commonsense, and symbolic reasoning tasks for the tested models.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+<p><strong>Zero-shot CoT:</strong> Kojima et al. used the instruction “Let's think step by step” without worked examples, followed by an answer-extraction prompt. They reported improvements on several reasoning benchmarks. These results do not establish that the instruction helps every model or task.<span class="cite">[<a href="#ref2">2</a>]</span></p>
+<h2 id="self-consistency">Self-consistency</h2>
+<p>Wang et al. sampled multiple reasoning paths and selected the most common answer. Aggregating over the sampled paths improved accuracy on the tested arithmetic and commonsense benchmarks. It does not verify an answer: several paths can share the same mistake.<span class="cite">[<a href="#ref3">3</a>]</span></p>
+<h2 id="limitations">Correctness and faithfulness</h2>
+<p><strong>Correctness</strong> concerns whether an answer or step is valid. <strong>Faithfulness</strong> concerns whether the generated explanation reflects the computation that produced the answer. A plausible explanation alone establishes neither.</p>
+<p>Lanham et al. tested faithfulness by intervening on generated chains, including truncating them or inserting mistakes. They found substantial variation across models and tasks. Intermediate text can help a model answer while still being an incomplete or misleading account of its internal computation.<span class="cite">[<a href="#ref4">4</a>]</span></p>
+<h2 id="see-also">See also</h2><ul><li><a href="/reference/reasoning/">Reasoning in Language Models</a></li><li><a href="/reference/prompt-engineering/">Prompt Engineering</a></li><li><a href="/reference/test-time-compute/">Test-Time Compute</a></li><li><a href="/reference/autoregressive/">Autoregressive Models</a></li></ul><h2 id="references">References</h2>
+<ol>
+<li id="ref1">Jason Wei et al. (2022). <a href="https://arxiv.org/abs/2201.11903">Chain-of-Thought Prompting Elicits Reasoning in Large Language Models</a>.</li>
+<li id="ref2">Takeshi Kojima et al. (2022). <a href="https://arxiv.org/abs/2205.11916">Large Language Models are Zero-Shot Reasoners</a>.</li>
+<li id="ref3">Xuezhi Wang et al. (2023). <a href="https://arxiv.org/abs/2203.11171">Self-Consistency Improves Chain of Thought Reasoning in Language Models</a>.</li>
+<li id="ref4">Tamera Lanham et al. (2023). <a href="https://arxiv.org/abs/2307.13702">Measuring Faithfulness in Chain-of-Thought Reasoning</a>.</li>
+</ol>
+  </main>
+
+  <button id="backToTop" class="back-to-top" aria-label="Back to top" title="Back to top">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M18 15l-6-6-6 6"/>
+    </svg>
+  </button>
+
+  <script>
+    const btt = document.getElementById('backToTop');
+    window.addEventListener('scroll', () => {
+      if (window.scrollY > 250) {
+        btt.classList.add('visible');
+      } else {
+        btt.classList.remove('visible');
+      }
+    }, { passive: true });
+    btt.addEventListener('click', () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  </script>
+</body>
+</html>

--- a/reference/index.html
+++ b/reference/index.html
@@ -228,6 +228,7 @@
       <div class="letter-group" id="C">
         <h2 class="letter-heading">C</h2>
         <ul>
+        <li><a href="/reference/chain-of-thought/">Chain-of-Thought</a></li>
         <li><a href="/reference/chiquito/">Chiquito (Actor)</a></li>
         <li><a href="/reference/chunked-prefill/">Chunked Prefill</a></li>
         <li><a href="/reference/code-churn/">Code Churn</a></li>

--- a/reference/model-context-protocol-20260909/index.html
+++ b/reference/model-context-protocol-20260909/index.html
@@ -3,13 +3,13 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Model Context Protocol · Reference · Nestor G Pestelos Jr</title>
-  <meta name="description" content="Model Context Protocol version 2026-07-28: roles, features, transports, consent, and implementation security boundaries.">
-  <meta property="og:title" content="Model Context Protocol · Reference">
-  <meta property="og:description" content="Model Context Protocol version 2026-07-28: roles, features, transports, consent, and implementation security boundaries.">
+  <title>Model Context Protocol · Reference · Nestor G Pestelos Jr · Archived 20260909</title>
+  <meta name="description" content="The Model Context Protocol (MCP) is an open-source standard for connecting AI systems with external tools, contextual data sources, and execution environments.">
+  <meta property="og:title" content="Model Context Protocol · Reference · Archived 20260909">
+  <meta property="og:description" content="Architecture, core primitives, transport mechanisms, and security boundaries of the Model Context Protocol.">
   <meta property="og:type" content="article">
-  <meta property="og:url" content="https://ngpestelos.com/reference/model-context-protocol/">
-  <link rel="canonical" href="https://ngpestelos.com/reference/model-context-protocol/">
+  <meta property="og:url" content="https://ngpestelos.com/reference/model-context-protocol-20260909/">
+  <link rel="canonical" href="https://ngpestelos.com/reference/model-context-protocol-20260909/">
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=20260813f">
   <link rel="icon" href="/favicon-192.png?v=20260813f" type="image/png" sizes="192x192">
   <link rel="icon" href="/favicon-32.png?v=20260813f" type="image/png" sizes="32x32">
@@ -25,7 +25,7 @@
     gtag('config', 'G-TLBY8P4GG9');
   </script>
   <style>
-
+    
     * { box-sizing: border-box; margin: 0; padding: 0; }
     html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
     body {
@@ -101,7 +101,6 @@
     p { margin-bottom: 0.9rem; }
     ul, ol { margin-bottom: 1rem; padding-left: 1.5rem; }
     li { margin-bottom: 0.35rem; }
-    .table-scroll { overflow-x: auto; }
     table {
       width: 100%;
       border-collapse: collapse;
@@ -202,23 +201,21 @@
     }
   </style>
   <script type="application/ld+json">
-{"@context":"https://schema.org","@type":"DefinedTerm","name":"Model Context Protocol","description":"Model Context Protocol version 2026-07-28: roles, features, transports, consent, and implementation security boundaries.","url":"https://ngpestelos.com/reference/model-context-protocol/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Model Context Protocol (archived 20260909)","description":"The Model Context Protocol (MCP) is an open-source standard for connecting AI systems with external tools, contextual data sources, and execution environments.","url":"https://ngpestelos.com/reference/model-context-protocol-20260909/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
   </script>
 </head>
 <body class="reference">
   <main id="top">
     <p class="back"><a href="/reference/">← Reference</a> · <a href="/">Nestor G Pestelos Jr</a> · <a href="#" onclick="window.print(); return false;">Print this page</a></p>
-<p class="kicker">Artificial Intelligence · Protocols &amp; Standards</p><h1>Model Context Protocol</h1>
-<p class="lede"><strong>Model Context Protocol</strong> (MCP) is an open protocol through which AI applications access tools, data, and prompt templates exposed by servers.<span class="cite">[<a href="#ref1">1</a>]</span></p>
-<p class="updated">Reference entry · last updated 20260909 · <a href="/reference/model-context-protocol-20260909/">Previous version</a></p>
-<p>This entry describes protocol version <code>2026-07-28</code>. Earlier versions differ in transport, initialization, and client features.<span class="cite">[<a href="#ref2">2</a>]</span></p><nav class="toc" aria-label="Contents"><p class="toc-title">Contents</p><ol><li><a href="#first-principles">First principles and definitions</a></li><li><a href="#architectural-roles">Host, client, and server</a></li><li><a href="#core-primitives">Features and version changes</a></li><li><a href="#transport-layers">Transports</a></li><li><a href="#lsp-analogy">The LSP comparison</a></li><li><a href="#security-boundaries">Consent and security boundaries</a></li><li><a href="#see-also">See also</a></li><li><a href="#references">References</a></li></ol></nav><h2 id="first-principles">First principles and definitions</h2>
-<p>A protocol defines the messages that programs exchange. MCP uses JSON-RPC 2.0 to describe requests, results, and errors. A common message format lets an application discover a server's tools and call them without a separate integration for each application. It does not grant access to the underlying system or enforce a security boundary.<span class="cite">[<a href="#ref1">1</a>]</span><span class="cite">[<a href="#ref3">3</a>]</span></p>
-<h2 id="architectural-roles">Host, client, and server</h2>
-<ul><li>The <strong>host</strong> is the AI application. It coordinates the model, user interaction, and access policies.</li>
-<li>A <strong>client</strong> is the host's protocol component for communicating with a server.</li>
-<li>A <strong>server</strong> exposes tools, resources, or prompts. It accesses external systems through their own interfaces.</li></ul>
-<p>MCP covers the client–server connection; the server's database or service integration can use another protocol.<span class="cite">[<a href="#ref1">1</a>]</span></p>        <div class="diagram-box">
-      <svg viewBox="0 0 660 210" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="MCP host, clients, servers, and external systems">
+    <p class="kicker">Artificial Intelligence · Protocols &amp; Standards</p>
+    <h1>Model Context Protocol</h1>
+    <p class="updated"><strong>Archived version captured 20260909.</strong> Superseded claims are preserved from commit <code>c8662d2d2ab64c6c8ab828f9cc326eccf651b745</code>. <a href="/reference/model-context-protocol/">Read the current entry</a>.</p>
+    <p class="updated">Reference entry · last updated August 30, 2026</p>
+
+    <p class="lede">The <strong>Model Context Protocol</strong> (MCP) is an open-source standard for connecting artificial intelligence models to external data sources, tools, and execution environments.<span class="cite">[<a href="#ref1">1</a>]</span> Introduced by Anthropic in November 2024, the specification provides a uniform JSON-RPC 2.0 communication layer between client applications and isolated server processes, replacing bespoke API integrations with a standard interface.<span class="cite">[<a href="#ref1">1</a>]</span><span class="cite">[<a href="#ref2">2</a>]</span></p>
+
+        <div class="diagram-box">
+      <svg viewBox="0 0 660 210" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Model Context Protocol Architecture">
         <!-- Host Box -->
         <rect x="10" y="15" width="205" height="180" rx="6" fill="#ffffff" stroke="#9a3412" stroke-width="1.5"/>
         <text x="112" y="35" font-family="-apple-system, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="#9a3412">MCP Host</text>
@@ -239,10 +236,10 @@
         <text x="162" y="88" font-family="-apple-system, sans-serif" font-size="9" font-weight="bold" text-anchor="middle" fill="#202122">Client 1</text>
         <text x="162" y="102" font-family="-apple-system, sans-serif" font-size="8" text-anchor="middle" fill="#54595d">stdio driver</text>
 
-        <!-- Client 2 (HTTP) -->
+        <!-- Client 2 (SSE) -->
         <rect x="120" y="127" width="85" height="50" rx="4" fill="#ffffff" stroke="#a2a9b1" stroke-width="1"/>
         <text x="162" y="148" font-family="-apple-system, sans-serif" font-size="9" font-weight="bold" text-anchor="middle" fill="#202122">Client 2</text>
-        <text x="162" y="162" font-family="-apple-system, sans-serif" font-size="8" text-anchor="middle" fill="#54595d">HTTP client</text>
+        <text x="162" y="162" font-family="-apple-system, sans-serif" font-size="8" text-anchor="middle" fill="#54595d">SSE client</text>
 
         <!-- Host -> Server Connectors -->
         <path d="M 205 92 L 245 92" stroke="#54595d" stroke-width="1.5" stroke-dasharray="3,3"/>
@@ -258,7 +255,7 @@
         <rect x="245" y="122" width="175" height="60" rx="6" fill="#ffffff" stroke="#a2a9b1" stroke-width="1.5"/>
         <text x="332" y="142" font-family="-apple-system, sans-serif" font-size="11" font-weight="bold" text-anchor="middle" fill="#202122">MCP Server (Remote)</text>
         <text x="332" y="157" font-family="-apple-system, sans-serif" font-size="8.5" text-anchor="middle" fill="#54595d">GitHub · Slack · Web Search</text>
-        <text x="332" y="171" font-family="-apple-system, sans-serif" font-size="8" text-anchor="middle" fill="#9a3412">Streamable HTTP</text>
+        <text x="332" y="171" font-family="-apple-system, sans-serif" font-size="8" text-anchor="middle" fill="#9a3412">Transport: SSE / HTTP</text>
 
         <!-- Server -> Data Systems Connectors -->
         <path d="M 420 92 L 465 92" stroke="#54595d" stroke-width="1.5"/>
@@ -273,43 +270,120 @@
         <rect x="465" y="122" width="185" height="60" rx="6" fill="#f8f9fa" stroke="#a2a9b1" stroke-width="1"/>
         <text x="557" y="142" font-family="-apple-system, sans-serif" font-size="10" font-weight="bold" text-anchor="middle" fill="#202122">Enterprise Services</text>
         <text x="557" y="157" font-family="-apple-system, sans-serif" font-size="8.5" text-anchor="middle" fill="#54595d">REST APIs · SaaS · Cloud DBs</text>
-        <text x="557" y="171" font-family="-apple-system, sans-serif" font-size="8" text-anchor="middle" fill="#166534">Service-specific API</text>
+        <text x="557" y="171" font-family="-apple-system, sans-serif" font-size="8" text-anchor="middle" fill="#166534">Authenticated JSON-RPC</text>
       </svg>
     </div>
 
-<h2 id="core-primitives">Features and version changes</h2>
-<p>The table summarizes features in version <code>2026-07-28</code>; it is not an exhaustive list of protocol methods. This version replaces the initialization handshake with per-request metadata and capability declarations. Requests for additional client input use multi-round-trip interactions.<span class="cite">[<a href="#ref2">2</a>]</span></p>
-<div class="table-scroll" role="region" aria-label="MCP features" tabindex="0"><table><thead><tr><th>Feature</th><th>Purpose</th><th>Version-specific behavior</th></tr></thead><tbody>
-<tr><td>Tools</td><td>Server operations available to the application.</td><td><code>tools/list</code> discovers tools; <code>tools/call</code> invokes one. The host controls access.<span class="cite">[<a href="#ref4">4</a>]</span></td></tr>
-<tr><td>Resources</td><td>Data identified by URI, such as a document or database schema.</td><td><code>resources/read</code> retrieves data. Resource subscriptions use the unified <code>subscriptions/listen</code> mechanism.</td></tr>
-<tr><td>Prompts</td><td>Server-provided templates with arguments.</td><td><code>prompts/list</code> discovers templates; <code>prompts/get</code> retrieves one.</td></tr>
-<tr><td>Elicitation</td><td>Additional information or interaction requested from the user.</td><td>Input requests are embedded in a result and fulfilled through a subsequent client request.</td></tr>
-<tr><td>Roots</td><td>Client-provided filesystem locations relevant to a task.</td><td>Deprecated, not removed. Roots requests use embedded input; the roots-change notification is removed. Roots are advisory.</td></tr>
-<tr><td>Sampling</td><td>Model generation requested through the client.</td><td>Deprecated, not removed. Sampling is requested as embedded input, not a separate server-initiated JSON-RPC request.</td></tr>
-</tbody></table></div>
+    <nav class="toc" aria-label="Contents">
+      <p class="toc-title">Contents</p>
+      <ol>
+        <li><a href="#architectural-roles">Architectural roles</a></li>
+        <li><a href="#core-primitives">Core protocol primitives</a></li>
+        <li><a href="#transport-layers">Transport layers and wire framing</a></li>
+        <li><a href="#lsp-analogy">The Language Server Protocol comparison</a></li>
+        <li><a href="#security-boundaries">Security and isolation boundaries</a></li>
+        <li><a href="#see-also">See also</a></li>
+        <li><a href="#references">References</a></li>
+      </ol>
+    </nav>
 
-<h2 id="transport-layers">Transports</h2>
-<p><strong>Standard input/output (stdio)</strong> connects a client to a local server process using newline-delimited JSON-RPC messages. The client launches the server; standard output carries protocol messages.<span class="cite">[<a href="#ref3">3</a>]</span></p>
-<p><strong>Streamable HTTP</strong> serves remote clients. In version <code>2026-07-28</code>, clients send requests by HTTP POST to a single endpoint. Responses can be JSON or request-scoped Server-Sent Events (SSE). There is no standalone GET stream or transport session.<span class="cite">[<a href="#ref5">5</a>]</span></p>
-<p>The older HTTP+SSE transport is historical. Earlier Streamable HTTP versions also had GET-stream and session behavior that this version removes.<span class="cite">[<a href="#ref2">2</a>]</span><span class="cite">[<a href="#ref5">5</a>]</span></p>
-<h2 id="lsp-analogy">The Language Server Protocol comparison</h2>
-<p>MCP follows an integration pattern similar to the Language Server Protocol (LSP), which connects editors with language tools.<span class="cite">[<a href="#ref1">1</a>]</span><span class="cite">[<a href="#ref6">6</a>]</span></p>
-<p>As an illustrative count, connecting M applications to N services can require M × N custom adapters. A shared protocol can reduce the protocol-facing implementations to M + N. This counts interfaces, not engineering effort: authentication, feature support, and service-specific behavior still need implementation.</p>
-<h2 id="security-boundaries">Consent and security boundaries</h2>
-<p>The specification calls for explicit user consent before tool use. The tools section recommends human oversight and confirmation interfaces, but it mandates no particular interaction model. Consent and approval policy belong to the host; MCP does not impose a confirmation dialog for every side-effecting call.<span class="cite">[<a href="#ref1">1</a>]</span><span class="cite">[<a href="#ref4">4</a>]</span></p>
-<p><strong>Roots are not a security boundary.</strong> They communicate intended filesystem locations. Filesystem permissions, sandboxing, and checks in the implementation must enforce containment. Running a server in a separate process does not itself provide a sandbox.<span class="cite">[<a href="#ref7">7</a>]</span></p>
-<p>Remote implementations must also validate origins and implement access controls appropriate to their deployment. A valid MCP message does not make its contents trusted.<span class="cite">[<a href="#ref5">5</a>]</span></p>
-<h2 id="see-also">See also</h2><ul>
-<li><a href="/reference/agent-harness/">Agent Harness</a></li><li><a href="/reference/agents/">Agents</a></li><li><a href="/reference/context-engineering/">Context Engineering</a></li><li><a href="/reference/fail-closed/">Fail-Closed</a></li><li><a href="/reference/llm-gateway/">LLM Gateway</a></li><li><a href="/reference/plan-approve-execute/">Plan-Approve-Execute</a></li></ul><h2 id="references">References</h2>
-<ol>
-<li id="ref1">Model Context Protocol. <a href="https://modelcontextprotocol.io/specification/2026-07-28">Specification, version 2026-07-28</a>.</li>
-<li id="ref2">Model Context Protocol. <a href="https://modelcontextprotocol.io/specification/2026-07-28/changelog">Key changes, version 2026-07-28</a>.</li>
-<li id="ref3">Model Context Protocol. <a href="https://modelcontextprotocol.io/specification/2026-07-28/basic/transports">Transports</a>.</li>
-<li id="ref4">Model Context Protocol. <a href="https://modelcontextprotocol.io/specification/2026-07-28/server/tools">Tools</a>.</li>
-<li id="ref5">Model Context Protocol. <a href="https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http">Streamable HTTP</a>.</li>
-<li id="ref6">Microsoft. <a href="https://microsoft.github.io/language-server-protocol/">Language Server Protocol</a>.</li>
-<li id="ref7">Model Context Protocol. <a href="https://modelcontextprotocol.io/docs/2026-07-28/learn/client-concepts">Client concepts: roots and their limitations</a>.</li>
-</ol>
+    <h2 id="architectural-roles">Architectural roles</h2>
+    <p>The Model Context Protocol establishes three explicit architectural participants:<span class="cite">[<a href="#ref2">2</a>]</span></p>
+    <ul>
+      <li><strong>Host</strong>: The root application or agent runtime (such as Claude Desktop, an IDE extension, or an autonomous CLI harness) that initiates sessions, evaluates user intentions, enforces permission policies, and coordinates model execution.</li>
+      <li><strong>Client</strong>: An internal protocol adapter within the host that establishes and maintains a direct 1:1 connection with a specific server instance.</li>
+      <li><strong>Server</strong>: An independent program that exposes domain tools, contextual resources, and prompt templates to connected clients through JSON-RPC 2.0 messages.</li>
+    </ul>
+
+    <h2 id="core-primitives">Core protocol primitives</h2>
+    <p>The protocol defines five functional capabilities partitioned between client-controlled and server-controlled operations:<span class="cite">[<a href="#ref2">2</a>]</span><span class="cite">[<a href="#ref3">3</a>]</span></p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Primitive</th>
+          <th>Control Direction</th>
+          <th>Function</th>
+          <th>Lifecycle &amp; Schema</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><strong>Tools</strong></td>
+          <td>Model-controlled</td>
+          <td>Executable operations callable by the LLM (file editing, database queries, terminal commands).</td>
+          <td>Exposed via <code>tools/list</code> with JSON Schema parameter definitions; invoked through <code>tools/call</code>.</td>
+        </tr>
+        <tr>
+          <td><strong>Resources</strong></td>
+          <td>Application-controlled</td>
+          <td>Read-only passive data attachments (files, documentation, database schemas, log streams).</td>
+          <td>Identified by uniform URIs (such as <code>file:///</code> or <code>postgres://</code>). Clients read via <code>resources/read</code> and track changes via <code>resources/subscribe</code>.</td>
+        </tr>
+        <tr>
+          <td><strong>Prompts</strong></td>
+          <td>User-controlled</td>
+          <td>Parameterized interaction templates and operational recipes authored by the server.</td>
+          <td>Retrieved via <code>prompts/list</code> and populated through <code>prompts/get</code> with user-supplied arguments.</td>
+        </tr>
+        <tr>
+          <td><strong>Sampling</strong></td>
+          <td>Server-initiated</td>
+          <td>Nested LLM completion requests sent from the server back to the host client during tool execution.</td>
+          <td>Invoked through <code>sampling/createMessage</code>, giving the server bounded inference access without separate API credentials.</td>
+        </tr>
+        <tr>
+          <td><strong>Roots</strong></td>
+          <td>Client-controlled</td>
+          <td>Filesystem boundaries and workspace path declarations provided by the host to constrain server operations.</td>
+          <td>Queried through <code>roots/list</code>; updated via <code>notifications/roots/list_changed</code>.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2 id="transport-layers">Transport layers and wire framing</h2>
+    <p>MCP supports two official transport mechanisms for bidirectional JSON-RPC 2.0 message exchange:<span class="cite">[<a href="#ref3">3</a>]</span></p>
+
+    <h3>1. Standard input / output (stdio)</h3>
+    <p>Used for local tools and command-line utilities. The host spawns the server as a child process and communicates directly over standard input and standard output streams. Messages are framed as newline-delimited JSON lines without HTTP overhead.</p>
+
+    <h3>2. Server-Sent Events with HTTP POST (SSE)</h3>
+    <p>Used for remote services and networked microservices. The client opens an HTTP GET stream using the Server-Sent Events protocol to receive real-time server messages, events, and notifications. The client sends outgoing JSON-RPC requests to an HTTP POST endpoint exposed by the server.</p>
+
+    <h2 id="lsp-analogy">The Language Server Protocol comparison</h2>
+    <p>The architectural pattern of MCP directly follows Microsoft's Language Server Protocol (LSP).<span class="cite">[<a href="#ref4">4</a>]</span> Prior to LSP, integrating $M$ code editors with $N$ programming language analyzers required $M 	imes N$ custom plugins. LSP established a shared protocol that reduced the engineering complexity to $M + N$.<span class="cite">[<a href="#ref4">4</a>]</span></p>
+    <p>MCP applies the same reduction to foundation models: instead of authoring custom connectors for every model and tool pair, developers write one MCP server per data source that connects to any compliant host runtime.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+
+    <h2 id="security-boundaries">Security and isolation boundaries</h2>
+    <p>Because MCP servers execute arbitrary code and read system data, the specification enforces strict security principles:<span class="cite">[<a href="#ref2">2</a>]</span></p>
+    <ul>
+      <li><strong>Process isolation</strong>: Local servers run in distinct operating system processes with user-level privileges rather than running inside the model runtime.</li>
+      <li><strong>Explicit permission gates</strong>: Tool calls with side effects require host-level confirmation before execution.</li>
+      <li><strong>Root containment</strong>: Servers must respect root URI boundaries provided during initialization, preventing arbitrary filesystem traversal.</li>
+      <li><strong>No credential leakage</strong>: When servers request model inference through sampling, the host processes the call using its existing model configuration without exposing underlying provider API keys to the server.</li>
+    </ul>
+
+    <h2 id="see-also">See also</h2>
+    <ul>
+      <li><a href="/reference/agent-harness/">Agent Harness</a></li>
+      <li><a href="/reference/agents/">Agents</a></li>
+      <li><a href="/reference/context-engineering/">Context Engineering</a></li>
+      <li><a href="/reference/fail-closed/">Fail-Closed</a></li>
+      <li><a href="/reference/llm-gateway/">LLM Gateway</a></li>
+      <li><a href="/reference/plan-approve-execute/">Plan-Approve-Execute</a></li>
+    </ul>
+
+    <h2 id="references">References</h2>
+    <ol>
+      <li id="ref1"><a class="backlink" href="#architectural-roles">↑</a> Anthropic. "Introducing the Model Context Protocol." Anthropic News &amp; Announcements, November 25, 2024. <a href="https://www.anthropic.com/news/model-context-protocol">https://www.anthropic.com/news/model-context-protocol</a></li>
+      <li id="ref2"><a class="backlink" href="#core-primitives">↑</a> Model Context Protocol Community. "Model Context Protocol Specification and Architecture." Model Context Protocol Documentation, 2024. <a href="https://modelcontextprotocol.io/">https://modelcontextprotocol.io/</a></li>
+      <li id="ref3"><a class="backlink" href="#transport-layers">↑</a> Model Context Protocol Specification Working Group. "MCP Schema and Transport Specification (JSON-RPC 2.0)." Open Specification, 2024. <a href="https://spec.modelcontextprotocol.io/">https://spec.modelcontextprotocol.io/</a></li>
+      <li id="ref4"><a class="backlink" href="#lsp-analogy">↑</a> Microsoft Corporation. "Language Server Protocol Overview and Specification." Microsoft Open Source, 2016. <a href="https://microsoft.github.io/language-server-protocol/">https://microsoft.github.io/language-server-protocol/</a></li>
+    </ol>
+
+    <footer class="meta">
+      <p><a href="#top">Back to top</a></p>
+    </footer>
   </main>
 
   <button id="backToTop" class="back-to-top" aria-label="Back to top" title="Back to top">

--- a/reference/reasoning-20260909/index.html
+++ b/reference/reasoning-20260909/index.html
@@ -1,0 +1,300 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Reasoning in Large Language Models &middot; Reference &middot; Nestor G Pestelos Jr · Archived 20260909</title>
+  <meta name="description" content="A citable ground-truth reference on reasoning in large language models: test-time compute scaling, Chain-of-Thought formalisms, Process Reward Models, and inference-time search architectures.">
+  <meta property="og:title" content="Reasoning in Large Language Models &middot; Reference · Archived 20260909">
+  <meta property="og:description" content="A citable ground-truth reference on reasoning in large language models: test-time compute scaling, Chain-of-Thought formalisms, Process Reward Models, and inference-time search architectures.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://ngpestelos.com/reference/reasoning-20260909/">
+  <link rel="canonical" href="https://ngpestelos.com/reference/reasoning-20260909/">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=20260813f">
+  <link rel="icon" href="/favicon-192.png?v=20260813f" type="image/png" sizes="192x192">
+  <link rel="icon" href="/favicon-32.png?v=20260813f" type="image/png" sizes="32x32">
+  <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
+  <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="stylesheet" href="/style.css?v=20260903e">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TLBY8P4GG9');
+  </script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css" crossorigin="anonymous">
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
+    onload="renderMathInElement(document.body, {
+      delimiters: [
+        {left: '$$', right: '$$', display: true},
+        {left: '\\[', right: '\\]', display: true},
+        {left: '\\(', right: '\\)', display: false}
+      ]
+    });"></script>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
+    body {
+      line-height: 1.6;
+    }
+    main {
+      max-width: 48rem;
+      margin: 0 auto;
+      padding: 1.4rem 1.4rem 4rem;
+    }
+    .back {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .back a { color: var(--link); text-decoration: none; }
+    .back a:hover { text-decoration: underline; }
+    .kicker {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.78rem;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--mute);
+      margin-bottom: 0.3rem;
+    }
+    h1 {
+      font-size: clamp(1.8rem, 4.5vw, 2.3rem);
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.4rem;
+      margin-bottom: 1rem;
+    }
+    .updated {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.82rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .lede { margin-bottom: 1.6rem; font-size: 1.05rem; }
+    .lede strong:first-child { font-weight: 700; }
+    .toc {
+      background: var(--well);
+      border: 1px solid var(--line);
+      border-radius: 4px;
+      padding: 1rem 1.4rem;
+      margin-bottom: 2rem;
+      max-width: 28rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.92rem;
+    }
+    .toc .toc-title {
+      font-weight: 700;
+      margin-bottom: 0.5rem;
+      text-align: center;
+    }
+    .toc ol { padding-left: 1.3rem; }
+    .toc ol ol { padding-left: 1.2rem; margin-top: 0.15rem; }
+    .toc li { margin: 0.2rem 0; }
+    .toc a { color: var(--link); text-decoration: none; }
+    .toc a:hover { text-decoration: underline; }
+    h2 {
+      font-size: 1.35rem;
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.3rem;
+      margin-top: 2.2rem;
+      margin-bottom: 0.8rem;
+    }
+    h3 {
+      font-size: 1.1rem;
+      font-weight: 700;
+      margin-top: 1.4rem;
+      margin-bottom: 0.4rem;
+    }
+    p { margin-bottom: 1rem; }
+    ul, ol { margin-bottom: 1rem; padding-left: 1.8rem; }
+    li { margin-bottom: 0.3rem; }
+    pre {
+      background: var(--well);
+      border: 1px solid var(--line);
+      border-radius: 4px;
+      padding: 0.8rem;
+      font-family: monospace;
+      font-size: 0.88rem;
+      overflow-x: auto;
+      margin-bottom: 1rem;
+    }
+    code {
+      font-family: monospace;
+      font-size: 0.9em;
+      background: var(--well);
+      padding: 0.1em 0.3em;
+      border-radius: 3px;
+    }
+    .cite {
+      font-size: 0.78rem;
+      vertical-align: super;
+      line-height: 0;
+      margin-left: 0.1rem;
+    }
+    .cite a { color: var(--link); text-decoration: none; }
+    .cite a:hover { text-decoration: underline; }
+    .references ol {
+      font-size: 0.88rem;
+      padding-left: 1.4rem;
+    }
+    .references li {
+      margin-bottom: 0.6rem;
+      line-height: 1.45;
+    }
+    .back-to-top {
+      position: fixed;
+      bottom: 1.5rem;
+      right: 1.5rem;
+      width: 2.6rem;
+      height: 2.6rem;
+      border-radius: 50%;
+      background: var(--well);
+      border: 1px solid var(--line);
+      color: var(--ink);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      opacity: 0;
+      visibility: hidden;
+      transition: opacity 0.2s, visibility 0.2s;
+      box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+      z-index: 10;
+    }
+    .back-to-top.visible {
+      opacity: 1;
+      visibility: visible;
+    }
+    @media print {
+      .back, .back-to-top { display: none; }
+    }
+  </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Reasoning in Large Language Models (archived 20260909)","description":"A citable ground-truth reference on reasoning in large language models: test-time compute scaling, Chain-of-Thought formalisms, Process Reward Models, and inference-time search architectures.","url":"https://ngpestelos.com/reference/reasoning-20260909/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
+</head>
+<body class="reference">
+  <main>
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/reference/">Reference</a> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a></p>
+    <p class="kicker">Artificial Intelligence · Reasoning</p>
+    <h1>Reasoning in Language Models</h1>
+    <p class="updated"><strong>Archived version captured 20260909.</strong> Superseded claims are preserved from commit <code>c8662d2d2ab64c6c8ab828f9cc326eccf651b745</code>. <a href="/reference/reasoning/">Read the current entry</a>.</p>
+    <p class="updated">Published September 3, 2026 &middot; Cognitive Science &amp; Artificial Intelligence</p>
+
+    <p class="lede"><strong>Reasoning in large language models</strong> is the capability of neural networks to execute multi-step symbolic deduction, mathematical problem-solving, and algorithmic planning across intermediate thought representations. Rather than predicting answers through single-step associative intuition, reasoning architectures allocate variable inference-time compute to search, verify, and revise intermediate reasoning paths before emitting final output.</p>
+
+    <nav class="toc" aria-label="Table of Contents">
+      <div class="toc-title">Contents</div>
+      <ol>
+        <li><a href="#theoretical-foundations">Theoretical Foundations: Dual-Process Cognitive Framing</a></li>
+        <li><a href="#prompt-level-reasoning">Prompt-Level Scaffolding (CoT &amp; Tree of Thoughts)</a></li>
+        <li><a href="#test-time-compute">Test-Time Compute Scaling Laws</a></li>
+        <li><a href="#verification-architectures">Verification Architectures: Process Supervision &amp; Search</a>
+          <ol>
+            <li><a href="#prm">Process Reward Models (PRMs)</a></li>
+            <li><a href="#mcts">Search &amp; Self-Correction (MCTS &amp; Pure RL)</a></li>
+          </ol>
+        </li>
+        <li><a href="#evaluation-benchmarks">Evaluation Benchmarks &amp; Frontier Challenges</a></li>
+        <li><a href="#see-also">See also</a></li>
+        <li><a href="#references">References</a></li>
+      </ol>
+    </nav>
+
+    <h2 id="theoretical-foundations">1. Theoretical Foundations: Dual-Process Cognitive Framing</h2>
+    <p>In cognitive psychology, Kahneman's dual-process theory categorizes human thought into two modes <span class="cite">[<a href="#ref-1">1</a>]</span>:</p>
+    <ul>
+      <li><strong>System 1 (Intuitive):</strong> Fast, automatic, associative, and low-compute (e.g. recognizing a face, completing common idioms).</li>
+      <li><strong>System 2 (Deliberative):</strong> Slow, sequential, rule-governed, and computationally intensive (e.g. calculating \(17 \times 43\), playing chess, compiling code).</li>
+    </ul>
+    <p>Standard autoregressive generation operates analogously to System 1: every token receives an identical, fixed computational budget across Transformer layers. When faced with complex multi-step reasoning problems, standard models hallucinate because intermediate calculations cannot be completed within a single forward pass without intermediate scratchpad states.</p>
+
+    <h2 id="prompt-level-reasoning">2. Prompt-Level Scaffolding (CoT &amp; Tree of Thoughts)</h2>
+    <p>Early breakthroughs demonstrated that reasoning capabilities could be unlocked without parameter modification by structuring the input context:</p>
+    <ul>
+      <li><strong>Chain-of-Thought (CoT):</strong> Wei et al. showed that prompting a model to "think step-by-step" causes it to emit intermediate rationales before producing an answer <span class="cite">[<a href="#ref-2">2</a>]</span>. Each generated step acts as conditional context for subsequent steps, transforming non-linear deduction into linear sequential token generation.</li>
+      <li><strong>Self-Consistency:</strong> Wang et al. improved task reliability by sampling multiple independent CoT reasoning paths at temperature \(\tau > 0\) and selecting the final answer via marginal majority voting, marginalizing out reasoning errors <span class="cite">[<a href="#ref-3">3</a>]</span>.</li>
+      <li><strong>Tree of Thoughts (ToT):</strong> Yao et al. generalized linear CoT into deliberate tree exploration, allowing models to branch out alternative intermediate hypotheses, evaluate their promise with self-evaluation prompts, and backtrack when dead ends are reached <span class="cite">[<a href="#ref-4">4</a>]</span>.</li>
+    </ul>
+
+    <h2 id="test-time-compute">3. Test-Time Compute Scaling Laws</h2>
+    <p>Historically, language model performance scaled with pre-training compute (model parameters \(N\) and training tokens \(D\)). In 2024, frontier research established a parallel scaling law: <em><a href="/reference/test-time-compute/">test-time compute scaling</a></em> <span class="cite">[<a href="#ref-5">5</a>]</span>. Performance on complex mathematics, competitive programming, and formal logic improves as a power law of the inference compute allocated to generating and verifying intermediate thinking tokens:</p>
+    $$\text{Accuracy} \propto (\text{Inference Compute})^{\gamma}$$
+    <p>Reasoning models (such as OpenAI o1/o3 and DeepSeek-R1) leverage this principle by generating long, internal "chains of thought" (often thousands of tokens) prior to delivering the final user-facing response <span class="cite">[<a href="#ref-6">6</a>]</span>. During this internal generation, models evaluate sub-problems, test counterexamples, catch early errors, and rewrite failed proofs.</p>
+
+    <h2 id="verification-architectures">4. Verification Architectures: Process Supervision &amp; Search</h2>
+
+    <h3 id="prm">Process Reward Models (PRMs)</h3>
+    <p>Traditional reinforcement learning trains an Outcome Reward Model (ORM) that rewards only the final correctness of the answer: \(r(x, y) \in \{0, 1\}\). In multi-step proofs, ORMs encourage reward hacking, where a model arrives at the correct answer through flawed, accidental logic.</p>
+    <p>Lightman et al. introduced <em>Process Supervision</em>, training a Process Reward Model (PRM) to score the mathematical validity of every individual step \(t\) in a reasoning chain <span class="cite">[<a href="#ref-7">7</a>]</span>:</p>
+    $$\text{Score}(z) = \prod_{t=1}^T P(\text{step } t \text{ is correct} \mid x, z_1, \dots, z_t)$$
+    <p>Process supervision guides beam search and rejection sampling directly toward logically rigorous derivations.</p>
+
+    <h3 id="mcts">Search &amp; Self-Correction (MCTS &amp; Pure RL)</h3>
+    <p>Production reasoning models integrate reinforcement learning with algorithmic verification:</p>
+    <ul>
+      <li><strong>Reinforcement Learning with Rule-Based Verifiers:</strong> DeepSeek-R1-Zero demonstrated that large language models trained purely with reinforcement learning (using deterministic unit tests and mathematical equivalence verifiers as the reward function) spontaneously develop self-verification, self-correction, and extensive multi-step deliberation strategies without human demonstration data <span class="cite">[<a href="#ref-6">6</a>]</span>.</li>
+      <li><strong>Monte Carlo Tree Search (MCTS):</strong> Pairing value networks with rollout simulations enables models to plan moves ahead in formal theorem provers (Lean, Isabelle) and competitive programming environments.</li>
+    </ul>
+
+    <h2 id="evaluation-benchmarks">5. Evaluation Benchmarks &amp; Frontier Challenges</h2>
+    <p>Reasoning evaluation has shifted away from multiple-choice benchmarks (MMLU) toward verifiable formal tasks:</p>
+    <ul>
+      <li><strong>GSM8K &amp; MATH:</strong> Grade-school and high-school competitive Olympiad mathematics requiring multi-step symbolic derivation.</li>
+      <li><strong>SWE-bench:</strong> Resolving real-world software engineering issues from GitHub repositories, evaluating multi-file code navigation and patch verification.</li>
+      <li><strong>ARC-AGI:</strong> François Chollet's Abstraction and Reasoning Corpus, measuring out-of-distribution visual inductive logic and few-shot program synthesis.</li>
+    </ul>
+    <p>Open frontier challenges include overthinking simple queries, degradation on creative tasks, and the computational latency cost of emitting thousands of thinking tokens per interaction.</p>
+
+    <section class="see-also" id="see-also">
+      <h2>See also</h2>
+      <ul>
+        <li><a href="/reference/test-time-compute/">Test-Time Compute</a> &middot; Scaling inference computation via search, verification, and extended reasoning tokens.</li>
+        <li><a href="/eli5/reasoning/">ELI5: Reasoning</a> &middot; Visual picture-book explainer of System 1 intuition vs. System 2 scratchpads.</li>
+        <li><a href="/reference/prompt-engineering/">Prompt Engineering</a> &middot; Chain-of-Thought prompting and in-context task scaffolding.</li>
+        <li><a href="/reference/fine-tuning/">Fine-Tuning and Alignment</a> &middot; RLHF, DPO, and reinforcement learning training procedures.</li>
+        <li><a href="/reference/context-window/">Context Windows</a> &middot; Memory boundaries that house expanded thinking traces.</li>
+        <li><a href="/reference/large-language-models/">Large Language Models</a> &middot; Foundation architectures supporting autoregressive reasoning.</li>
+      </ul>
+    </section>
+
+    <section class="references" id="references">
+      <h2>References</h2>
+      <ol>
+        <li id="ref-1">[1] D. Kahneman, <em>Thinking, Fast and Slow</em>, Farrar, Straus and Giroux, New York, 2011.</li>
+        <li id="ref-2">[2] J. Wei, X. Wang, D. Schuurmans, et al., "Chain-of-Thought Prompting Elicits Reasoning in Large Language Models," in <em>NeurIPS</em>, 2022. <a href="https://arxiv.org/abs/2201.11903">https://arxiv.org/abs/2201.11903</a></li>
+        <li id="ref-3">[3] X. Wang, J. Wei, D. Schuurmans, et al., "Self-Consistency Improves Chain of Thought Reasoning in Language Models," in <em>ICLR</em>, 2023. <a href="https://arxiv.org/abs/2203.11171">https://arxiv.org/abs/2203.11171</a></li>
+        <li id="ref-4">[4] S. Yao, D. Yu, J. Zhao, et al., "Tree of Thoughts: Deliberate Problem Solving with Large Language Models," in <em>NeurIPS</em>, 2023. <a href="https://arxiv.org/abs/2305.10601">https://arxiv.org/abs/2305.10601</a></li>
+        <li id="ref-5">[5] N. Brown, G. Zhang, S. Feng, et al., "Large Language Models at Test-Time: Scaling Compute via Search and Verification," <em>OpenAI Technical Papers</em>, 2024.</li>
+        <li id="ref-6">[6] DeepSeek-AI, "DeepSeek-R1: Incentivizing Reasoning Capability in LLMs via Reinforcement Learning," <em>arXiv:2501.12948</em>, 2025. <a href="https://arxiv.org/abs/2501.12948">https://arxiv.org/abs/2501.12948</a></li>
+        <li id="ref-7">[7] H. Lightman, V. Kosaraju, Y. Burda, et al., "Let's Verify Step by Step," in <em>ICLR</em>, 2024. <a href="https://arxiv.org/abs/2305.20050">https://arxiv.org/abs/2305.20050</a></li>
+      </ol>
+    </section>
+  </main>
+
+  <button id="backToTop" class="back-to-top" aria-label="Back to top" title="Back to top">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M18 15l-6-6-6 6"/>
+    </svg>
+  </button>
+
+  <script>
+    const btt = document.getElementById('backToTop');
+    window.addEventListener('scroll', () => {
+      if (window.scrollY > 250) {
+        btt.classList.add('visible');
+      } else {
+        btt.classList.remove('visible');
+      }
+    }, { passive: true });
+    btt.addEventListener('click', () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  </script>
+</body>
+</html>

--- a/reference/reasoning/index.html
+++ b/reference/reasoning/index.html
@@ -3,10 +3,10 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Reasoning in Large Language Models &middot; Reference &middot; Nestor G Pestelos Jr</title>
-  <meta name="description" content="A citable ground-truth reference on reasoning in large language models: test-time compute scaling, Chain-of-Thought formalisms, Process Reward Models, and inference-time search architectures.">
-  <meta property="og:title" content="Reasoning in Large Language Models &middot; Reference">
-  <meta property="og:description" content="A citable ground-truth reference on reasoning in large language models: test-time compute scaling, Chain-of-Thought formalisms, Process Reward Models, and inference-time search architectures.">
+  <title>Reasoning in Language Models · Reference · Nestor G Pestelos Jr</title>
+  <meta name="description" content="Reasoning in language models: chain-of-thought prompting, test-time compute, process supervision, search, and evidence limits.">
+  <meta property="og:title" content="Reasoning in Language Models · Reference">
+  <meta property="og:description" content="Reasoning in language models: chain-of-thought prompting, test-time compute, process supervision, search, and evidence limits.">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://ngpestelos.com/reference/reasoning/">
   <link rel="canonical" href="https://ngpestelos.com/reference/reasoning/">
@@ -24,24 +24,15 @@
     gtag('js', new Date());
     gtag('config', 'G-TLBY8P4GG9');
   </script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css" crossorigin="anonymous">
-  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
-  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"
-    onload="renderMathInElement(document.body, {
-      delimiters: [
-        {left: '$$', right: '$$', display: true},
-        {left: '\\[', right: '\\]', display: true},
-        {left: '\\(', right: '\\)', display: false}
-      ]
-    });"></script>
   <style>
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
     body {
       line-height: 1.6;
     }
     main {
-      max-width: 48rem;
+      max-width: 46rem;
       margin: 0 auto;
       padding: 1.4rem 1.4rem 4rem;
     }
@@ -62,7 +53,7 @@
       margin-bottom: 0.3rem;
     }
     h1 {
-      font-size: clamp(1.8rem, 4.5vw, 2.3rem);
+      font-size: clamp(1.9rem, 5vw, 2.4rem);
       font-weight: 400;
       border-bottom: 1px solid var(--line);
       padding-bottom: 0.4rem;
@@ -74,7 +65,7 @@
       color: var(--mute);
       margin-bottom: 1.4rem;
     }
-    .lede { margin-bottom: 1.6rem; font-size: 1.05rem; }
+    .lede { margin-bottom: 1.6rem; }
     .lede strong:first-child { font-weight: 700; }
     .toc {
       background: var(--well);
@@ -82,7 +73,7 @@
       border-radius: 4px;
       padding: 1rem 1.4rem;
       margin-bottom: 2rem;
-      max-width: 28rem;
+      max-width: 26rem;
       font-family: "Segoe UI", Helvetica, Arial, sans-serif;
       font-size: 0.92rem;
     }
@@ -92,59 +83,48 @@
       text-align: center;
     }
     .toc ol { padding-left: 1.3rem; }
-    .toc ol ol { padding-left: 1.2rem; margin-top: 0.15rem; }
     .toc li { margin: 0.2rem 0; }
     .toc a { color: var(--link); text-decoration: none; }
     .toc a:hover { text-decoration: underline; }
     h2 {
-      font-size: 1.35rem;
+      font-size: 1.5rem;
       font-weight: 400;
       border-bottom: 1px solid var(--line);
       padding-bottom: 0.3rem;
-      margin-top: 2.2rem;
-      margin-bottom: 0.8rem;
+      margin: 2rem 0 0.9rem;
     }
     h3 {
-      font-size: 1.1rem;
+      font-size: 1.15rem;
       font-weight: 700;
-      margin-top: 1.4rem;
-      margin-bottom: 0.4rem;
+      margin: 1.3rem 0 0.4rem;
     }
-    p { margin-bottom: 1rem; }
-    ul, ol { margin-bottom: 1rem; padding-left: 1.8rem; }
-    li { margin-bottom: 0.3rem; }
-    pre {
-      background: var(--well);
-      border: 1px solid var(--line);
-      border-radius: 4px;
-      padding: 0.8rem;
-      font-family: monospace;
-      font-size: 0.88rem;
-      overflow-x: auto;
-      margin-bottom: 1rem;
-    }
+    p { margin-bottom: 0.9rem; }
+    ul, ol { margin-bottom: 1rem; padding-left: 1.5rem; }
+    li { margin-bottom: 0.35rem; }
+    a { color: var(--link); }
+    a:visited { color: var(--link-visited); }
     code {
-      font-family: monospace;
+      font-family: "SF Mono", Consolas, Monaco, monospace;
       font-size: 0.9em;
       background: var(--well);
-      padding: 0.1em 0.3em;
+      padding: 0.1em 0.35em;
       border-radius: 3px;
     }
     .cite {
-      font-size: 0.78rem;
+      font-size: 0.75em;
       vertical-align: super;
       line-height: 0;
-      margin-left: 0.1rem;
+      text-decoration: none;
     }
-    .cite a { color: var(--link); text-decoration: none; }
-    .cite a:hover { text-decoration: underline; }
-    .references ol {
-      font-size: 0.88rem;
-      padding-left: 1.4rem;
+    .cite a { text-decoration: none; }
+    #see-also ul, #references ol {
+      padding-left: 1.5rem;
     }
-    .references li {
-      margin-bottom: 0.6rem;
-      line-height: 1.45;
+    #see-also li, #references li { margin-bottom: 0.5rem; }
+    #references { font-size: 0.95rem; }
+    #references .backlink { margin-right: 0.3rem; }
+    @media print {
+      .back {font-family:"Segoe UI", Helvetica, Arial, sans-serif;display: none;}
     }
     .back-to-top {
       position: fixed;
@@ -153,127 +133,76 @@
       width: 2.6rem;
       height: 2.6rem;
       border-radius: 50%;
-      background: var(--well);
-      border: 1px solid var(--line);
+      background: var(--bg);
       color: var(--ink);
+      border: 1px solid var(--line);
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
       display: flex;
       align-items: center;
       justify-content: center;
       cursor: pointer;
       opacity: 0;
       visibility: hidden;
-      transition: opacity 0.2s, visibility 0.2s;
-      box-shadow: 0 2px 5px rgba(0,0,0,0.1);
-      z-index: 10;
+      transform: translateY(8px);
+      transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease, background 0.15s ease, border-color 0.15s ease;
+      z-index: 100;
     }
     .back-to-top.visible {
       opacity: 1;
       visibility: visible;
+      transform: translateY(0);
+    }
+    .back-to-top:hover {
+      background: var(--well);
+      border-color: var(--link);
+      color: var(--link);
+    }
+    .back-to-top:focus-visible {
+      outline: 2px solid var(--link);
+      outline-offset: 2px;
     }
     @media print {
-      .back, .back-to-top { display: none; }
+      .back-to-top { display: none !important; }
     }
   </style>
   <script type="application/ld+json">
-{"@context":"https://schema.org","@type":"DefinedTerm","name":"Reasoning in Large Language Models","description":"A citable ground-truth reference on reasoning in large language models: test-time compute scaling, Chain-of-Thought formalisms, Process Reward Models, and inference-time search architectures.","url":"https://ngpestelos.com/reference/reasoning/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Reasoning in Language Models","description":"Reasoning in language models: chain-of-thought prompting, test-time compute, process supervision, search, and evidence limits.","url":"https://ngpestelos.com/reference/reasoning/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
   </script>
 </head>
 <body class="reference">
-  <main>
-    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/reference/">Reference</a> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a></p>
-    <p class="kicker">Artificial Intelligence · Reasoning</p>
-    <h1>Reasoning in Language Models</h1>
-    <p class="updated">Published September 3, 2026 &middot; Cognitive Science &amp; Artificial Intelligence</p>
-
-    <p class="lede"><strong>Reasoning in large language models</strong> is the capability of neural networks to execute multi-step symbolic deduction, mathematical problem-solving, and algorithmic planning across intermediate thought representations. Rather than predicting answers through single-step associative intuition, reasoning architectures allocate variable inference-time compute to search, verify, and revise intermediate reasoning paths before emitting final output.</p>
-
-    <nav class="toc" aria-label="Table of Contents">
-      <div class="toc-title">Contents</div>
-      <ol>
-        <li><a href="#theoretical-foundations">Theoretical Foundations: Dual-Process Cognitive Framing</a></li>
-        <li><a href="#prompt-level-reasoning">Prompt-Level Scaffolding (CoT &amp; Tree of Thoughts)</a></li>
-        <li><a href="#test-time-compute">Test-Time Compute Scaling Laws</a></li>
-        <li><a href="#verification-architectures">Verification Architectures: Process Supervision &amp; Search</a>
-          <ol>
-            <li><a href="#prm">Process Reward Models (PRMs)</a></li>
-            <li><a href="#mcts">Search &amp; Self-Correction (MCTS &amp; Pure RL)</a></li>
-          </ol>
-        </li>
-        <li><a href="#evaluation-benchmarks">Evaluation Benchmarks &amp; Frontier Challenges</a></li>
-        <li><a href="#see-also">See also</a></li>
-        <li><a href="#references">References</a></li>
-      </ol>
-    </nav>
-
-    <h2 id="theoretical-foundations">1. Theoretical Foundations: Dual-Process Cognitive Framing</h2>
-    <p>In cognitive psychology, Kahneman's dual-process theory categorizes human thought into two modes <span class="cite">[<a href="#ref-1">1</a>]</span>:</p>
-    <ul>
-      <li><strong>System 1 (Intuitive):</strong> Fast, automatic, associative, and low-compute (e.g. recognizing a face, completing common idioms).</li>
-      <li><strong>System 2 (Deliberative):</strong> Slow, sequential, rule-governed, and computationally intensive (e.g. calculating \(17 \times 43\), playing chess, compiling code).</li>
-    </ul>
-    <p>Standard autoregressive generation operates analogously to System 1: every token receives an identical, fixed computational budget across Transformer layers. When faced with complex multi-step reasoning problems, standard models hallucinate because intermediate calculations cannot be completed within a single forward pass without intermediate scratchpad states.</p>
-
-    <h2 id="prompt-level-reasoning">2. Prompt-Level Scaffolding (CoT &amp; Tree of Thoughts)</h2>
-    <p>Early breakthroughs demonstrated that reasoning capabilities could be unlocked without parameter modification by structuring the input context:</p>
-    <ul>
-      <li><strong>Chain-of-Thought (CoT):</strong> Wei et al. showed that prompting a model to "think step-by-step" causes it to emit intermediate rationales before producing an answer <span class="cite">[<a href="#ref-2">2</a>]</span>. Each generated step acts as conditional context for subsequent steps, transforming non-linear deduction into linear sequential token generation.</li>
-      <li><strong>Self-Consistency:</strong> Wang et al. improved task reliability by sampling multiple independent CoT reasoning paths at temperature \(\tau > 0\) and selecting the final answer via marginal majority voting, marginalizing out reasoning errors <span class="cite">[<a href="#ref-3">3</a>]</span>.</li>
-      <li><strong>Tree of Thoughts (ToT):</strong> Yao et al. generalized linear CoT into deliberate tree exploration, allowing models to branch out alternative intermediate hypotheses, evaluate their promise with self-evaluation prompts, and backtrack when dead ends are reached <span class="cite">[<a href="#ref-4">4</a>]</span>.</li>
-    </ul>
-
-    <h2 id="test-time-compute">3. Test-Time Compute Scaling Laws</h2>
-    <p>Historically, language model performance scaled with pre-training compute (model parameters \(N\) and training tokens \(D\)). In 2024, frontier research established a parallel scaling law: <em><a href="/reference/test-time-compute/">test-time compute scaling</a></em> <span class="cite">[<a href="#ref-5">5</a>]</span>. Performance on complex mathematics, competitive programming, and formal logic improves as a power law of the inference compute allocated to generating and verifying intermediate thinking tokens:</p>
-    $$\text{Accuracy} \propto (\text{Inference Compute})^{\gamma}$$
-    <p>Reasoning models (such as OpenAI o1/o3 and DeepSeek-R1) leverage this principle by generating long, internal "chains of thought" (often thousands of tokens) prior to delivering the final user-facing response <span class="cite">[<a href="#ref-6">6</a>]</span>. During this internal generation, models evaluate sub-problems, test counterexamples, catch early errors, and rewrite failed proofs.</p>
-
-    <h2 id="verification-architectures">4. Verification Architectures: Process Supervision &amp; Search</h2>
-
-    <h3 id="prm">Process Reward Models (PRMs)</h3>
-    <p>Traditional reinforcement learning trains an Outcome Reward Model (ORM) that rewards only the final correctness of the answer: \(r(x, y) \in \{0, 1\}\). In multi-step proofs, ORMs encourage reward hacking, where a model arrives at the correct answer through flawed, accidental logic.</p>
-    <p>Lightman et al. introduced <em>Process Supervision</em>, training a Process Reward Model (PRM) to score the mathematical validity of every individual step \(t\) in a reasoning chain <span class="cite">[<a href="#ref-7">7</a>]</span>:</p>
-    $$\text{Score}(z) = \prod_{t=1}^T P(\text{step } t \text{ is correct} \mid x, z_1, \dots, z_t)$$
-    <p>Process supervision guides beam search and rejection sampling directly toward logically rigorous derivations.</p>
-
-    <h3 id="mcts">Search &amp; Self-Correction (MCTS &amp; Pure RL)</h3>
-    <p>Production reasoning models integrate reinforcement learning with algorithmic verification:</p>
-    <ul>
-      <li><strong>Reinforcement Learning with Rule-Based Verifiers:</strong> DeepSeek-R1-Zero demonstrated that large language models trained purely with reinforcement learning (using deterministic unit tests and mathematical equivalence verifiers as the reward function) spontaneously develop self-verification, self-correction, and extensive multi-step deliberation strategies without human demonstration data <span class="cite">[<a href="#ref-6">6</a>]</span>.</li>
-      <li><strong>Monte Carlo Tree Search (MCTS):</strong> Pairing value networks with rollout simulations enables models to plan moves ahead in formal theorem provers (Lean, Isabelle) and competitive programming environments.</li>
-    </ul>
-
-    <h2 id="evaluation-benchmarks">5. Evaluation Benchmarks &amp; Frontier Challenges</h2>
-    <p>Reasoning evaluation has shifted away from multiple-choice benchmarks (MMLU) toward verifiable formal tasks:</p>
-    <ul>
-      <li><strong>GSM8K &amp; MATH:</strong> Grade-school and high-school competitive Olympiad mathematics requiring multi-step symbolic derivation.</li>
-      <li><strong>SWE-bench:</strong> Resolving real-world software engineering issues from GitHub repositories, evaluating multi-file code navigation and patch verification.</li>
-      <li><strong>ARC-AGI:</strong> François Chollet's Abstraction and Reasoning Corpus, measuring out-of-distribution visual inductive logic and few-shot program synthesis.</li>
-    </ul>
-    <p>Open frontier challenges include overthinking simple queries, degradation on creative tasks, and the computational latency cost of emitting thousands of thinking tokens per interaction.</p>
-
-    <section class="see-also" id="see-also">
-      <h2>See also</h2>
-      <ul>
-        <li><a href="/reference/test-time-compute/">Test-Time Compute</a> &middot; Scaling inference computation via search, verification, and extended reasoning tokens.</li>
-        <li><a href="/eli5/reasoning/">ELI5: Reasoning</a> &middot; Visual picture-book explainer of System 1 intuition vs. System 2 scratchpads.</li>
-        <li><a href="/reference/prompt-engineering/">Prompt Engineering</a> &middot; Chain-of-Thought prompting and in-context task scaffolding.</li>
-        <li><a href="/reference/fine-tuning/">Fine-Tuning and Alignment</a> &middot; RLHF, DPO, and reinforcement learning training procedures.</li>
-        <li><a href="/reference/context-window/">Context Windows</a> &middot; Memory boundaries that house expanded thinking traces.</li>
-        <li><a href="/reference/large-language-models/">Large Language Models</a> &middot; Foundation architectures supporting autoregressive reasoning.</li>
-      </ul>
-    </section>
-
-    <section class="references" id="references">
-      <h2>References</h2>
-      <ol>
-        <li id="ref-1">[1] D. Kahneman, <em>Thinking, Fast and Slow</em>, Farrar, Straus and Giroux, New York, 2011.</li>
-        <li id="ref-2">[2] J. Wei, X. Wang, D. Schuurmans, et al., "Chain-of-Thought Prompting Elicits Reasoning in Large Language Models," in <em>NeurIPS</em>, 2022. <a href="https://arxiv.org/abs/2201.11903">https://arxiv.org/abs/2201.11903</a></li>
-        <li id="ref-3">[3] X. Wang, J. Wei, D. Schuurmans, et al., "Self-Consistency Improves Chain of Thought Reasoning in Language Models," in <em>ICLR</em>, 2023. <a href="https://arxiv.org/abs/2203.11171">https://arxiv.org/abs/2203.11171</a></li>
-        <li id="ref-4">[4] S. Yao, D. Yu, J. Zhao, et al., "Tree of Thoughts: Deliberate Problem Solving with Large Language Models," in <em>NeurIPS</em>, 2023. <a href="https://arxiv.org/abs/2305.10601">https://arxiv.org/abs/2305.10601</a></li>
-        <li id="ref-5">[5] N. Brown, G. Zhang, S. Feng, et al., "Large Language Models at Test-Time: Scaling Compute via Search and Verification," <em>OpenAI Technical Papers</em>, 2024.</li>
-        <li id="ref-6">[6] DeepSeek-AI, "DeepSeek-R1: Incentivizing Reasoning Capability in LLMs via Reinforcement Learning," <em>arXiv:2501.12948</em>, 2025. <a href="https://arxiv.org/abs/2501.12948">https://arxiv.org/abs/2501.12948</a></li>
-        <li id="ref-7">[7] H. Lightman, V. Kosaraju, Y. Burda, et al., "Let's Verify Step by Step," in <em>ICLR</em>, 2024. <a href="https://arxiv.org/abs/2305.20050">https://arxiv.org/abs/2305.20050</a></li>
-      </ol>
-    </section>
+  <main id="top">
+    <p class="back"><a href="/reference/">← Reference</a> · <a href="/">Nestor G Pestelos Jr</a> · <a href="#" onclick="window.print(); return false;">Print this page</a></p>
+<p class="kicker">Artificial Intelligence · Reasoning</p><h1>Reasoning in Language Models</h1>
+<p class="lede"><strong>Reasoning in language models</strong> refers to solving tasks that require intermediate deductions, calculations, or planning. Researchers study prompting, search, training, and inference computation as ways to improve performance. Generated explanations are not direct evidence of the model's internal reasoning.<span class="cite">[<a href="#ref1">1</a>]</span><span class="cite">[<a href="#ref4">4</a>]</span></p>
+<p class="updated">Reference entry · last updated 20260909 · <a href="/reference/reasoning-20260909/">Previous version</a></p>
+<nav class="toc" aria-label="Contents"><p class="toc-title">Contents</p><ol><li><a href="#first-principles">First principles and definitions</a></li><li><a href="#prompt-level-reasoning">Prompting and sampled answers</a></li><li><a href="#test-time-compute">Test-time compute</a></li><li><a href="#verification-architectures">Step scoring and search</a></li><li><a href="#prm">Process supervision</a></li><li><a href="#mcts">Search and reinforcement learning</a></li><li><a href="#evaluation-benchmarks">Evaluation and limits</a></li><li><a href="#see-also">See also</a></li><li><a href="#references">References</a></li></ol></nav><h2 id="first-principles">First principles and definitions</h2>
+<p id="theoretical-foundations">An <a href="/reference/autoregressive/">autoregressive model</a> predicts the next token from its context. A generated calculation can become part of the context used to produce the answer. Prompting for intermediate steps is one method; sampling and evaluating candidate solutions are methods.<span class="cite">[<a href="#ref1">1</a>]</span><span class="cite">[<a href="#ref3">3</a>]</span></p>
+<p>Answer correctness and explanation faithfulness are distinct. A model can produce plausible steps that fail to explain what caused its answer. Lanham et al. found that faithfulness varied across the models and tasks they tested.<span class="cite">[<a href="#ref4">4</a>]</span></p>
+<h2 id="prompt-level-reasoning">Prompting and sampled answers</h2>
+<p><a href="/reference/chain-of-thought/">Chain-of-thought</a> (CoT) prompting elicits intermediate steps before an answer. Wei et al. used worked examples in the prompt. Kojima et al. studied zero-shot prompting with “Let's think step by step,” followed by answer extraction. Both reported gains on selected reasoning benchmarks.<span class="cite">[<a href="#ref1">1</a>]</span><span class="cite">[<a href="#ref2">2</a>]</span></p>
+<p><strong>Self-consistency</strong> samples several reasoning paths and selects the most common answer. Wang et al. aggregate over sampled paths, not over an identified set of errors. Agreement can improve benchmark accuracy but cannot establish correctness when paths share mistakes.<span class="cite">[<a href="#ref3">3</a>]</span></p>
+<h2 id="test-time-compute">Test-time compute</h2>
+<p><a href="/reference/test-time-compute/">Test-time compute</a> is computation spent while answering a request. It can fund longer generation, additional candidates, or evaluation and search.</p>
+<p>Snell et al. studied verifier-guided search and iterative answer revision on mathematical problems. The effective allocation depended on problem difficulty and the available model and method. Their results support task-dependent allocation, not a universal power law between inference compute and accuracy.<span class="cite">[<a href="#ref5">5</a>]</span></p>
+<h2 id="verification-architectures">Step scoring and search</h2>
+<h3 id="prm">Process supervision</h3>
+<p>Outcome supervision scores a completed answer; process supervision provides feedback on intermediate steps. Lightman et al. trained models from human step-level feedback and evaluated them by selecting among sampled mathematical solutions. Process supervision outperformed outcome supervision in that experiment. A learned score remains an estimate, not a proof that a step is valid.<span class="cite">[<a href="#ref6">6</a>]</span></p>
+<h3 id="mcts">Search and reinforcement learning</h3>
+<p><strong>Tree of Thoughts</strong>, studied by Yao et al., explores alternative intermediate steps, evaluates them, and can backtrack. The paper reports results on Game of 24, creative writing, and mini crosswords. This is an explicit search procedure, not a property established by asking for one chain of thought.<span class="cite">[<a href="#ref7">7</a>]</span></p>
+<p><strong>DeepSeek-R1-Zero</strong> is a training example. It starts from a pretrained base model and applies reinforcement learning without a preliminary supervised fine-tuning stage. The report uses accuracy and format rewards and describes emerging behaviors such as checking and revising answers. This does not imply that all reasoning models use the same training or search architecture.<span class="cite">[<a href="#ref8">8</a>]</span></p>
+<h2 id="evaluation-benchmarks">Evaluation and limits</h2>
+<p>The cited studies measure different outcomes: final-answer accuracy, selection of mathematical solutions, task success under search, or changes caused by interventions on intermediate text. Their results should be read with the tested model, task, and compute budget. Higher answer accuracy alone does not demonstrate faithful explanations.<span class="cite">[<a href="#ref4">4</a>]</span><span class="cite">[<a href="#ref5">5</a>]</span><span class="cite">[<a href="#ref6">6</a>]</span></p>
+<h2 id="see-also">See also</h2><ul><li><a href="/reference/chain-of-thought/">Chain-of-Thought</a></li><li><a href="/reference/test-time-compute/">Test-Time Compute</a></li><li><a href="/eli5/reasoning/">ELI5: Reasoning</a></li><li><a href="/reference/prompt-engineering/">Prompt Engineering</a></li><li><a href="/reference/fine-tuning/">Fine-Tuning and Alignment</a></li><li><a href="/reference/context-window/">Context Windows</a></li><li><a href="/reference/large-language-models/">Large Language Models</a></li></ul><h2 id="references">References</h2>
+<ol>
+<li id="ref1">Jason Wei et al. (2022). <a href="https://arxiv.org/abs/2201.11903">Chain-of-Thought Prompting Elicits Reasoning in Large Language Models</a>.</li>
+<li id="ref2">Takeshi Kojima et al. (2022). <a href="https://arxiv.org/abs/2205.11916">Large Language Models are Zero-Shot Reasoners</a>.</li>
+<li id="ref3">Xuezhi Wang et al. (2023). <a href="https://arxiv.org/abs/2203.11171">Self-Consistency Improves Chain of Thought Reasoning in Language Models</a>.</li>
+<li id="ref4">Tamera Lanham et al. (2023). <a href="https://arxiv.org/abs/2307.13702">Measuring Faithfulness in Chain-of-Thought Reasoning</a>.</li>
+<li id="ref5">Charlie Snell et al. (2024). <a href="https://arxiv.org/abs/2408.03314">Scaling LLM Test-Time Compute Optimally can be More Effective than Scaling Model Parameters</a>.</li>
+<li id="ref6">Hunter Lightman et al. (2023). <a href="https://arxiv.org/abs/2305.20050">Let's Verify Step by Step</a>.</li>
+<li id="ref7">Shunyu Yao et al. (2023). <a href="https://arxiv.org/abs/2305.10601">Tree of Thoughts: Deliberate Problem Solving with Large Language Models</a>.</li>
+<li id="ref8">DeepSeek-AI (2025). <a href="https://arxiv.org/abs/2501.12948">DeepSeek-R1: Incentivizing Reasoning Capability in LLMs via Reinforcement Learning</a>.</li>
+</ol>
   </main>
 
   <button id="backToTop" class="back-to-top" aria-label="Back to top" title="Back to top">

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -196,6 +196,11 @@
     <priority>0.5</priority>
   </url>
   <url>
+    <loc>https://ngpestelos.com/reference/chain-of-thought/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
     <loc>https://ngpestelos.com/reference/chiquito/</loc>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>


### PR DESCRIPTION
The MCP reference overstated security guarantees and described obsolete transport behavior. The reasoning entry conflated prompting studies, treated explanations as reliable reasoning traces, and cited an unverified universal scaling law.

- Pin MCP to protocol version `2026-07-28`; correct transports, feature status, diagram labels, consent policy and advisory roots.
- Correct CoT attribution, self-consistency, faithfulness and scoped test-time compute evidence in the reasoning entry.
- Add a dedicated Chain-of-Thought reference with a worked example, prompting variants and limitations; register it in the reference index and sitemap.
- Preserve both prior pages at dated routes with reciprocal links. Historical bodies match baseline `c8662d2d2ab64c6c8ab828f9cc326eccf651b745` after reversing identity metadata and archive notices. Archives are excluded from the current index and sitemap.

Validation at `e9f345e2c32e12e03fea6dd868c3a32692542a2f`: 36 existing tests passed; all five routes returned HTTP 200 locally; anchors, local links, JSON-LD and archive fidelity passed. The eight preserved reasoning-archive equations render with KaTeX; current pages use plain text. Primary-source and prose checks passed.

Desktop/mobile visual inspection was not completed because browser launches failed in this environment. The revised MCP table has page-local horizontal overflow handling.
