### PR TITLE
Clarify payment rails comparison and timing

### DIFF
--- a/writing/atom.xml
+++ b/writing/atom.xml
@@ -74,7 +74,7 @@
   <entry>
     <id>https://ngpestelos.com/writing/us-and-philippine-payment-rails/</id>
     <title>US and Philippine Payment Rails</title>
-    <summary>The Fed names four public rails: currency, checks, ACH, and Fedwire. FedNow sits beside ACH. BSP names five designated systems. Cards sit on neither list. Pair the jobs, not the brand names.</summary>
+    <summary>Compare US and Philippine payment systems by the jobs they do. ACH and PESONet process batches; Fedwire and PhilPaSSplus settle transfers individually. FedNow and InstaPay give customers immediate funds, but settle between banks differently.</summary>
     <updated>2026-08-18T00:00:00+08:00</updated>
     <link href="https://ngpestelos.com/writing/us-and-philippine-payment-rails/"/>
   </entry>

--- a/writing/us-and-philippine-payment-rails/index.html
+++ b/writing/us-and-philippine-payment-rails/index.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>US and Philippine Payment Rails — Nestor G Pestelos Jr</title>
-  <meta name="description" content="The Fed names four public rails: currency, checks, ACH, and Fedwire. FedNow sits beside ACH. BSP names five designated systems. Cards sit on neither list. Pair the jobs, not the brand names.">
+  <meta name="description" content="Compare US and Philippine payment systems by the jobs they do. ACH and PESONet process batches; Fedwire and PhilPaSSplus settle transfers individually. FedNow and InstaPay give customers immediate funds, but settle between banks differently.">
   <meta property="og:title" content="US and Philippine Payment Rails">
-  <meta property="og:description" content="The Fed names four public rails: currency, checks, ACH, and Fedwire. FedNow sits beside ACH. BSP names five designated systems. Cards sit on neither list. Pair the jobs, not the brand names.">
+  <meta property="og:description" content="Compare US and Philippine payment systems by the jobs they do. ACH and PESONet process batches; Fedwire and PhilPaSSplus settle transfers individually. FedNow and InstaPay give customers immediate funds, but settle between banks differently.">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://ngpestelos.com/writing/us-and-philippine-payment-rails/">
   <link rel="canonical" href="https://ngpestelos.com/writing/us-and-philippine-payment-rails/">
@@ -26,7 +26,7 @@
     gtag('config', 'G-TLBY8P4GG9');
   </script>
   <script type="application/ld+json">
-{"@context":"https://schema.org","@type":"Article","headline":"US and Philippine Payment Rails","description":"The Fed names four public rails: currency, checks, ACH, and Fedwire. FedNow sits beside ACH. BSP names five designated systems. Cards sit on neither list. Pair the jobs, not the brand names.","url":"https://ngpestelos.com/writing/us-and-philippine-payment-rails/","author":{"@type":"Person","name":"Nestor G Pestelos Jr"},"datePublished":"2026-08-18"}
+{"@context":"https://schema.org","@type":"Article","headline":"US and Philippine Payment Rails","description":"Compare US and Philippine payment systems by the jobs they do. ACH and PESONet process batches; Fedwire and PhilPaSSplus settle transfers individually. FedNow and InstaPay give customers immediate funds, but settle between banks differently.","url":"https://ngpestelos.com/writing/us-and-philippine-payment-rails/","author":{"@type":"Person","name":"Nestor G Pestelos Jr"},"datePublished":"2026-08-18"}
   </script>
 </head>
 <body>
@@ -37,11 +37,13 @@
 
 <p class="series">Travel Guide to Philippine Payments</p>
 
-<div class="tldr"><span class="tldr-label">TL;DR</span><p>The Fed names four public rails: currency, checks, ACH, and Fedwire. FedNow sits beside ACH. BSP names five designated systems. Cards sit on neither list. Pair the jobs, not the brand names.</p></div>
+<div class="tldr"><span class="tldr-label">TL;DR</span><p>Compare US and Philippine payment systems by the jobs they do. ACH and PESONet process batches; Fedwire and PhilPaSSplus settle transfers individually. FedNow and InstaPay give customers immediate funds, but settle between banks differently.</p></div>
 
 <hr>
 
-<p>I published a <a href="https://ngpestelos.com/writing/payments-glossary/">payments glossary</a> so later pieces have one address. A rail is who can send, who says the money is there, when the receiver can spend it, and who eats a mistake.</p>
+<p>A customer can receive funds before the banks settle with each other. This comparison covers how US and Philippine payment systems process transfers, when customers receive funds, and when banks settle.</p>
+
+<p>The <a href="https://ngpestelos.com/writing/payments-glossary/">payments glossary</a> defines the terms used here.</p>
 
 <h2 id="side-by-side">Side by side</h2>
 
@@ -51,65 +53,63 @@
 <tr><th>Job</th><th>United States</th><th>Philippines</th></tr>
 </thead>
 <tbody>
-<tr><td>Weekday wholesale, item by item</td><td><a href="https://ngpestelos.com/writing/payments-glossary/#fedwire">Fedwire</a></td><td><a href="https://ngpestelos.com/writing/payments-glossary/#philpassplus">PhilPaSSplus</a></td></tr>
+<tr><td>Wholesale settlement, item by item</td><td><a href="https://ngpestelos.com/writing/payments-glossary/#fedwire">Fedwire</a></td><td><a href="https://ngpestelos.com/writing/payments-glossary/#philpassplus">PhilPaSSplus</a></td></tr>
 <tr><td>Planned batch credit or debit</td><td><a href="https://ngpestelos.com/writing/payments-glossary/#ach">ACH</a> (<a href="https://ngpestelos.com/writing/payments-glossary/#nacha">Nacha</a> rules)</td><td><a href="https://ngpestelos.com/writing/payments-glossary/#pesonet">PESONet</a> (credit in the published FAQ; no scheme cap)</td></tr>
 <tr><td>Faster batch, still a batch</td><td><a href="https://ngpestelos.com/writing/payments-glossary/#same-day-ach">Same-Day ACH</a> ($1m cap now)</td><td>PESONet&#x27;s three same-day cycles</td></tr>
 <tr><td>Instant for the customer, every day</td><td><a href="https://ngpestelos.com/writing/payments-glossary/#fednow">FedNow</a> (also instant between banks)</td><td><a href="https://ngpestelos.com/writing/payments-glossary/#instapay">InstaPay</a> (customer instant; banks net on weekday <a href="https://ngpestelos.com/writing/payments-glossary/#rtgs">RTGS</a>)</td></tr>
-<tr><td>Paper check</td><td><a href="https://ngpestelos.com/writing/payments-glossary/#check-presentment">Check presentment</a></td><td>Check nets settle on PhilPaSSplus; not a separate designated rail</td></tr>
-<tr><td>Domestic foreign-currency book</td><td>Not on the Fed four-list as a named twin</td><td><a href="https://ngpestelos.com/writing/payments-glossary/#pddts">PDDTS</a> (dollars); <a href="https://ngpestelos.com/writing/payments-glossary/#php-usd-pvp">PhP-USD PvP</a> (both legs)</td></tr>
+<tr><td>Paper check</td><td><a href="https://ngpestelos.com/writing/payments-glossary/#check-presentment">Check presentment</a></td><td>Check nets settle on PhilPaSSplus</td></tr>
+<tr><td>Domestic dollar transfers and peso-dollar settlement</td><td>No counterpart covered here</td><td><a href="https://ngpestelos.com/writing/payments-glossary/#pddts">PDDTS</a> (dollars); <a href="https://ngpestelos.com/writing/payments-glossary/#php-usd-pvp">PhP-USD PvP</a> (both legs)</td></tr>
 <tr><td>Tap or typed card</td><td>Private card network</td><td>Private card network</td></tr>
-<tr><td>Scan a QR</td><td>Not a Fed rail</td><td><a href="https://ngpestelos.com/writing/payments-glossary/#qr-ph">QR Ph</a> / <a href="https://ngpestelos.com/writing/payments-glossary/#instapay-qr">InstaPay QR</a>, then InstaPay</td></tr>
+<tr><td>Scan a QR</td><td>Not covered here</td><td><a href="https://ngpestelos.com/writing/payments-glossary/#qr-ph">QR Ph</a> / <a href="https://ngpestelos.com/writing/payments-glossary/#instapay-qr">InstaPay QR</a>, then InstaPay</td></tr>
 </tbody>
 </table>
 </div>
 
-<p>BSP still calls InstaPay and PESONet &quot;ACHs.&quot; Circular 980 uses ACH for the NRPS schemes. That is not Nacha&#x27;s batch network. PESONet is the batch sibling. InstaPay is a third shape.</p>
+<p>BSP uses ACH for the automated clearing houses under NRPS in Circular 980. PESONet processes batches; InstaPay credits customers immediately. The US ACH network processes batches under Nacha rules.</p>
 
-<p>Visa, Mastercard, and the other card networks are on neither official list. A grocery tap still happens. It rides a private switch. The banks settle later.</p>
+<p>Visa, Mastercard, and other card networks route card payments through private networks. The banks settle later.</p>
 
 <h2 id="the-us-map">The US map</h2>
 
-<p>The Federal Reserve&#x27;s own list is <a href="https://ngpestelos.com/writing/payments-glossary/#federal-reserve-payment-system">currency</a>, checks, ACH, and Fedwire. <a href="https://ngpestelos.com/writing/payments-glossary/#reserve-bank">Reserve Banks</a> are banks for banks. They hold master accounts where depository institutions settle with each other.</p>
+<p>The <a href="https://www.federalreserve.gov/aboutthefed/fedexplained/payment-systems.htm">Federal Reserve explains payment systems</a> through examples including currency, checks, ACH, and Fedwire, and discusses FedNow separately. These examples serve a different purpose from BSP&#x27;s regulatory list of designated systems. Neither list is a complete inventory of payment rails. <a href="https://ngpestelos.com/writing/payments-glossary/#reserve-bank">Reserve Banks</a> are banks for banks. They hold master accounts where depository institutions settle with each other.</p>
 
 <p>Currency is immediate physical notes. Check presentment takes days. Reserve Banks present and settle.</p>
 
-<p>ACH files go through <a href="https://ngpestelos.com/writing/payments-glossary/#fedach-and-epn">FedACH and EPN</a>. Nacha writes the rules. Speed is next day, or the same processing day.</p>
+<p>ACH files go through <a href="https://ngpestelos.com/writing/payments-glossary/#fedach-and-epn">FedACH and EPN</a>. Nacha writes the rules. <a href="https://www.nacha.org/news/significant-majority-ach-payments-settle-one-business-day-or-less">ACH credits can settle the same day, the next banking day, or in two banking days</a>.</p>
 
-<p>Fedwire posts each item on a master account during banking hours. Minutes for the customer. That shape is RTGS.</p>
+<p>Fedwire posts each transfer individually on a master account. Its <a href="https://www.frbservices.org/resources/financial-services/wires/operating-hours.html">operating window</a> runs from 9 p.m. Eastern Time on the preceding calendar day to 7 p.m. Eastern Time for each funds-transfer business day. Banks set their customer cutoffs and crediting times separately.</p>
 
 <p>FedNow launched in 2023. It is a public instant rail beside ACH. Each item also posts on a master account. Seconds, any day.</p>
 
 <p>Same-Day ACH is still a batch. The item has to hit a same-day deadline and must not be future-dated. Items above $1,000,000 are ineligible until 17 September 2027, when the cap rises to $10 million.</p>
 
-<p>RTGS means each transfer posts one by one, as it arrives, usually on a central-bank account. Final when posted. The Board has used &quot;instant payment&quot; for a payment in which an end user receives funds immediately, and at any time, with near real time interbank settlement of that same payment. FedNow is that shape. Fedwire is RTGS for large value, on weekday banking hours.</p>
+<p>RTGS means each transfer posts one by one, as it arrives, usually on a central-bank account. Final when posted. The Board has used &quot;instant payment&quot; for a payment in which an end user receives funds immediately, and at any time, with near real time interbank settlement of that same payment. FedNow is that shape. Fedwire is RTGS for large-value transfers within its business-day operating window.</p>
 
 <h2 id="the-philippine-map">The Philippine map</h2>
 
 <p>BSP&#x27;s published operators list names five designated systems. <a href="https://ngpestelos.com/writing/payments-glossary/#ra-11127">RA 11127</a> gives BSP oversight and the power to own and operate systems. An <a href="https://ngpestelos.com/writing/payments-glossary/#odps">ODPS</a> needs prior Monetary Board authority.</p>
 
-<p><a href="https://ngpestelos.com/writing/payments-glossary/#nrps">NRPS</a> is a policy framework (Monetary Board 2015; Circular 980, 6 November 2017). It is not a sixth rail and not a BSP-owned retail switch. InstaPay and PESONet sit under it.</p>
+<p><a href="https://ngpestelos.com/writing/payments-glossary/#nrps">NRPS</a> is a policy framework (Monetary Board 2015; Circular 980, 6 November 2017). InstaPay and PESONet sit under it.</p>
 
-<p>Published operators: PhilPaSSplus is BSP. InstaPay is <a href="https://ngpestelos.com/writing/payments-glossary/#bancnet">BancNet</a>. PESONet, PDDTS, and PhP-USD PvP are <a href="https://ngpestelos.com/writing/payments-glossary/#pchc">PCHC</a> (BAP established).</p>
+<p>BSP&#x27;s <a href="https://www.bsp.gov.ph/PaymentAndSettlement/List_of_Operators_of_Designated_Payment_Systems.pdf">operators list</a> names BSP for Peso RTGS (PhilPaSSplus) and <a href="https://ngpestelos.com/writing/payments-glossary/#pnpi">PNPI</a> for InstaPay, PESONet, PDDTS, and PhP-USD PvP. Its footnote confirms that the BancNet-PCHC merger took effect on June 1, 2026.</p>
 
-<p>PDDTS speed and the dollar book are unstated on that list. PhP-USD PvP is same-session. The peso side links to the peso RTGS.</p>
+<p>The operators list does not specify PDDTS processing times or how its dollar transfers settle. PhP-USD PvP is same-session. The peso side links to the peso RTGS.</p>
 
-<p>PhilPaSSplus succeeded <a href="https://ngpestelos.com/writing/payments-glossary/#philpass">PhilPaSS</a> in 2021. Hours: 09:00 to 17:45, Monday to Friday. Large items post one by one. It also takes the nets of other schemes.</p>
+<p>PhilPaSSplus succeeded <a href="https://ngpestelos.com/writing/payments-glossary/#philpass">PhilPaSS</a> in 2021. Hours: 09:00 to 17:45 Philippine time, Monday to Friday. Large items post one by one. It also takes the nets of other schemes.</p>
 
 <p>InstaPay is PHP only and domestic only. Published FAQ cap: PHP 50,000. The sender may pay a fee. The receiver is not charged and gets the full amount. The customer credit is already final. Banks prefund the nets on PhilPaSSplus. That is not each customer payment posting as RTGS.</p>
 
-<p>PESONet has three cycles on a business day: 10:00 a.m., 1:00 p.m., 4:00 p.m. The inward file is released only after every participant&#x27;s net settlement succeeds.</p>
+<p>PESONet has <a href="https://www.bsp.gov.ph/PaymentAndSettlement/FAQs_3MBS_of_the_PESONet.pdf">three settlement cycles</a> on a business day: 10:00 a.m., 1:00 p.m., and 4:00 p.m. Philippine time. Banks set their customer cutoffs separately. The inward file is released only after every participant&#x27;s net settlement succeeds. BSP says customers are typically credited within two hours after the receiving bank gets the inward clearing advice.</p>
 
-<p>QR Ph is not on the designated-operators list. It is a national QR standard. The P2P FAQ says there is no stand-alone QR Ph app. Person-to-person and person-to-merchant payments that use the code settle on InstaPay. After the July 2026 rebrand, QR Ph on the logo is person-to-merchant and InstaPay QR is person-to-person. Both still settle on InstaPay.</p>
+<p>QR Ph is a national QR standard. The P2P FAQ says there is no stand-alone QR Ph app. Person-to-person and person-to-merchant payments that use the code settle on InstaPay. After the July 2026 rebrand, QR Ph on the logo is person-to-merchant and InstaPay QR is person-to-person. Both still settle on InstaPay.</p>
 
-<p><a href="https://ngpestelos.com/writing/payments-glossary/#ppmi">PPMI</a> is the industry body the InstaPay FAQ names. Press reported a BancNet-PCHC merger under <a href="https://ngpestelos.com/writing/payments-glossary/#pnpi">PNPI</a> from 1 June 2026. The published operators list still names the two operators separately.</p>
+<p><a href="https://ngpestelos.com/writing/payments-glossary/#ppmi">PPMI</a> is the industry body the InstaPay FAQ names.</p>
 
 <h2 id="not-on-this-map">Not on this map</h2>
 
 <p>The public US instant row is FedNow. This page does not cover The Clearing House RTP.</p>
 
-<p>The InstaPay amount is the published FAQ figure: PHP 50,000.</p>
-
-<p>GCash-to-GCash and Maya-to-Maya transfers are not split from InstaPay in BSP&#x27;s public series. They are not a sixth designated system here.</p>
+<p>Transfers within the same wallet provider, such as GCash-to-GCash or Maya-to-Maya, are outside this comparison.</p>
 
 <h2 id="sources">Sources</h2>
 
@@ -121,7 +121,11 @@
 
 <li>Federal Reserve Bank Services, <a href="https://www.frbservices.org/financial-services/ach/same-day-service.html">FedACH SameDay Service</a></li>
 
+<li>Federal Reserve Bank Services, <a href="https://www.frbservices.org/resources/financial-services/wires/operating-hours.html">Fedwire Funds operating hours</a></li>
+
 <li>Nacha, <a href="https://achdevguide.nacha.org/how-ach-works">How ACH works</a></li>
+
+<li>Nacha, <a href="https://www.nacha.org/news/significant-majority-ach-payments-settle-one-business-day-or-less">ACH settlement timing</a></li>
 
 <li>Nacha, <a href="https://www.nacha.org/news/same-day-ach-payment-limit-increase-10-million">Same Day ACH payment limit increase to $10 million</a></li>
 
@@ -144,8 +148,6 @@
 <li>BSP, <a href="https://www.bsp.gov.ph/Media_And_Research/Primers%20Faqs/FAQs-QR-Ph-Rebranding.pdf">QR Ph Rebranding FAQs</a></li>
 
 <li><a href="https://lawphil.net/statutes/repacts/ra2018/ra_11127_2018.html">Republic Act No. 11127</a></li>
-
-<li>BusinessWorld, <a href="https://bworldonline.com/banking-finance/2026/06/03/753866/sec-clears-bancnet-pchc-merger/">SEC clears BancNet-PCHC merger</a></li>
 
 <li><a href="https://ngpestelos.com/writing/payments-glossary/">Payments Glossary</a></li>
 


### PR DESCRIPTION
The payment rails comparison treated an illustrative Federal Reserve list as equivalent to BSP regulatory designations, retained outdated operator names, and blurred system timing with customer availability.

Reframe the comparison by payment function, update PNPI attribution, clarify Fedwire/ACH/PESONet timing, remove the unsupported wallet-statistics claim, and narrow the introduction to the article’s scope. Update the page’s metadata and primary-source references with the revised text.

Validation: existing Python site suite, HTML structure and content checks, and `git diff --check`.
