### PR TITLE
Show latest articles first on the Writing page

### DIFF
--- a/scripts/test_site_discoverability.py
+++ b/scripts/test_site_discoverability.py
@@ -150,7 +150,7 @@ class SiteDiscoverabilityTests(unittest.TestCase):
                 rendered = index.read_text(encoding="utf-8")
                 latest = re.search(r'<section id="latest">(.*?)</section>', rendered, re.S)
                 self.assertIsNotNone(latest, "index rebuild must generate Latest")
-                rows = re.findall(r"<li>(.*?)</li>", latest.group(1), re.S)
+                rows = re.findall(r"<li[^>]*>(.*?)</li>", latest.group(1), re.S)
                 expected = sorted(catalog, key=lambda item: item["date"], reverse=True)[:3]
                 self.assertEqual(len(rows), 3)
                 for row, item in zip(rows, expected):
@@ -161,12 +161,12 @@ class SiteDiscoverabilityTests(unittest.TestCase):
                     self.assertIn(dict(writing_catalog.BUCKETS)[item["bucket"]], row)
                 self.assertRegex(rendered, r'<h1>Writing</h1>\s*<section id="latest">')
                 self.assertLess(rendered.index('</section>', latest.start()), rendered.index('class="next-step"'))
-                topics = re.search(r'<nav aria-label="Browse by topic">(.*?)</nav>\s*<section id="writing">', rendered, re.S)
+                topics = re.search(r'<nav aria-label="Browse by topic"[^>]*>(.*?)</nav>\s*<section id="writing">', rendered, re.S)
                 self.assertIsNotNone(topics)
                 for bucket, label in writing_catalog.BUCKETS:
                     self.assertIn(f'<a href="#{bucket}">{label}</a>', topics.group(1))
                 self.assertEqual(rendered.count('id="latest"'), 1)
-                self.assertEqual(rendered.count('<nav aria-label="Browse by topic">'), 1)
+                self.assertEqual(rendered.count('<nav aria-label="Browse by topic"'), 1)
                 writing_catalog.apply_index_inner(root, catalog)
                 self.assertEqual(index.read_text(encoding="utf-8"), rendered)
                 if catalog is items:

--- a/scripts/test_site_discoverability.py
+++ b/scripts/test_site_discoverability.py
@@ -6,11 +6,15 @@ from __future__ import annotations
 import json
 import re
 import unittest
+from tempfile import TemporaryDirectory
+
 from html import unescape
 from html.parser import HTMLParser
 import xml.etree.ElementTree as ET
 from datetime import datetime, timedelta
 from pathlib import Path
+
+import writing_catalog
 
 SCRIPTS = Path(__file__).resolve().parent
 ROOT = SCRIPTS.parent
@@ -129,6 +133,44 @@ class SiteDiscoverabilityTests(unittest.TestCase):
         meat = systems.find("/writing/meat-proxy-problem/")
         source = systems.find("/writing/build-source-of-truth-before-index/")
         self.assertTrue(0 <= employee < meat < source)
+
+    def test_latest_regenerates_from_global_publication_dates(self):
+        original = INDEX.read_text(encoding="utf-8")
+        items = load_catalog()
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "writing").mkdir()
+            index = root / "writing" / "index.html"
+            index.write_text(original, encoding="utf-8")
+            # A catalog update must displace a Latest entry on the next rebuild.
+            updated = [dict(item) for item in items]
+            updated[-1]["date"] = "2099-01-01"
+            for catalog in (items, updated):
+                writing_catalog.apply_index_inner(root, catalog)
+                rendered = index.read_text(encoding="utf-8")
+                latest = re.search(r'<section id="latest">(.*?)</section>', rendered, re.S)
+                self.assertIsNotNone(latest, "index rebuild must generate Latest")
+                rows = re.findall(r"<li>(.*?)</li>", latest.group(1), re.S)
+                expected = sorted(catalog, key=lambda item: item["date"], reverse=True)[:3]
+                self.assertEqual(len(rows), 3)
+                for row, item in zip(rows, expected):
+                    self.assertIn(f'href="/writing/{item["slug"]}/"', row)
+                    self.assertIn(item["title"], unescape(row))
+                    self.assertIn(f'datetime="{item["date"]}"', row)
+                    self.assertIn(writing_catalog.display_date(item["date"]), row)
+                    self.assertIn(dict(writing_catalog.BUCKETS)[item["bucket"]], row)
+                self.assertRegex(rendered, r'<h1>Writing</h1>\s*<section id="latest">')
+                self.assertLess(rendered.index('</section>', latest.start()), rendered.index('class="next-step"'))
+                topics = re.search(r'<nav aria-label="Browse by topic">(.*?)</nav>\s*<section id="writing">', rendered, re.S)
+                self.assertIsNotNone(topics)
+                for bucket, label in writing_catalog.BUCKETS:
+                    self.assertIn(f'<a href="#{bucket}">{label}</a>', topics.group(1))
+                self.assertEqual(rendered.count('id="latest"'), 1)
+                self.assertEqual(rendered.count('<nav aria-label="Browse by topic">'), 1)
+                writing_catalog.apply_index_inner(root, catalog)
+                self.assertEqual(index.read_text(encoding="utf-8"), rendered)
+                if catalog is items:
+                    self.assertEqual(rendered, original, "checked-in index must match its generator")
 
     def test_homepage_pins_and_linters(self):
         html = HOME.read_text(encoding="utf-8")

--- a/scripts/test_writing_layout.py
+++ b/scripts/test_writing_layout.py
@@ -95,8 +95,20 @@ class WritingLayoutTests(unittest.TestCase):
             self.assertEqual(bucket["h2"], 1)
             self.assertTrue(bucket["ul_li_counts"])
             self.assertTrue(any(count > 0 for count in bucket["ul_li_counts"]))
+        latest = re.search(r'<section id="latest">.*?</section>', rendered, re.S)
+        self.assertIsNotNone(latest)
+        original_latest = re.search(
+            r'<section id="latest">.*?</section>', INDEX.read_text(encoding="utf-8"), re.S
+        ).group(0)
+        self.assertEqual(latest.group(0), original_latest)
+        self.assertIn('style="list-style: none; padding: 0;"', latest.group(0))
+        self.assertIn('display: block; color: var(--mute);', latest.group(0))
+        self.assertIn('style="margin-bottom: 2rem; line-height: 1.8;"', rendered)
+        latest_parser = WritingIndexParser()
+        latest_parser.feed(latest.group(0))
+        self.assertEqual(latest_parser.li_count, 3)
         self.assertEqual(
-            parser.li_count,
+            parser.li_count - latest_parser.li_count,
             sum(bucket["li_count"] for bucket in parser.buckets),
         )
         self.assertNotIn("pager", parser.classes)

--- a/scripts/writing_catalog.py
+++ b/scripts/writing_catalog.py
@@ -103,14 +103,33 @@ def replace_writing_inner(html_text: str, inner: str) -> str:
     return html_text[: start + len(open_tag)] + "\n" + inner + "    " + html_text[end:]
 
 
+def latest_html(items: list[dict]) -> str:
+    labels = dict(BUCKETS)
+    lines = ['      <section id="latest">', '        <h2>Latest</h2>', '        <ul>']
+    for item in sorted(items, key=lambda item: item["date"], reverse=True)[:3]:
+        title = html.escape(item["title"], quote=True)
+        lines.append(
+            f'          <li><a href="/writing/{item["slug"]}/">{title}</a>'
+            f' <time datetime="{item["date"]}">{display_date(item["date"])}</time>'
+            f'<small>{labels[item["bucket"]]}</small></li>'
+        )
+    lines.extend(['        </ul>', '      </section>'])
+    return "\n".join(lines)
+
+
 def apply_index_inner(root: Path | None = None, items: list[dict] | None = None) -> Path:
     base = root or ROOT
     path = base / "writing" / "index.html"
     catalog = items if items is not None else load_catalog()
-    path.write_text(
-        replace_writing_inner(path.read_text(encoding="utf-8"), index_inner_html(catalog)),
-        encoding="utf-8",
-    )
+    rendered = replace_writing_inner(path.read_text(encoding="utf-8"), index_inner_html(catalog))
+    # Replace only generated landing blocks; retain contact copy and archive chrome.
+    rendered = re.sub(r'\n      <section id="latest">.*?</section>', '', rendered, flags=re.S)
+    rendered = rendered.replace('<h1>Writing</h1>', '<h1>Writing</h1>\n' + latest_html(catalog), 1)
+    rendered = re.sub(r'    <nav aria-label="Browse by topic">.*?</nav>\n', '', rendered, flags=re.S)
+    links = ' · '.join(f'<a href="#{bucket}">{label}</a>' for bucket, label in BUCKETS)
+    topics = f'    <nav aria-label="Browse by topic">Browse by topic: {links}</nav>\n'
+    rendered = rendered.replace('    <section id="writing">', topics + '    <section id="writing">', 1)
+    path.write_text(rendered, encoding="utf-8")
     return path
 
 

--- a/scripts/writing_catalog.py
+++ b/scripts/writing_catalog.py
@@ -105,13 +105,17 @@ def replace_writing_inner(html_text: str, inner: str) -> str:
 
 def latest_html(items: list[dict]) -> str:
     labels = dict(BUCKETS)
-    lines = ['      <section id="latest">', '        <h2>Latest</h2>', '        <ul>']
+    lines = [
+        '      <section id="latest">',
+        '        <h2 style="font-size: 1.1rem; margin-bottom: 1rem;">Latest</h2>',
+        '        <ul style="list-style: none; padding: 0;">',
+    ]
     for item in sorted(items, key=lambda item: item["date"], reverse=True)[:3]:
         title = html.escape(item["title"], quote=True)
         lines.append(
-            f'          <li><a href="/writing/{item["slug"]}/">{title}</a>'
+            f'          <li style="padding: 0.5rem 0;"><a href="/writing/{item["slug"]}/">{title}</a>'
             f' <time datetime="{item["date"]}">{display_date(item["date"])}</time>'
-            f'<small>{labels[item["bucket"]]}</small></li>'
+            f'<small style="display: block; color: var(--mute); font-size: 0.85em;">{labels[item["bucket"]]}</small></li>'
         )
     lines.extend(['        </ul>', '      </section>'])
     return "\n".join(lines)
@@ -125,9 +129,9 @@ def apply_index_inner(root: Path | None = None, items: list[dict] | None = None)
     # Replace only generated landing blocks; retain contact copy and archive chrome.
     rendered = re.sub(r'\n      <section id="latest">.*?</section>', '', rendered, flags=re.S)
     rendered = rendered.replace('<h1>Writing</h1>', '<h1>Writing</h1>\n' + latest_html(catalog), 1)
-    rendered = re.sub(r'    <nav aria-label="Browse by topic">.*?</nav>\n', '', rendered, flags=re.S)
+    rendered = re.sub(r'    <nav aria-label="Browse by topic"[^>]*>.*?</nav>\n', '', rendered, flags=re.S)
     links = ' · '.join(f'<a href="#{bucket}">{label}</a>' for bucket, label in BUCKETS)
-    topics = f'    <nav aria-label="Browse by topic">Browse by topic: {links}</nav>\n'
+    topics = f'    <nav aria-label="Browse by topic" style="margin-bottom: 2rem; line-height: 1.8;">Browse by topic: {links}</nav>\n'
     rendered = rendered.replace('    <section id="writing">', topics + '    <section id="writing">', 1)
     path.write_text(rendered, encoding="utf-8")
     return path

--- a/writing/index.html
+++ b/writing/index.html
@@ -25,15 +25,31 @@
     gtag('js', new Date());
     gtag('config', 'G-TLBY8P4GG9');
   </script>
+  <style>
+    #latest h2 { font-size: 1.1rem; margin-bottom: 1rem; }
+    #latest ul { list-style: none; padding: 0; }
+    #latest li { padding: 0.5rem 0; }
+    #latest small { display: block; color: var(--mute); font-size: 0.85em; }
+    nav[aria-label="Browse by topic"] { margin-bottom: 2rem; line-height: 1.8; }
+  </style>
 </head>
 <body>
   <main>
     <header>
       <p class="back"><a href="/">← Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
       <h1>Writing</h1>
+      <section id="latest">
+        <h2>Latest</h2>
+        <ul>
+          <li><a href="/writing/the-programmer-was-only-ever-one-incarnation/">The Programmer Was Only Ever One Incarnation</a> <time datetime="2026-09-10">10 Sep 2026</time><small>Essays</small></li>
+          <li><a href="/writing/accepting-agent-written-code/">What I Check Before Accepting Agent-Written Code</a> <time datetime="2026-09-08">8 Sep 2026</time><small>Production systems and agents</small></li>
+          <li><a href="/writing/reading-aloud-is-pointing-and-calling-for-your-brain/">Reading Aloud Is Pointing and Calling for Your Brain</a> <time datetime="2026-09-06">6 Sep 2026</time><small>Essays</small></li>
+        </ul>
+      </section>
       <p class="next-step">To understand legacy <a href="https://rubyonrails.org/">Ruby on Rails</a> or wire agents into a real codebase, <a href="mailto:nestor@pestelos.net?subject=About%20the%20codebase%20(writing)&amp;body=What%20does%20the%20product%20do%2C%20and%20who%20uses%20it%3F%0A%0AWhat%20prompted%20you%20to%20look%20at%20this%20now%3F%0A%0AStack%20and%20versions%20%28language%2C%20framework%2C%20database%2C%20hosting%2C%20agents%20if%20any%29%3A%0A">write me</a> or <a href="https://calendly.com/ngpestelos/25min">book 25 minutes</a>.</p>
     </header>
 
+    <nav aria-label="Browse by topic">Browse by topic: <a href="#systems">Production systems and agents</a> · <a href="#payments">Payments</a> · <a href="#essays">Essays</a></nav>
     <section id="writing">
       <section class="bucket" id="systems">
         <h2>Production systems and agents</h2>

--- a/writing/index.html
+++ b/writing/index.html
@@ -25,13 +25,6 @@
     gtag('js', new Date());
     gtag('config', 'G-TLBY8P4GG9');
   </script>
-  <style>
-    #latest h2 { font-size: 1.1rem; margin-bottom: 1rem; }
-    #latest ul { list-style: none; padding: 0; }
-    #latest li { padding: 0.5rem 0; }
-    #latest small { display: block; color: var(--mute); font-size: 0.85em; }
-    nav[aria-label="Browse by topic"] { margin-bottom: 2rem; line-height: 1.8; }
-  </style>
 </head>
 <body>
   <main>
@@ -39,17 +32,17 @@
       <p class="back"><a href="/">← Nestor G Pestelos Jr</a><span class="print"> · <a href="#print" onclick="window.print();return false">Print</a></span></p>
       <h1>Writing</h1>
       <section id="latest">
-        <h2>Latest</h2>
-        <ul>
-          <li><a href="/writing/the-programmer-was-only-ever-one-incarnation/">The Programmer Was Only Ever One Incarnation</a> <time datetime="2026-09-10">10 Sep 2026</time><small>Essays</small></li>
-          <li><a href="/writing/accepting-agent-written-code/">What I Check Before Accepting Agent-Written Code</a> <time datetime="2026-09-08">8 Sep 2026</time><small>Production systems and agents</small></li>
-          <li><a href="/writing/reading-aloud-is-pointing-and-calling-for-your-brain/">Reading Aloud Is Pointing and Calling for Your Brain</a> <time datetime="2026-09-06">6 Sep 2026</time><small>Essays</small></li>
+        <h2 style="font-size: 1.1rem; margin-bottom: 1rem;">Latest</h2>
+        <ul style="list-style: none; padding: 0;">
+          <li style="padding: 0.5rem 0;"><a href="/writing/the-programmer-was-only-ever-one-incarnation/">The Programmer Was Only Ever One Incarnation</a> <time datetime="2026-09-10">10 Sep 2026</time><small style="display: block; color: var(--mute); font-size: 0.85em;">Essays</small></li>
+          <li style="padding: 0.5rem 0;"><a href="/writing/accepting-agent-written-code/">What I Check Before Accepting Agent-Written Code</a> <time datetime="2026-09-08">8 Sep 2026</time><small style="display: block; color: var(--mute); font-size: 0.85em;">Production systems and agents</small></li>
+          <li style="padding: 0.5rem 0;"><a href="/writing/reading-aloud-is-pointing-and-calling-for-your-brain/">Reading Aloud Is Pointing and Calling for Your Brain</a> <time datetime="2026-09-06">6 Sep 2026</time><small style="display: block; color: var(--mute); font-size: 0.85em;">Essays</small></li>
         </ul>
       </section>
       <p class="next-step">To understand legacy <a href="https://rubyonrails.org/">Ruby on Rails</a> or wire agents into a real codebase, <a href="mailto:nestor@pestelos.net?subject=About%20the%20codebase%20(writing)&amp;body=What%20does%20the%20product%20do%2C%20and%20who%20uses%20it%3F%0A%0AWhat%20prompted%20you%20to%20look%20at%20this%20now%3F%0A%0AStack%20and%20versions%20%28language%2C%20framework%2C%20database%2C%20hosting%2C%20agents%20if%20any%29%3A%0A">write me</a> or <a href="https://calendly.com/ngpestelos/25min">book 25 minutes</a>.</p>
     </header>
 
-    <nav aria-label="Browse by topic">Browse by topic: <a href="#systems">Production systems and agents</a> · <a href="#payments">Payments</a> · <a href="#essays">Essays</a></nav>
+    <nav aria-label="Browse by topic" style="margin-bottom: 2rem; line-height: 1.8;">Browse by topic: <a href="#systems">Production systems and agents</a> · <a href="#payments">Payments</a> · <a href="#essays">Essays</a></nav>
     <section id="writing">
       <section class="bucket" id="systems">
         <h2>Production systems and agents</h2>


### PR DESCRIPTION
The Writing page now puts the three newest published articles directly below its heading, before the contact pitch. Each entry shows its publication date and category; Browse by topic links lead to the existing category archive.

Latest regenerates from the same writing catalog on each index rebuild. Its scoped styles survive the existing layout rebuild. The archive, article metadata, feeds, homepage, and contact copy are unchanged.

Validation:
- All 37 site tests pass, including global date ordering, updated catalog regeneration, placement, topic links, idempotence, and layout roundtrip checks.
- Desktop screenshot inspected. At a 390px emulated mobile viewport, client width and scroll width both measure 375px: no horizontal overflow.
