### PR TITLE
Add InstaPay and ACH reference pages

### DIFF
--- a/reference/ach/index.html
+++ b/reference/ach/index.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ACH (United States) · Reference · Nestor G Pestelos Jr</title>
+  <meta name="description" content="The US Automated Clearing House network: credit and debit entries, Nacha rules, FedACH and EPN, settlement timing, Same Day ACH limits, returns, and reversals.">
+  <meta property="og:title" content="ACH (United States) · Reference">
+  <meta property="og:description" content="The US Automated Clearing House network: credit and debit entries, Nacha rules, FedACH and EPN, settlement timing, Same Day ACH limits, returns, and reversals.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://ngpestelos.com/reference/ach/">
+  <link rel="canonical" href="https://ngpestelos.com/reference/ach/">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=20260813f">
+  <link rel="icon" href="/favicon-192.png?v=20260813f" type="image/png" sizes="192x192">
+  <link rel="icon" href="/favicon-32.png?v=20260813f" type="image/png" sizes="32x32">
+  <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
+  <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="stylesheet" href="/style.css?v=20260903e">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TLBY8P4GG9');
+  </script>
+  <style>
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; -webkit-text-size-adjust:100%; text-size-adjust:100%; }
+body { line-height:1.65; }
+main { max-width:48rem; margin:auto; padding:1.4rem 1.4rem 4rem; }
+h1 { font-size:clamp(1.9rem,5vw,2.4rem); font-weight:400; line-height:1.2; border-bottom:1px solid var(--line); padding-bottom:.5rem; }
+h2 { font-weight:400; margin-top:2rem; font-size:1.45rem; border-bottom:1px solid var(--line); padding-bottom:.3rem; }
+p,li { margin-bottom:.7rem; }
+.back,.kicker,.updated,.toc,footer { font-family:"Segoe UI",Helvetica,Arial,sans-serif; }
+.back,.updated,footer { font-size:.85rem; color:var(--mute); }
+.kicker { font-size:.78rem; text-transform:uppercase; letter-spacing:.08em; font-weight:700; color:var(--mute); }
+.lede { margin:1.4rem 0; }
+.toc { background:var(--well); border:1px solid var(--line); border-radius:4px; padding:1rem 1.3rem; margin:1.7rem 0; font-size:.9rem; }
+.toc ol { margin-bottom:0; padding-left:1.5rem; }
+.toc li { margin-bottom:.25rem; }
+.cite { font-size:.75em; vertical-align:super; }
+.cite a { text-decoration:none; }
+#references ~ ol { font-size:.9rem; overflow-wrap:anywhere; }
+footer { border-top:1px solid var(--line); margin-top:2rem; }
+.back-to-top { position:fixed; bottom:1.5rem; right:1.5rem; width:2.6rem; height:2.6rem; border-radius:50%; background:var(--bg); color:var(--ink); border:1px solid var(--line); cursor:pointer; opacity:0; visibility:hidden; }
+.back-to-top.visible { opacity:1; visibility:visible; }
+@media print { .back,.back-to-top { display:none !important; } main { max-width:none; padding:0; } }
+  </style>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"DefinedTerm","name":"ACH (United States)","description":"The US Automated Clearing House network: credit and debit entries, Nacha rules, FedACH and EPN, settlement timing, Same Day ACH limits, returns, and reversals.","url":"https://ngpestelos.com/reference/ach/","inDefinedTermSet":"https://ngpestelos.com/reference/"}</script>
+</head>
+<body class="reference">
+<main id="top">
+<p class="back"><a href="/reference/">&larr; Reference</a> &middot; <a href="/">Home</a> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a></p>
+<p class="kicker">Finance · Payments</p>
+<h1>ACH (United States)</h1>
+<p class="updated">Reference entry &middot; last updated September 9, 2026</p>
+<p class="lede"><strong>The Automated Clearing House (ACH) network</strong> is a US electronic payment network that processes batches of credit and debit entries between financial institutions. Nacha sets its operating rules; FedACH and EPN operate its processing services.<span class="cite">[<a href="#ref1">1</a>]</span><span class="cite">[<a href="#ref2">2</a>]</span></p>
+<nav class="toc" aria-label="Contents"><strong>Contents</strong><ol>
+<li><a href="#first-principles">First principles: credit and debit entries</a></li>
+<li><a href="#participants">Participants and operators</a></li>
+<li><a href="#timing">Processing and settlement timing</a></li>
+<li><a href="#same-day">Same Day ACH and its limit</a></li>
+<li><a href="#returns">Returns and reversals</a></li>
+<li><a href="#other-systems">Instant payments and Philippine terminology</a></li>
+<li><a href="#see-also">See also</a></li>
+<li><a href="#references">References</a></li>
+</ol></nav>
+<h2 id="first-principles">1. First principles: credit and debit entries</h2>
+<p>An <em>ACH credit</em> pushes funds from the originator’s account toward another account, as in payroll. An <em>ACH debit</em> pulls funds from an account under authorization, as in an agreed bill payment. Credit and debit describe the direction of the entry.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+<p>ACH carries batches of payment instructions. Clearing processes those instructions between institutions; <a href="/writing/payments-glossary/#settlement">settlement</a> transfers the corresponding value. Common uses include direct deposit, consumer bills, and business payments.<span class="cite">[<a href="#ref2">2</a>]</span></p>
+<h2 id="participants">2. Participants and operators</h2>
+<p>An ACH transaction has an originator, financial institutions, an operator, and a receiver. The roles apply to credits and debits, so the receiver of an entry is not always the person receiving money.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+<ul>
+<li><strong>Originator:</strong> initiates an authorized ACH entry.</li>
+<li><strong>Originating Depository Financial Institution (ODFI):</strong> submits entries on the originator’s behalf.</li>
+<li><strong>ACH operator:</strong> sorts and delivers entries between financial institutions.</li>
+<li><strong>Receiving Depository Financial Institution (RDFI):</strong> receives entries and posts them to the receiver’s account.</li>
+<li><strong>Receiver:</strong> the account holder whose account is credited or debited.</li>
+</ul>
+<p>Nacha administers the operating rules. The Federal Reserve’s FedACH and The Clearing House’s Electronic Payments Network (EPN) process ACH transactions. EPN exchanges transactions with FedACH so institutions served by different operators can exchange payments.<span class="cite">[<a href="#ref1">1</a>]</span><span class="cite">[<a href="#ref2">2</a>]</span></p>
+<h2 id="timing">3. Processing and settlement timing</h2>
+<p>ACH credits can settle on the same banking day, the next banking day, or in two banking days. ACH debits can settle on the same or next banking day. The available timing depends on the entry, its effective date, and when it reaches processing.<span class="cite">[<a href="#ref3">3</a>]</span></p>
+<p>A customer’s submission time is separate from an operator’s deadline. For example, FedACH SameDay processes an eligible item on the current processing day when it arrives by a same-day deadline and is not future-dated. Bank submission cutoffs and account posting are additional steps in the payment path. The settlement date alone does not establish an exact customer crediting time.<span class="cite">[<a href="#ref4">4</a>]</span></p>
+<h2 id="same-day">4. Same Day ACH and its limit</h2>
+<p>Same Day ACH adds settlement opportunities within a banking day. It uses ACH batch processing and remains subject to eligibility rules and deadlines. FedACH excludes international ACH transactions (IAT), automated enrollment entries (ENR), and items above the applicable same-day dollar limit.<span class="cite">[<a href="#ref4">4</a>]</span></p>
+<p>As of September 9, 2026, the Same Day ACH limit is $1 million per payment. Nacha has announced an increase to $10 million effective September 17, 2027. This is a limit for same-day eligibility, not a network-wide cap on all ACH payments.<span class="cite">[<a href="#ref5">5</a>]</span></p>
+<h2 id="returns">5. Returns and reversals</h2>
+<p>A <em>return</em> sends an entry back for a reason allowed by the network’s rules, such as insufficient funds or an account problem. A <em>reversal</em> corrects a qualifying error in an originated entry. Nacha limits reversals to specified circumstances, including duplicate entries and certain incorrect payment details.<span class="cite">[<a href="#ref6">6</a>]</span></p>
+<p>A reversal is not a general right to cancel a completed payment or undo a fraud loss. It must meet the applicable rules, and recovery can depend on whether funds remain available. Settlement, the right to return an entry, and successful recovery of money are separate questions.<span class="cite">[<a href="#ref6">6</a>]</span></p>
+<h2 id="other-systems">6. Instant payments and Philippine terminology</h2>
+<p>FedNow handles individual payments in near real time, with immediate end-user access to funds and interbank settlement available 24 hours a day, every day. Same Day ACH uses scheduled batch processing. A same-day settlement date therefore does not describe the same service as an instant payment.<span class="cite">[<a href="#ref7">7</a>]</span><span class="cite">[<a href="#ref4">4</a>]</span></p>
+<p>BSP uses <em>automated clearing house</em> for a multilateral agreement governing a Philippine payment stream under NRPS. That use includes arrangements with different processing models. <a href="/reference/instapay/">InstaPay</a> belongs to this Philippine framework; the abbreviation alone does not make it part of the US ACH network or imply US ACH timing and return rules.<span class="cite">[<a href="#ref8">8</a>]</span></p>
+<h2 id="see-also">7. See also</h2>
+<ul>
+<li><a href="/reference/instapay/">InstaPay (Philippines)</a></li>
+<li><a href="/reference/online-payments/">Online Payments</a></li>
+<li><a href="/writing/us-and-philippine-payment-rails/">US and Philippine Payment Rails</a></li>
+<li><a href="/writing/instapay-is-not-ach/">InstaPay Is Not ACH</a></li>
+<li><a href="/writing/payments-glossary/">Payments Glossary</a></li>
+</ul>
+<h2 id="references">8. References</h2>
+<p>Sources checked September 9, 2026.</p>
+<ol>
+<li id="ref1">Nacha. <a href="https://achdevguide.nacha.org/how-ach-works">How ACH works</a>.</li>
+<li id="ref2">The Clearing House. <a href="https://www.theclearinghouse.org/payment-systems/ach">Electronic Payments Network (EPN)</a>.</li>
+<li id="ref3">Nacha. <a href="https://www.nacha.org/news/significant-majority-ach-payments-settle-one-business-day-or-less">Significant majority of ACH payments settle in one business day or less</a>.</li>
+<li id="ref4">Federal Reserve Financial Services. <a href="https://www.frbservices.org/financial-services/ach/same-day-service.html">FedACH SameDay Service</a>.</li>
+<li id="ref5">Nacha. <a href="https://www.nacha.org/news/same-day-ach-payment-limit-increase-10-million">Same Day ACH payment limit to increase to $10 million (April 27, 2026)</a>.</li>
+<li id="ref6">Olivia Maciel, Nacha. <a href="https://www.nacha.org/news/second-chance-understanding-ach-reversals">Second Chance: Understanding ACH Reversals (August 6, 2026)</a>.</li>
+<li id="ref7">Federal Reserve Board. <a href="https://www.federalreserve.gov/paymentsystems/fednow-additional-questions-and-answers.htm">FedNow Service: Additional questions and answers</a>.</li>
+<li id="ref8">Bangko Sentral ng Pilipinas. <a href="https://www.bsp.gov.ph/Regulations/Issuances/2017/c980.pdf">Circular No. 980: National Retail Payment System framework (2017)</a>.</li>
+</ol>
+<footer><p><a href="#top">Back to top</a></p></footer>
+</main>
+  <button id="backToTop" class="back-to-top" aria-label="Back to top" title="Back to top">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M18 15l-6-6-6 6"/>
+    </svg>
+  </button>
+
+  <script>
+    const btt = document.getElementById('backToTop');
+    window.addEventListener('scroll', () => {
+      if (window.scrollY > 250) {
+        btt.classList.add('visible');
+      } else {
+        btt.classList.remove('visible');
+      }
+    }, { passive: true });
+    btt.addEventListener('click', () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  </script>
+</body>
+</html>

--- a/reference/index.html
+++ b/reference/index.html
@@ -199,6 +199,7 @@
         <h2 class="letter-heading">A</h2>
         <ul>
         <li><a href="/reference/acceleration-whiplash/">Acceleration Whiplash</a></li>
+        <li><a href="/reference/ach/">ACH (United States)</a></li>
         <li><a href="/reference/adversarial-agent-review/">Adversarial Review</a></li>
         <li><a href="/reference/russell-norvig-agent/">Agent (Russell and Norvig Definition)</a></li>
         <li><a href="/reference/agent-harness/">Agent Harness</a></li>
@@ -295,6 +296,7 @@
       <div class="letter-group" id="I">
         <h2 class="letter-heading">I</h2>
         <ul>
+        <li><a href="/reference/instapay/">InstaPay (Philippines)</a></li>
         <li><a href="/reference/intermediate-packets/">Intermediate Packets</a></li>
         </ul>
       </div>

--- a/reference/instapay/index.html
+++ b/reference/instapay/index.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>InstaPay (Philippines) · Reference · Nestor G Pestelos Jr</title>
+  <meta name="description" content="InstaPay in the Philippines: participant roles, instant customer credit, net settlement, transaction limits, QR access, and payment errors.">
+  <meta property="og:title" content="InstaPay (Philippines) · Reference">
+  <meta property="og:description" content="InstaPay in the Philippines: participant roles, instant customer credit, net settlement, transaction limits, QR access, and payment errors.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://ngpestelos.com/reference/instapay/">
+  <link rel="canonical" href="https://ngpestelos.com/reference/instapay/">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=20260813f">
+  <link rel="icon" href="/favicon-192.png?v=20260813f" type="image/png" sizes="192x192">
+  <link rel="icon" href="/favicon-32.png?v=20260813f" type="image/png" sizes="32x32">
+  <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
+  <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="stylesheet" href="/style.css?v=20260903e">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TLBY8P4GG9');
+  </script>
+  <style>
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; -webkit-text-size-adjust:100%; text-size-adjust:100%; }
+body { line-height:1.65; }
+main { max-width:48rem; margin:auto; padding:1.4rem 1.4rem 4rem; }
+h1 { font-size:clamp(1.9rem,5vw,2.4rem); font-weight:400; line-height:1.2; border-bottom:1px solid var(--line); padding-bottom:.5rem; }
+h2 { font-weight:400; margin-top:2rem; font-size:1.45rem; border-bottom:1px solid var(--line); padding-bottom:.3rem; }
+p,li { margin-bottom:.7rem; }
+.back,.kicker,.updated,.toc,footer { font-family:"Segoe UI",Helvetica,Arial,sans-serif; }
+.back,.updated,footer { font-size:.85rem; color:var(--mute); }
+.kicker { font-size:.78rem; text-transform:uppercase; letter-spacing:.08em; font-weight:700; color:var(--mute); }
+.lede { margin:1.4rem 0; }
+.toc { background:var(--well); border:1px solid var(--line); border-radius:4px; padding:1rem 1.3rem; margin:1.7rem 0; font-size:.9rem; }
+.toc ol { margin-bottom:0; padding-left:1.5rem; }
+.toc li { margin-bottom:.25rem; }
+.cite { font-size:.75em; vertical-align:super; }
+.cite a { text-decoration:none; }
+#references ~ ol { font-size:.9rem; overflow-wrap:anywhere; }
+footer { border-top:1px solid var(--line); margin-top:2rem; }
+.back-to-top { position:fixed; bottom:1.5rem; right:1.5rem; width:2.6rem; height:2.6rem; border-radius:50%; background:var(--bg); color:var(--ink); border:1px solid var(--line); cursor:pointer; opacity:0; visibility:hidden; }
+.back-to-top.visible { opacity:1; visibility:visible; }
+@media print { .back,.back-to-top { display:none !important; } main { max-width:none; padding:0; } }
+  </style>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"DefinedTerm","name":"InstaPay (Philippines)","description":"InstaPay in the Philippines: participant roles, instant customer credit, net settlement, transaction limits, QR access, and payment errors.","url":"https://ngpestelos.com/reference/instapay/","inDefinedTermSet":"https://ngpestelos.com/reference/"}</script>
+</head>
+<body class="reference">
+<main id="top">
+<p class="back"><a href="/reference/">&larr; Reference</a> &middot; <a href="/">Home</a> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a></p>
+<p class="kicker">Finance · Payments</p>
+<h1>InstaPay (Philippines)</h1>
+<p class="updated">Reference entry &middot; last updated September 9, 2026</p>
+<p class="lede"><strong>InstaPay</strong> is a Philippine electronic funds transfer service for domestic Philippine-peso payments between accounts at participating financial institutions. It operates 24 hours a day, seven days a week.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+<nav class="toc" aria-label="Contents"><strong>Contents</strong><ol>
+<li><a href="#first-principles">First principles: transfers and clearing</a></li>
+<li><a href="#participants">Participants and operator</a></li>
+<li><a href="#timing">Customer credit and interbank settlement</a></li>
+<li><a href="#limits">Limits, access, and fees</a></li>
+<li><a href="#qr">QR payment access</a></li>
+<li><a href="#errors">Errors and recovery</a></li>
+<li><a href="#related-systems">Related payment systems</a></li>
+<li><a href="#see-also">See also</a></li>
+<li><a href="#references">References</a></li>
+</ol></nav>
+<h2 id="first-principles">1. First principles: transfers and clearing</h2>
+<p>A payment moves value from a payer to a payee. Clearing establishes the obligations between participating institutions; <a href="/writing/payments-glossary/#settlement">settlement</a> discharges those obligations. The National Retail Payment System (NRPS) provides the Philippine framework for interoperable retail payments.<span class="cite">[<a href="#ref2">2</a>]</span></p>
+<p>Within NRPS, an <em>automated clearing house</em> (ACH) is a multilateral agreement that governs clearing and settlement for a payment stream. It does not prescribe batch processing for every service. InstaPay and PESONet operate under that framework; the <a href="/reference/ach/">US ACH network</a> uses the same abbreviation in a different national system.<span class="cite">[<a href="#ref2">2</a>]</span><span class="cite">[<a href="#ref6">6</a>]</span></p>
+<h2 id="participants">2. Participants and operator</h2>
+<p>NRPS separates oversight, scheme governance, and technical operation. BSP oversees the framework. A payment system management body provides industry governance; ACH participants agree the rules for their payment stream. A clearing switch operator supplies the infrastructure that processes payment instructions. These roles distinguish the agreement from the service that carries its messages.<span class="cite">[<a href="#ref2">2</a>]</span></p>
+<p>BSP’s current designated-operators list names Payments Network of the Philippines, Inc. (PNPI) for InstaPay and PESONet. Its footnote records that the BancNet-PCHC merger took effect on June 1, 2026. Older documents may therefore name BancNet as InstaPay’s operator. BSP remains the listed operator of Peso RTGS (PhilPaSSplus).<span class="cite">[<a href="#ref3">3</a>]</span></p>
+<h2 id="timing">3. Customer credit and interbank settlement</h2>
+<p>InstaPay provides almost instant credit to the recipient, with finality. Participants prefund their net clearing obligations in demand deposit accounts at BSP. Settlement uses BSP’s peso settlement system; institutions without direct access can use a sponsoring member.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+<p>PhilPaSSplus, adopted in 2021, is BSP’s real-time gross settlement system. It settles individual obligations transaction by transaction and also settles net clearing results from retail systems, including InstaPay. Its published operating hours are 9:00 a.m. to 5:45 p.m., Monday to Friday, Philippine time.<span class="cite">[<a href="#ref4">4</a>]</span></p>
+<p>A retail system can submit a net clearing result to an RTGS system. That result combines obligations from multiple customer payments. The RTGS posting and the earlier credit to a recipient describe different events; the settlement of a net result does not make each underlying customer transfer a separate RTGS transaction.<span class="cite">[<a href="#ref4">4</a>]</span></p>
+<h2 id="limits">4. Limits, access, and fees</h2>
+<p>The published InstaPay limit is ₱50,000 per transaction. Participating banks and non-bank electronic money issuers provide access through their channels. An institution may impose daily limits. Sending fees vary by provider; recipients receive the full transfer amount without a receiving fee.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+<h2 id="qr">5. QR payment access</h2>
+<p>QR codes provide payment details through participating apps. BSP’s July 29, 2026 rebranding FAQ assigns the QR Ph brand to person-to-merchant payments and InstaPay QR to person-to-person payments. Both use the national QR Ph standard. The branding change leaves the technical standards, operating rules, and infrastructure unchanged.<span class="cite">[<a href="#ref5">5</a>]</span></p>
+<h2 id="errors">6. Errors and recovery</h2>
+<p>Incorrect recipient details should be reported promptly to the sending institution. Completed transfers have finality, so contacting the bank does not guarantee recovery. A complaint or request to recover funds is separate from the original payment’s completion.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+<h2 id="related-systems">7. Related payment systems</h2>
+<p>PESONet processes credit transfers in batches. BSP’s three-cycle arrangement adds settlement opportunities during the banking day; receiving institutions credit beneficiaries after receiving inward clearing advice. That batch schedule differs from InstaPay’s immediate customer credit.<span class="cite">[<a href="#ref6">6</a>]</span><span class="cite">[<a href="#ref1">1</a>]</span></p>
+<p>FedNow is a US instant payment service. It provides immediate access to funds for end users and processes individual interbank payments in near real time, around the clock.<span class="cite">[<a href="#ref7">7</a>]</span></p>
+<h2 id="see-also">8. See also</h2>
+<ul>
+<li><a href="/reference/ach/">ACH (United States)</a></li>
+<li><a href="/reference/online-payments/">Online Payments</a></li>
+<li><a href="/writing/us-and-philippine-payment-rails/">US and Philippine Payment Rails</a></li>
+<li><a href="/writing/instapay-is-not-ach/">InstaPay Is Not ACH</a></li>
+<li><a href="/writing/payments-glossary/">Payments Glossary</a></li>
+</ul>
+<h2 id="references">9. References</h2>
+<p>Sources checked September 9, 2026.</p>
+<ol>
+<li id="ref1">Bangko Sentral ng Pilipinas. <a href="https://www.bsp.gov.ph/PaymentAndSettlement/FAQ_Instapay.pdf">InstaPay FAQ</a>.</li>
+<li id="ref2">Bangko Sentral ng Pilipinas. <a href="https://www.bsp.gov.ph/Regulations/Issuances/2017/c980.pdf">Circular No. 980: National Retail Payment System framework (2017)</a>.</li>
+<li id="ref3">Bangko Sentral ng Pilipinas. <a href="https://www.bsp.gov.ph/PaymentAndSettlement/List_of_Operators_of_Designated_Payment_Systems.pdf">List of operators of designated payment systems</a>.</li>
+<li id="ref4">Bangko Sentral ng Pilipinas. <a href="https://www.bsp.gov.ph/Pages/PAYMENTS%20AND%20SETTLEMENTS/PhilPaSS/PhilPaSS-Overview.aspx">PhilPaSS overview</a>.</li>
+<li id="ref5">Bangko Sentral ng Pilipinas. <a href="https://www.bsp.gov.ph/Media_And_Research/Primers%20Faqs/FAQs-QR-Ph-Rebranding.pdf">QR Ph rebranding FAQs (July 29, 2026)</a>.</li>
+<li id="ref6">Bangko Sentral ng Pilipinas. <a href="https://www.bsp.gov.ph/PaymentAndSettlement/FAQs_3MBS_of_the_PESONet.pdf">PESONet three multilateral batch settlement cycles: FAQs</a>.</li>
+<li id="ref7">Federal Reserve Board. <a href="https://www.federalreserve.gov/paymentsystems/fednow-additional-questions-and-answers.htm">FedNow Service: Additional questions and answers</a>.</li>
+</ol>
+<footer><p><a href="#top">Back to top</a></p></footer>
+</main>
+  <button id="backToTop" class="back-to-top" aria-label="Back to top" title="Back to top">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M18 15l-6-6-6 6"/>
+    </svg>
+  </button>
+
+  <script>
+    const btt = document.getElementById('backToTop');
+    window.addEventListener('scroll', () => {
+      if (window.scrollY > 250) {
+        btt.classList.add('visible');
+      } else {
+        btt.classList.remove('visible');
+      }
+    }, { passive: true });
+    btt.addEventListener('click', () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  </script>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1185,4 +1185,16 @@
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
+  <url>
+    <loc>https://ngpestelos.com/reference/ach/</loc>
+    <lastmod>2026-09-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://ngpestelos.com/reference/instapay/</loc>
+    <lastmod>2026-09-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
 </urlset>

--- a/writing/instapay-is-not-ach/index.html
+++ b/writing/instapay-is-not-ach/index.html
@@ -96,6 +96,8 @@
 
 <p>GCash-to-GCash and Maya-to-Maya transfers are not split from interoperable InstaPay in BSP&#x27;s public series. They are later walks.</p>
 
+<p>Reference pages: <a href="/reference/instapay/">InstaPay (Philippines)</a> and <a href="/reference/ach/">ACH (United States)</a>.</p>
+
 <h2 id="sources">Sources</h2>
 
 <p>Same primaries as the <a href="https://ngpestelos.com/writing/us-and-philippine-payment-rails/">overview</a> and the <a href="https://ngpestelos.com/writing/payments-glossary/">glossary</a>. Not a first look.</p>

--- a/writing/payments-glossary/index.html
+++ b/writing/payments-glossary/index.html
@@ -260,6 +260,8 @@
 
 <p>Operator of a designated payment system. Needs prior BSP / Monetary Board authority.</p>
 
+<p>Reference pages: <a href="/reference/instapay/">InstaPay (Philippines)</a> and <a href="/reference/ach/">ACH (United States)</a>.</p>
+
 <h2 id="sources">Sources</h2>
 
 <ul>

--- a/writing/us-and-philippine-payment-rails/index.html
+++ b/writing/us-and-philippine-payment-rails/index.html
@@ -111,6 +111,8 @@
 
 <p>Transfers within the same wallet provider, such as GCash-to-GCash or Maya-to-Maya, are outside this comparison.</p>
 
+<p>Reference pages: <a href="/reference/instapay/">InstaPay (Philippines)</a> and <a href="/reference/ach/">ACH (United States)</a>.</p>
+
 <h2 id="sources">Sources</h2>
 
 <ul>


### PR DESCRIPTION
Add separate reference entries for InstaPay in the Philippines and the US Automated Clearing House network. Explain their participants, payment flows, settlement, timing, and limits using primary sources, including the different Philippine use of ACH.

Link both entries from the payment-rails article, InstaPay comparison, and payments glossary. Add reciprocal references, reference-index entries, and sitemap routes.

Validation: existing site tests, citation and internal-link checks, metadata/TOC checks, and local HTTP delivery.

Desktop/mobile screenshots could not run: macOS denied Chromium MachPortRendezvousServer registration in the sandbox (exit 133). No visual pass is claimed.
