### PR TITLE
Publish The Programmer Was Only Ever One Incarnation

### DIFF
--- a/scripts/writing-catalog.json
+++ b/scripts/writing-catalog.json
@@ -1,5 +1,12 @@
 [
   {
+    "slug": "the-programmer-was-only-ever-one-incarnation",
+    "title": "The Programmer Was Only Ever One Incarnation",
+    "date": "2026-09-10",
+    "bucket": "essays",
+    "pin": null
+  },
+  {
     "slug": "accepting-agent-written-code",
     "title": "What I Check Before Accepting Agent-Written Code",
     "date": "2026-09-08",

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -811,6 +811,11 @@
     <priority>0.5</priority>
   </url>
   <url>
+    <loc>https://ngpestelos.com/writing/the-programmer-was-only-ever-one-incarnation/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
     <loc>https://ngpestelos.com/writing/accepting-agent-written-code/</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>

--- a/writing/atom.xml
+++ b/writing/atom.xml
@@ -4,10 +4,17 @@
   <link rel="self" href="https://ngpestelos.com/writing/atom.xml"/>
   <link href="https://ngpestelos.com/writing/"/>
   <id>https://ngpestelos.com/writing/</id>
-  <updated>2026-09-08T04:16:09Z</updated>
+  <updated>2026-09-09T22:20:16Z</updated>
   <author>
     <name>Nestor G Pestelos Jr</name>
   </author>
+  <entry>
+    <id>https://ngpestelos.com/writing/the-programmer-was-only-ever-one-incarnation/</id>
+    <title>The Programmer Was Only Ever One Incarnation</title>
+    <summary>I want to keep discovering and solving problems with AI's help. Writing the syntax myself can become a smaller part of that work. The calling survives a change in how I practice it.</summary>
+    <updated>2026-09-10T00:00:00+08:00</updated>
+    <link href="https://ngpestelos.com/writing/the-programmer-was-only-ever-one-incarnation/"/>
+  </entry>
   <entry>
     <id>https://ngpestelos.com/writing/accepting-agent-written-code/</id>
     <title>What I Check Before Accepting Agent-Written Code</title>

--- a/writing/index.html
+++ b/writing/index.html
@@ -84,6 +84,7 @@
       <section class="bucket" id="essays">
         <h2>Essays</h2>
         <ul>
+          <li><a href="/writing/the-programmer-was-only-ever-one-incarnation/">The Programmer Was Only Ever One Incarnation</a> <time datetime="2026-09-10">10 Sep 2026</time></li>
           <li><a href="/writing/reading-aloud-is-pointing-and-calling-for-your-brain/">Reading Aloud Is Pointing and Calling for Your Brain</a> <time datetime="2026-09-06">6 Sep 2026</time></li>
           <li class="pin"><a href="/writing/five-checks-against-motivated-reasoning/">Five Checks Against Motivated Reasoning</a> <time datetime="2026-08-24">24 Aug 2026</time></li>
           <li class="pin"><a href="/writing/what-actually-buys-you-the-power-to-say-no/">What Actually Buys You the Power to Say No</a> <time datetime="2026-08-21">21 Aug 2026</time></li>

--- a/writing/the-programmer-was-only-ever-one-incarnation/index.html
+++ b/writing/the-programmer-was-only-ever-one-incarnation/index.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>The Programmer Was Only Ever One Incarnation — Nestor G Pestelos Jr</title>
+  <meta name="description" content="I want to keep discovering and solving problems with AI&#x27;s help. Writing the syntax myself can become a smaller part of that work. The calling survives a change in how I practice it.">
+  <meta property="og:title" content="The Programmer Was Only Ever One Incarnation">
+  <meta property="og:description" content="I want to keep discovering and solving problems with AI&#x27;s help. Writing the syntax myself can become a smaller part of that work. The calling survives a change in how I practice it.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://ngpestelos.com/writing/the-programmer-was-only-ever-one-incarnation/">
+  <link rel="canonical" href="https://ngpestelos.com/writing/the-programmer-was-only-ever-one-incarnation/">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=20260813f">
+  <link rel="icon" href="/favicon-192.png?v=20260813f" type="image/png" sizes="192x192">
+  <link rel="icon" href="/favicon-32.png?v=20260813f" type="image/png" sizes="32x32">
+  <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
+  <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="stylesheet" href="/style.css?v=20260903e">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TLBY8P4GG9');
+  </script>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"Article","headline":"The Programmer Was Only Ever One Incarnation","description":"I want to keep discovering and solving problems with AI's help. Writing the syntax myself can become a smaller part of that work. The calling survives a change in how I practice it.","url":"https://ngpestelos.com/writing/the-programmer-was-only-ever-one-incarnation/","author":{"@type":"Person","name":"Nestor G Pestelos Jr","url":"https://ngpestelos.com/"},"datePublished":"2026-09-10"}
+  </script>
+</head>
+<body>
+  <main class="article">
+    <p class="back" id="top"><a href="/">Nestor G Pestelos Jr</a> &middot; <a href="/writing/">Writing</a><span class="print"> &middot; <a href="#print" onclick="window.print();return false">Print</a></span></p>
+    <h1>The Programmer Was Only Ever One Incarnation</h1>
+<p class="byline">Published September 10, 2026</p>
+
+
+<div class="tldr"><span class="tldr-label">TL;DR</span><p>I want to keep discovering and solving problems with AI&#x27;s help. Writing the syntax myself can become a smaller part of that work. The calling survives a change in how I practice it.</p></div><hr>
+
+<p><a href="https://digitaleconomy.stanford.edu/news/canariesaug26/">Stanford&#x27;s Digital Economy Lab</a> updated its employment study in August. Employment among workers aged 22 to 25 in highly AI-exposed occupations was about 19 percent below the level implied by growth among their less-exposed peers. &quot;Experienced workers show no comparable gap.&quot; The shortfall appeared mainly in hiring young workers. This is not evidence that experienced programmers are being discarded, and the study does not establish how much AI caused the gap.</p>
+
+<p>I should have found that comforting when a founder passed on me for a role I wanted. The feedback was that my answers were too general and missed details other candidates identified. I had spent the week before the interview writing plans and adversarial reviews. I agreed with the criticism.</p>
+
+<p>I want to keep discovering and solving problems, now assisted by AI tooling. That means letting go of syntax: writing each line myself can become a smaller part of the work. The interview feedback remains relevant even when a tool can produce the code; the missing details still matter.</p>
+
+<p>In <em>The War of Art</em>, Steven Pressfield writes: &quot;The professional does not permit himself to become hidebound within one incarnation, however comfortable or successful.&quot; I can apply that permission to the way I solve problems. Programming gave that work a form I knew well. AI gives me a way to continue it with less of my effort spent expressing a solution in code.</p>
+
+<p><a href="https://tim.blog/2026/08/12/how-to-reinvent-yourself/">Steve Young told Tim Ferriss</a> that leaving his NFL role required mourning it and treating it as something he could visit rather than keep carrying. In the same episode, Matthew McConaughey describes refusing romantic comedies for about twenty months before different offers arrived. He stayed an actor but gave up the kind of acting that paid him. Their changes were larger than the one I want to make within software, where AI can help me keep solving problems.</p>
+
+<p>I run a small fleet of agents at home. This year, a formatting check blocked the job that syncs my notes across machines 51 times because it rejected trailing spaces. The fix exempted the automatic sync from that check. Solving that problem required deciding where the rule should apply. Typing the exemption was one part of the repair.</p>
+
+<p>Sources: Steven Pressfield, <em>The War of Art</em>, Book Two, “A Professional Reinvents Himself” (Rugged Land, 2002; <a href="https://stevenpressfield.com/books/the-war-of-art/">book page</a>). Research and interview sources are linked inline.</p>
+    <p class="to-top"><a href="#top">Back to top</a></p>
+    <footer class="meta">
+      <a href="/privacy.html">Privacy</a>
+    </footer>
+  </main>
+  <button id="backToTop" class="back-to-top" aria-label="Back to top" title="Back to top">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M18 15l-6-6-6 6"/>
+    </svg>
+  </button>
+
+  <script>
+    const btt = document.getElementById('backToTop');
+    window.addEventListener('scroll', () => {
+      if (window.scrollY > 250) {
+        btt.classList.add('visible');
+      } else {
+        btt.classList.remove('visible');
+      }
+    }, { passive: true });
+    btt.addEventListener('click', () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Publish “The Programmer Was Only Ever One Incarnation” at its approved writing permalink, preserving the staged body and citations. Add the unpinned essays entry and refresh the writing index, Atom feed, and sitemap.

Validation: all 36 existing site tests pass; rendered paragraphs and three source links match the staged essay.
