### PR TITLE
Clarify acquirer role in payments glossary

### DIFF
--- a/writing/payments-glossary/index.html
+++ b/writing/payments-glossary/index.html
@@ -66,7 +66,7 @@
 
 <h3 id="acquirer">Acquirer</h3>
 
-<p>The merchant&#x27;s bank, or a processor working for that bank. It brings the merchant into the card network.</p>
+<p>A bank or other payment service provider that contracts with a merchant to accept and process payments, resulting in funds being transferred to the merchant. It may use a processor to handle the technical processing.</p>
 
 <h3 id="issuing-bank">Issuing bank</h3>
 
@@ -265,6 +265,12 @@
 <ul>
 
 <li>Federal Reserve, <a href="https://www.federalreserve.gov/aboutthefed/fedexplained/payment-systems.htm">The Fed Explained: Payment Systems</a>. Currency, checks, ACH, Fedwire. Reserve Banks as a bank for banks. FedNow launched 2023.</li>
+
+<li>Visa, <a href="https://developer.visa.com/pages/glossary">Glossary</a>. Acquirer and processor roles.</li>
+
+<li>FCA, <a href="https://www.fca.org.uk/firms/payment-services-regulations-e-money-regulations">Payment Services Regulations and Electronic Money Regulations</a>. Non-bank merchant acquirers.</li>
+
+<li>European Union, <a href="https://eur-lex.europa.eu/legal-content/en/TXT/?uri=CELEX%3A32015L2366">PSD2, Article 4(44)</a>. Definition of acquiring payment transactions.</li>
 
 <li>Stripe, <a href="https://stripe.com/guides/introduction-to-online-payments">Collecting online payments</a>. Four parties, gateway, processor, acquirer, interchange, scheme fees, chargebacks.</li>
 


### PR DESCRIPTION
The payments glossary treated a processor working for a bank as an acquirer and implied that all acquirers are banks. Define the acquirer through its merchant contract and distinguish outsourced technical processing.

Add Visa, FCA, and PSD2 Article 4(44) to the existing sources list.

Validation: existing Python site test suite, HTML content/link checks, and `git diff --check`.
