### PR TITLE
Correct agentic loops and add supporting references

### DIFF
--- a/reference/agentic-loops-20260910/index.html
+++ b/reference/agentic-loops-20260910/index.html
@@ -1,0 +1,403 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Agentic Loops (Archived 20260910) · Reference · Nestor G Pestelos Jr</title>
+  <meta name="description" content="An agentic loop is an autonomous execution cycle that drives an AI agent toward a target goal through continuous observation, action, and verification.">
+  <meta property="og:title" content="Agentic Loops · Reference">
+  <meta property="og:description" content="Architecture, 4 leverage layers, autonomy tiers, exit gates, and failure modes for AI agent loops.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://ngpestelos.com/reference/agentic-loops-20260910/">
+  <link rel="canonical" href="https://ngpestelos.com/reference/agentic-loops-20260910/">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=20260813f">
+  <link rel="icon" href="/favicon-192.png?v=20260813f" type="image/png" sizes="192x192">
+  <link rel="icon" href="/favicon-32.png?v=20260813f" type="image/png" sizes="32x32">
+  <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
+  <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="stylesheet" href="/style.css?v=20260903e">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TLBY8P4GG9');
+  </script>
+  <script type="module">
+    import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
+    mermaid.initialize({
+      startOnLoad: true,
+      theme: 'base',
+      themeVariables: {
+        primaryColor: '#fffaf3',
+        primaryTextColor: '#1c1915',
+        primaryBorderColor: '#d8d2c6',
+        lineColor: '#5c564e',
+        secondaryColor: '#f4efe6',
+        tertiaryColor: '#fffaf3',
+        mainBkg: '#fffaf3',
+        nodeBorder: '#d8d2c6',
+        clusterBkg: '#fdfbf7',
+        clusterBorder: '#9a3412',
+        titleColor: '#9a3412',
+        edgeLabelBackground: '#f4efe6',
+        fontFamily: 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+        fontSize: '13px'
+      }
+    });
+  </script>
+  <style>
+    
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
+    body {
+      line-height: 1.6;
+    }
+    main {
+      max-width: 46rem;
+      margin: 0 auto;
+      padding: 1.4rem 1.4rem 4rem;
+    }
+    .back {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .back a { color: var(--link); text-decoration: none; }
+    .back a:hover { text-decoration: underline; }
+    .kicker {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.78rem;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--mute);
+      margin-bottom: 0.3rem;
+    }
+    h1 {
+      font-size: clamp(1.9rem, 5vw, 2.4rem);
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.4rem;
+      margin-bottom: 1rem;
+    }
+    .updated {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.82rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .lede { margin-bottom: 1.6rem; }
+    .lede strong:first-child { font-weight: 700; }
+    .toc {
+      background: var(--well);
+      border: 1px solid var(--line);
+      border-radius: 4px;
+      padding: 1rem 1.4rem;
+      margin-bottom: 2rem;
+      max-width: 24rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.92rem;
+    }
+    .toc .toc-title {
+      font-weight: 700;
+      margin-bottom: 0.5rem;
+      text-align: center;
+    }
+    .toc ol { padding-left: 1.3rem; }
+    .toc li { margin: 0.2rem 0; }
+    .toc a { color: var(--link); text-decoration: none; }
+    .toc a:hover { text-decoration: underline; }
+    h2 {
+      font-size: 1.5rem;
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.3rem;
+      margin: 2rem 0 0.9rem;
+    }
+    p { margin-bottom: 0.9rem; }
+    a { color: var(--link); }
+    a:visited { color: var(--link-visited); }
+    code {
+      font-family: "SF Mono", Consolas, Monaco, monospace;
+      font-size: 0.9em;
+      background: var(--well);
+      padding: 0.1em 0.35em;
+      border-radius: 3px;
+    }
+    .cite {
+      font-size: 0.75em;
+      vertical-align: super;
+      line-height: 0;
+      text-decoration: none;
+    }
+    .cite a { text-decoration: none; }
+    #see-also ul, #references ol {
+      padding-left: 1.5rem;
+    }
+    #see-also li, #references li { margin-bottom: 0.5rem; }
+    #references { font-size: 0.95rem; }
+    #references .backlink { margin-right: 0.3rem; }
+    .diagram-box {
+      background: var(--well);
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      padding: 1.2rem;
+      margin: 1.4rem 0;
+      text-align: center;
+    }
+    .diagram-box svg {
+      max-width: 100%;
+      height: auto;
+    }
+    .agent-diagram .diagram-scroll { overflow-x: auto; }
+    .agent-diagram pre.mermaid {
+      margin: 0;
+      background: transparent;
+      border: none;
+      padding: 0;
+      font-family: inherit;
+    }
+    .agent-diagram .mermaid svg { min-width: 600px; }
+    .agent-diagram figcaption {
+      margin-top: 1rem;
+      font-size: 0.85rem;
+      color: var(--mute);
+      text-align: left;
+    }
+    footer.meta {
+      margin-top: 3rem;
+      padding-top: 1.2rem;
+      border-top: 1px solid var(--line);
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+    }
+    footer.meta a { color: var(--link); }
+    @media print {
+      .back {font-family:"Segoe UI", Helvetica, Arial, sans-serif;display: none;}
+    }
+      .back-to-top {
+      position: fixed;
+      bottom: 1.5rem;
+      right: 1.5rem;
+      width: 2.6rem;
+      height: 2.6rem;
+      border-radius: 50%;
+      background: var(--bg);
+      color: var(--ink);
+      border: 1px solid var(--line);
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      opacity: 0;
+      visibility: hidden;
+      transform: translateY(8px);
+      transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease, background 0.15s ease, border-color 0.15s ease;
+      z-index: 100;
+    }
+    .back-to-top.visible {
+      opacity: 1;
+      visibility: visible;
+      transform: translateY(0);
+    }
+    .back-to-top:hover {
+      background: var(--well);
+      border-color: var(--link);
+      color: var(--link);
+    }
+    .back-to-top:focus-visible {
+      outline: 2px solid var(--link);
+      outline-offset: 2px;
+    }
+    @media print {
+      .back-to-top { display: none !important; }
+    }
+  </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Agentic Loops","description":"An agentic loop is an autonomous execution cycle that drives an AI agent toward a target goal through continuous observation, action, and verification.","url":"https://ngpestelos.com/reference/agentic-loops-20260910/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
+</head>
+<body class="reference">
+  <main id="top">
+    <p class="back"><a href="/reference/">← Reference</a> · <a href="/">Nestor G Pestelos Jr</a> · <a href="#" onclick="window.print(); return false;">Print this page</a></p>
+    <p class="kicker">Systems Architecture · Artificial Intelligence</p>
+    <h1>Agentic Loops</h1>
+    <p class="updated">Archived version captured 20260910. This page preserves superseded claims. <a href="/reference/agentic-loops/">Read the current entry</a>.</p>
+    <p class="updated">Reference entry · last updated 20260909</p>
+
+    <p class="lede">An <strong>agentic loop</strong> is an autonomous execution cycle that drives an artificial intelligence agent toward a specified objective through iterative observation, reasoning, tool execution, and verification.<span class="cite">[<a href="#ref1">1</a>]</span> Positioned as the fourth and outermost layer of modern AI systems, the loop orchestrates prompts, context pipelines, and runtime harnesses into a self-directed feedback cycle.<span class="cite">[<a href="#ref2">2</a>]</span></p>
+
+    <div class="diagram-box">
+      <svg viewBox="0 0 660 160" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Agentic Loop Feedback Cycle">
+        <!-- Goal -->
+        <rect x="10" y="55" width="95" height="50" rx="6" fill="#ffffff" stroke="#a2a9b1" stroke-width="1.5"/>
+        <text x="57" y="78" font-family="-apple-system, sans-serif" font-size="11" text-anchor="middle" fill="#202122">Goal / Task</text>
+        <text x="57" y="93" font-family="-apple-system, sans-serif" font-size="9" text-anchor="middle" fill="#54595d">Target Spec</text>
+
+        <path d="M 105 80 L 145 80" stroke="#54595d" stroke-width="1.5"/>
+
+        <!-- The Loop Circle -->
+        <rect x="145" y="15" width="370" height="130" rx="8" fill="#f8f9fa" stroke="#9a3412" stroke-width="1.5"/>
+        <text x="330" y="38" font-family="-apple-system, sans-serif" font-size="13" font-weight="bold" text-anchor="middle" fill="#9a3412">Autonomous Execution Loop</text>
+
+        <!-- Node 1: Observe -->
+        <rect x="160" y="55" width="75" height="35" rx="4" fill="#ffffff" stroke="#a2a9b1" stroke-width="1"/>
+        <text x="197" y="77" font-family="-apple-system, sans-serif" font-size="10" text-anchor="middle" fill="#202122">1. Observe</text>
+
+        <path d="M 235 72 L 255 72" stroke="#54595d" stroke-width="1.5"/>
+
+        <!-- Node 2: Reason -->
+        <rect x="255" y="55" width="75" height="35" rx="4" fill="#ffffff" stroke="#9a3412" stroke-width="1.2"/>
+        <text x="292" y="77" font-family="-apple-system, sans-serif" font-size="10" font-weight="bold" text-anchor="middle" fill="#9a3412">2. Reason</text>
+
+        <path d="M 330 72 L 350 72" stroke="#54595d" stroke-width="1.5"/>
+
+        <!-- Node 3: Act -->
+        <rect x="350" y="55" width="75" height="35" rx="4" fill="#ffffff" stroke="#a2a9b1" stroke-width="1"/>
+        <text x="387" y="77" font-family="-apple-system, sans-serif" font-size="10" text-anchor="middle" fill="#202122">3. Act</text>
+
+        <path d="M 425 72 L 445 72" stroke="#54595d" stroke-width="1.5"/>
+
+        <!-- Node 4: Verify -->
+        <rect x="445" y="55" width="60" height="35" rx="4" fill="#ffffff" stroke="#166534" stroke-width="1.2"/>
+        <text x="475" y="77" font-family="-apple-system, sans-serif" font-size="10" font-weight="bold" text-anchor="middle" fill="#166534">4. Verify</text>
+
+        <!-- Feedback arrow -->
+        <path d="M 475 90 L 475 115 L 197 115 L 197 90" fill="none" stroke="#166534" stroke-width="1.5" stroke-dasharray="3,3"/>
+        <text x="330" y="110" font-family="-apple-system, sans-serif" font-size="8" fill="#166534" text-anchor="middle">Feedback &amp; Error Trace (Next Move)</text>
+
+        <path d="M 515 80 L 555 80" stroke="#166534" stroke-width="1.5"/>
+
+        <!-- Done -->
+        <rect x="555" y="55" width="95" height="50" rx="6" fill="#dcfce7" stroke="#166534" stroke-width="1.5"/>
+        <text x="602" y="78" font-family="-apple-system, sans-serif" font-size="11" font-weight="bold" text-anchor="middle" fill="#166534">Exit Gate</text>
+        <text x="602" y="93" font-family="-apple-system, sans-serif" font-size="9" text-anchor="middle" fill="#166534">Tests Passed ✅</text>
+      </svg>
+    </div>
+
+    <figure class="diagram-box agent-diagram">
+      <div class="diagram-scroll" tabindex="0" role="region" aria-label="Agent architecture diagram; scroll horizontally on small screens">
+        <pre class="mermaid">
+flowchart LR
+    accTitle: Agent architecture and feedback loop
+    accDescr: The user sends a query to the agent and receives an answer. The agent sends actions to the environment and receives feedback. The agent contains reasoning through a large language model, with memory, tools, and planning as parallel supporting components.
+    U[User]
+    subgraph A[Agent]
+        direction TB
+        R["Reasoning&lt;br/&gt;Large Language Model"]
+        R --- M[Memory]
+        R --- T[Tools]
+        R --- P[Planning]
+    end
+    E[Environment]
+    U -->|Query| A
+    A -->|Answer| U
+    A -->|Action| E
+    E -->|Feedback| A
+        </pre>
+      </div>
+      <figcaption>Adapted from Maarten Grootendorst and Jay Alammar, <a href="https://learning.oreilly.com/library/view/an-illustrated-guide/9798341662681/ch01.html#ch01_large_language_models_1783538923685647"><cite>An Illustrated Guide to AI Agents</cite>, Chapter 1, “Introduction”</a> (O’Reilly Media, 2026).</figcaption>
+    </figure>
+
+    <nav class="toc" aria-label="Contents">
+      <p class="toc-title">Contents</p>
+      <ol>
+        <li><a href="#four-layers">The four nested leverage layers</a></li>
+        <li><a href="#loop-definition">The true loop criterion</a></li>
+        <li><a href="#four-conditions">The four-condition automation gate</a></li>
+        <li><a href="#autonomy-tiers">Taxonomy of agentic loop tiers</a></li>
+        <li><a href="#failure-modes">Failure modes and safety bounds</a></li>
+        <li><a href="#see-also">See also</a></li>
+        <li><a href="#references">References</a></li>
+      </ol>
+    </nav>
+
+    <h2 id="four-layers">The four nested leverage layers</h2>
+    <p>Modern agent engineering structures capabilities into four concentric layers:<span class="cite">[<a href="#ref2">2</a>]</span></p>
+    <ol>
+      <li><strong>Prompt engineering</strong>: Static text instructions formulated for model inference.</li>
+      <li><strong>Context engineering</strong>: Dynamic pipelines that select, compress, and isolate relevant tokens per turn.<span class="cite">[<a href="#ref3">3</a>]</span></li>
+      <li><strong>Harness engineering</strong>: Runtime software infrastructure managing tools, state persistence, error classification, and guardrails.<span class="cite">[<a href="#ref4">4</a>]</span></li>
+      <li><strong>Loop engineering</strong>: The autonomous control cycle driving the underlying three layers toward a goal without human intervention on every step.<span class="cite">[<a href="#ref1">1</a>]</span></li>
+    </ol>
+
+    <h2 id="loop-definition">The true loop criterion</h2>
+    <p>A repetitive script or naive retry loop is not an agentic loop. A system earns the designation of a loop only when output from turn \(N\) actively alters the prompt, strategy, or search parameters of turn \(N+1\).<span class="cite">[<a href="#ref1">1</a>]</span> If failures do not narrow the problem space or inject corrective evidence into working memory, the system executes blind iteration rather than intelligent convergence.</p>
+
+    <h2 id="four-conditions">The four-condition automation gate</h2>
+    <p>Building an autonomous loop introduces token costs and execution risks. System designers evaluate four prerequisites before automating a loop:<span class="cite">[<a href="#ref2">2</a>]</span></p>
+    <ul>
+      <li><strong>Frequent repetition</strong>: The task occurs at high enough volume (daily, weekly, or continuously) to justify development.</li>
+      <li><strong>Deterministic verification</strong>: A non-probabilistic check (such as unit test suites, compilers, or linters) must evaluate pass/fail state. Without programmatic verification, loops hallucinate in circles.</li>
+      <li><strong>Exploration token budget</strong>: A defined budget allocated for trial-and-error discovery.</li>
+      <li><strong>Actionable tooling</strong>: Direct access to filesystem, terminal, or API mutations to execute real changes.</li>
+    </ul>
+
+    <h2 id="autonomy-tiers">Taxonomy of agentic loop tiers</h2>
+    <p>Agentic loops operate across four distinct architectural levels:<span class="cite">[<a href="#ref5">5</a>]</span></p>
+    <ul>
+      <li><strong>Level 1: Interactive ReAct</strong>: Single-turn Thought-Action-Observation loops requiring explicit human sign-off on mutations.</li>
+      <li><strong>Level 2: Bounded goal loop</strong>: Autonomous task execution (such as test-driven refactoring) that iterates until predefined exit criteria are met.</li>
+      <li><strong>Level 3: Bilevel / dual-agent loop</strong>: An inner worker agent executes actions while an outer supervisor agent audits strategy and protocol compliance.</li>
+      <li><strong>Level 4: Self-optimizing loop</strong>: Continuous recursive improvement loops (such as hill climbing on test traces) that rewrite the agent's own prompts and tools over time.<span class="cite">[<a href="#ref6">6</a>]</span></li>
+    </ul>
+
+    <h2 id="failure-modes">Failure modes and safety bounds</h2>
+    <p>Autonomous loops require defensive engineering to avoid common systemic failures:<span class="cite">[<a href="#ref3">3</a>]</span></p>
+    <ul>
+      <li><strong>Runaway token loops</strong>: Failing to specify max-turn thresholds or hard budget caps causes infinite loops on unresolvable tasks.</li>
+      <li><strong>Local maxima stalling</strong>: When an agent repeatedly attempts the same invalid syntax fix, the harness must inject forced entropy (such as temperature adjustments or plan re-anchoring) to break the cycle.</li>
+      <li><strong>Epistemic drift</strong>: Multi-turn loops can drift from initial ground truth unless periodic re-anchoring to original requirements is enforced.</li>
+    </ul>
+
+    <h2 id="see-also">See also</h2>
+    <ul>
+      <li><a href="/reference/agent-harness/">Agent Harness</a></li>
+      <li><a href="/reference/agents/">Agents</a></li>
+      <li><a href="/reference/model-context-protocol/">Model Context Protocol</a></li>
+      <li><a href="/reference/fail-closed/">Fail-closed</a></li>
+      <li><a href="/reference/plan-approve-execute/">Plan-Approve-Execute</a></li>
+      <li><a href="/reference/ooda-loop/">OODA Loop</a></li>
+      <li><a href="/reference/acceleration-whiplash/">Acceleration whiplash</a></li>
+      <li><a href="/eli5/agentic-loops/">Agentic Loops (ELI5 explainer)</a></li>
+    </ul>
+
+    <h2 id="references">References</h2>
+    <ol>
+      <li id="ref1"><a class="backlink" href="#loop-definition">↑</a> Osmani, Addy. "Loop Harness Factory: The Three-Layer Agentic Engineering Stack." Technical Notes, 2026.</li>
+      <li id="ref2"><a class="backlink" href="#four-layers">↑</a> Weng, Lilian. "LLM Powered Autonomous Agents." <em>lilianweng.github.io</em>, 2023.</li>
+      <li id="ref3"><a class="backlink" href="#four-layers">↑</a> Mitra, Sampriti. <em>System Design for the LLM Era: Patterns and Principles for Production-Grade AI Architecture</em>. Packt Publishing, 2026. Ch. 2: "Core Architectural Patterns for LLM System Design."</li>
+      <li id="ref4"><a class="backlink" href="#four-layers">↑</a> Trivedy, Vivek. "The Anatomy of an Agent Harness." LangChain Engineering Blog, March 2026.</li>
+      <li id="ref5"><a class="backlink" href="#autonomy-tiers">↑</a> Anthropic. "Building Effective Agents: Workflow and Autonomous Patterns." Research Report, 2024.</li>
+      <li id="ref6"><a class="backlink" href="#autonomy-tiers">↑</a> Shinn, N., et al. "Reflexion: Language Agents with Verbal Reinforcement Learning." <em>NeurIPS</em>, 2023.</li>
+    </ol>
+
+    <footer class="meta">
+      <p><a href="#top">Back to top</a></p>
+    </footer>
+  </main>
+  <button id="backToTop" class="back-to-top" aria-label="Back to top" title="Back to top">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M18 15l-6-6-6 6"/>
+    </svg>
+  </button>
+
+  <script>
+    const btt = document.getElementById('backToTop');
+    window.addEventListener('scroll', () => {
+      if (window.scrollY > 250) {
+        btt.classList.add('visible');
+      } else {
+        btt.classList.remove('visible');
+      }
+    }, { passive: true });
+    btt.addEventListener('click', () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  </script>
+</body>
+</html>

--- a/reference/agentic-loops/index.html
+++ b/reference/agentic-loops/index.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Agentic Loops · Reference · Nestor G Pestelos Jr</title>
-  <meta name="description" content="An agentic loop is an autonomous execution cycle that drives an AI agent toward a target goal through continuous observation, action, and verification.">
+  <meta name="description" content="Feedback-driven action selection, architecture patterns, verification, and stopping conditions for AI agents.">
   <meta property="og:title" content="Agentic Loops · Reference">
-  <meta property="og:description" content="Architecture, 4 leverage layers, autonomy tiers, exit gates, and failure modes for AI agent loops.">
+  <meta property="og:description" content="Feedback-driven action selection, architecture patterns, verification, and stopping conditions for AI agents.">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://ngpestelos.com/reference/agentic-loops/">
   <link rel="canonical" href="https://ngpestelos.com/reference/agentic-loops/">
@@ -23,29 +23,6 @@
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
     gtag('config', 'G-TLBY8P4GG9');
-  </script>
-  <script type="module">
-    import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      themeVariables: {
-        primaryColor: '#fffaf3',
-        primaryTextColor: '#1c1915',
-        primaryBorderColor: '#d8d2c6',
-        lineColor: '#5c564e',
-        secondaryColor: '#f4efe6',
-        tertiaryColor: '#fffaf3',
-        mainBkg: '#fffaf3',
-        nodeBorder: '#d8d2c6',
-        clusterBkg: '#fdfbf7',
-        clusterBorder: '#9a3412',
-        titleColor: '#9a3412',
-        edgeLabelBackground: '#f4efe6',
-        fontFamily: 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
-        fontSize: '13px'
-      }
-    });
   </script>
   <style>
     
@@ -147,25 +124,8 @@
       margin: 1.4rem 0;
       text-align: center;
     }
-    .diagram-box svg {
-      max-width: 100%;
-      height: auto;
-    }
-    .agent-diagram .diagram-scroll { overflow-x: auto; }
-    .agent-diagram pre.mermaid {
-      margin: 0;
-      background: transparent;
-      border: none;
-      padding: 0;
-      font-family: inherit;
-    }
-    .agent-diagram .mermaid svg { min-width: 600px; }
-    .agent-diagram figcaption {
-      margin-top: 1rem;
-      font-size: 0.85rem;
-      color: var(--mute);
-      text-align: left;
-    }
+    .diagram-box figcaption { margin-top: 1rem; color: var(--mute); font-size: 0.85rem; }
+    .loop-flow { font-family: "Segoe UI", Helvetica, Arial, sans-serif; line-height: 1.8; }
     footer.meta {
       margin-top: 3rem;
       padding-top: 1.2rem;
@@ -218,7 +178,7 @@
     }
   </style>
   <script type="application/ld+json">
-{"@context":"https://schema.org","@type":"DefinedTerm","name":"Agentic Loops","description":"An agentic loop is an autonomous execution cycle that drives an AI agent toward a target goal through continuous observation, action, and verification.","url":"https://ngpestelos.com/reference/agentic-loops/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Agentic Loops","description":"Feedback-driven action selection, architecture patterns, verification, and stopping conditions for AI agents.","url":"https://ngpestelos.com/reference/agentic-loops/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
   </script>
 </head>
 <body class="reference">
@@ -226,155 +186,43 @@
     <p class="back"><a href="/reference/">← Reference</a> · <a href="/">Nestor G Pestelos Jr</a> · <a href="#" onclick="window.print(); return false;">Print this page</a></p>
     <p class="kicker">Systems Architecture · Artificial Intelligence</p>
     <h1>Agentic Loops</h1>
-    <p class="updated">Reference entry · last updated 20260909</p>
+    <p class="updated">Reference entry · last updated 20260910</p>
 
-    <p class="lede">An <strong>agentic loop</strong> is an autonomous execution cycle that drives an artificial intelligence agent toward a specified objective through iterative observation, reasoning, tool execution, and verification.<span class="cite">[<a href="#ref1">1</a>]</span> Positioned as the fourth and outermost layer of modern AI systems, the loop orchestrates prompts, context pipelines, and runtime harnesses into a self-directed feedback cycle.<span class="cite">[<a href="#ref2">2</a>]</span></p>
+<p class="lede">An <strong>agentic loop</strong> is a repeated execution cycle in which an <a href="/reference/agents/">AI agent</a> uses observations from its environment to choose subsequent actions toward a task.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+<p class="updated"><a href="/reference/agentic-loops-20260910/">Previous version, captured 20260910</a></p>
+<nav class="toc" aria-label="Contents"><p class="toc-title">Contents</p><ol><li><a href="#first-principles">First principles and definitions</a></li><li><a href="#worked-example">Worked example</a></li><li><a href="#architecture-patterns">Architecture patterns</a></li><li><a href="#design-considerations">Design considerations</a></li><li><a href="#failure-modes">Failure modes and stopping</a></li><li><a href="#see-also">See also</a></li><li><a href="#references">References</a></li></ol></nav>
 
-    <div class="diagram-box">
-      <svg viewBox="0 0 660 160" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Agentic Loop Feedback Cycle">
-        <!-- Goal -->
-        <rect x="10" y="55" width="95" height="50" rx="6" fill="#ffffff" stroke="#a2a9b1" stroke-width="1.5"/>
-        <text x="57" y="78" font-family="-apple-system, sans-serif" font-size="11" text-anchor="middle" fill="#202122">Goal / Task</text>
-        <text x="57" y="93" font-family="-apple-system, sans-serif" font-size="9" text-anchor="middle" fill="#54595d">Target Spec</text>
-
-        <path d="M 105 80 L 145 80" stroke="#54595d" stroke-width="1.5"/>
-
-        <!-- The Loop Circle -->
-        <rect x="145" y="15" width="370" height="130" rx="8" fill="#f8f9fa" stroke="#9a3412" stroke-width="1.5"/>
-        <text x="330" y="38" font-family="-apple-system, sans-serif" font-size="13" font-weight="bold" text-anchor="middle" fill="#9a3412">Autonomous Execution Loop</text>
-
-        <!-- Node 1: Observe -->
-        <rect x="160" y="55" width="75" height="35" rx="4" fill="#ffffff" stroke="#a2a9b1" stroke-width="1"/>
-        <text x="197" y="77" font-family="-apple-system, sans-serif" font-size="10" text-anchor="middle" fill="#202122">1. Observe</text>
-
-        <path d="M 235 72 L 255 72" stroke="#54595d" stroke-width="1.5"/>
-
-        <!-- Node 2: Reason -->
-        <rect x="255" y="55" width="75" height="35" rx="4" fill="#ffffff" stroke="#9a3412" stroke-width="1.2"/>
-        <text x="292" y="77" font-family="-apple-system, sans-serif" font-size="10" font-weight="bold" text-anchor="middle" fill="#9a3412">2. Reason</text>
-
-        <path d="M 330 72 L 350 72" stroke="#54595d" stroke-width="1.5"/>
-
-        <!-- Node 3: Act -->
-        <rect x="350" y="55" width="75" height="35" rx="4" fill="#ffffff" stroke="#a2a9b1" stroke-width="1"/>
-        <text x="387" y="77" font-family="-apple-system, sans-serif" font-size="10" text-anchor="middle" fill="#202122">3. Act</text>
-
-        <path d="M 425 72 L 445 72" stroke="#54595d" stroke-width="1.5"/>
-
-        <!-- Node 4: Verify -->
-        <rect x="445" y="55" width="60" height="35" rx="4" fill="#ffffff" stroke="#166534" stroke-width="1.2"/>
-        <text x="475" y="77" font-family="-apple-system, sans-serif" font-size="10" font-weight="bold" text-anchor="middle" fill="#166534">4. Verify</text>
-
-        <!-- Feedback arrow -->
-        <path d="M 475 90 L 475 115 L 197 115 L 197 90" fill="none" stroke="#166534" stroke-width="1.5" stroke-dasharray="3,3"/>
-        <text x="330" y="110" font-family="-apple-system, sans-serif" font-size="8" fill="#166534" text-anchor="middle">Feedback &amp; Error Trace (Next Move)</text>
-
-        <path d="M 515 80 L 555 80" stroke="#166534" stroke-width="1.5"/>
-
-        <!-- Done -->
-        <rect x="555" y="55" width="95" height="50" rx="6" fill="#dcfce7" stroke="#166534" stroke-width="1.5"/>
-        <text x="602" y="78" font-family="-apple-system, sans-serif" font-size="11" font-weight="bold" text-anchor="middle" fill="#166534">Exit Gate</text>
-        <text x="602" y="93" font-family="-apple-system, sans-serif" font-size="9" text-anchor="middle" fill="#166534">Tests Passed ✅</text>
-      </svg>
-    </div>
-
-    <figure class="diagram-box agent-diagram">
-      <div class="diagram-scroll" tabindex="0" role="region" aria-label="Agent architecture diagram; scroll horizontally on small screens">
-        <pre class="mermaid">
-flowchart LR
-    accTitle: Agent architecture and feedback loop
-    accDescr: The user sends a query to the agent and receives an answer. The agent sends actions to the environment and receives feedback. The agent contains reasoning through a large language model, with memory, tools, and planning as parallel supporting components.
-    U[User]
-    subgraph A[Agent]
-        direction TB
-        R["Reasoning&lt;br/&gt;Large Language Model"]
-        R --- M[Memory]
-        R --- T[Tools]
-        R --- P[Planning]
-    end
-    E[Environment]
-    U -->|Query| A
-    A -->|Answer| U
-    A -->|Action| E
-    E -->|Feedback| A
-        </pre>
-      </div>
-      <figcaption>Adapted from Maarten Grootendorst and Jay Alammar, <a href="https://learning.oreilly.com/library/view/an-illustrated-guide/9798341662681/ch01.html#ch01_large_language_models_1783538923685647"><cite>An Illustrated Guide to AI Agents</cite>, Chapter 1, “Introduction”</a> (O’Reilly Media, 2026).</figcaption>
-    </figure>
-
-    <nav class="toc" aria-label="Contents">
-      <p class="toc-title">Contents</p>
-      <ol>
-        <li><a href="#four-layers">The four nested leverage layers</a></li>
-        <li><a href="#loop-definition">The true loop criterion</a></li>
-        <li><a href="#four-conditions">The four-condition automation gate</a></li>
-        <li><a href="#autonomy-tiers">Taxonomy of agentic loop tiers</a></li>
-        <li><a href="#failure-modes">Failure modes and safety bounds</a></li>
-        <li><a href="#see-also">See also</a></li>
-        <li><a href="#references">References</a></li>
-      </ol>
-    </nav>
-
-    <h2 id="four-layers">The four nested leverage layers</h2>
-    <p>Modern agent engineering structures capabilities into four concentric layers:<span class="cite">[<a href="#ref2">2</a>]</span></p>
-    <ol>
-      <li><strong>Prompt engineering</strong>: Static text instructions formulated for model inference.</li>
-      <li><strong>Context engineering</strong>: Dynamic pipelines that select, compress, and isolate relevant tokens per turn.<span class="cite">[<a href="#ref3">3</a>]</span></li>
-      <li><strong>Harness engineering</strong>: Runtime software infrastructure managing tools, state persistence, error classification, and guardrails.<span class="cite">[<a href="#ref4">4</a>]</span></li>
-      <li><strong>Loop engineering</strong>: The autonomous control cycle driving the underlying three layers toward a goal without human intervention on every step.<span class="cite">[<a href="#ref1">1</a>]</span></li>
-    </ol>
-
-    <h2 id="loop-definition">The true loop criterion</h2>
-    <p>A repetitive script or naive retry loop is not an agentic loop. A system earns the designation of a loop only when output from turn \(N\) actively alters the prompt, strategy, or search parameters of turn \(N+1\).<span class="cite">[<a href="#ref1">1</a>]</span> If failures do not narrow the problem space or inject corrective evidence into working memory, the system executes blind iteration rather than intelligent convergence.</p>
-
-    <h2 id="four-conditions">The four-condition automation gate</h2>
-    <p>Building an autonomous loop introduces token costs and execution risks. System designers evaluate four prerequisites before automating a loop:<span class="cite">[<a href="#ref2">2</a>]</span></p>
-    <ul>
-      <li><strong>Frequent repetition</strong>: The task occurs at high enough volume (daily, weekly, or continuously) to justify development.</li>
-      <li><strong>Deterministic verification</strong>: A non-probabilistic check (such as unit test suites, compilers, or linters) must evaluate pass/fail state. Without programmatic verification, loops hallucinate in circles.</li>
-      <li><strong>Exploration token budget</strong>: A defined budget allocated for trial-and-error discovery.</li>
-      <li><strong>Actionable tooling</strong>: Direct access to filesystem, terminal, or API mutations to execute real changes.</li>
-    </ul>
-
-    <h2 id="autonomy-tiers">Taxonomy of agentic loop tiers</h2>
-    <p>Agentic loops operate across four distinct architectural levels:<span class="cite">[<a href="#ref5">5</a>]</span></p>
-    <ul>
-      <li><strong>Level 1: Interactive ReAct</strong>: Single-turn Thought-Action-Observation loops requiring explicit human sign-off on mutations.</li>
-      <li><strong>Level 2: Bounded goal loop</strong>: Autonomous task execution (such as test-driven refactoring) that iterates until predefined exit criteria are met.</li>
-      <li><strong>Level 3: Bilevel / dual-agent loop</strong>: An inner worker agent executes actions while an outer supervisor agent audits strategy and protocol compliance.</li>
-      <li><strong>Level 4: Self-optimizing loop</strong>: Continuous recursive improvement loops (such as hill climbing on test traces) that rewrite the agent's own prompts and tools over time.<span class="cite">[<a href="#ref6">6</a>]</span></li>
-    </ul>
-
-    <h2 id="failure-modes">Failure modes and safety bounds</h2>
-    <p>Autonomous loops require defensive engineering to avoid common systemic failures:<span class="cite">[<a href="#ref3">3</a>]</span></p>
-    <ul>
-      <li><strong>Runaway token loops</strong>: Failing to specify max-turn thresholds or hard budget caps causes infinite loops on unresolvable tasks.</li>
-      <li><strong>Local maxima stalling</strong>: When an agent repeatedly attempts the same invalid syntax fix, the harness must inject forced entropy (such as temperature adjustments or plan re-anchoring) to break the cycle.</li>
-      <li><strong>Epistemic drift</strong>: Multi-turn loops can drift from initial ground truth unless periodic re-anchoring to original requirements is enforced.</li>
-    </ul>
-
-    <h2 id="see-also">See also</h2>
-    <ul>
-      <li><a href="/reference/agent-harness/">Agent Harness</a></li>
-      <li><a href="/reference/agents/">Agents</a></li>
-      <li><a href="/reference/model-context-protocol/">Model Context Protocol</a></li>
-      <li><a href="/reference/fail-closed/">Fail-closed</a></li>
-      <li><a href="/reference/plan-approve-execute/">Plan-Approve-Execute</a></li>
-      <li><a href="/reference/ooda-loop/">OODA Loop</a></li>
-      <li><a href="/reference/acceleration-whiplash/">Acceleration whiplash</a></li>
-      <li><a href="/eli5/agentic-loops/">Agentic Loops (ELI5 explainer)</a></li>
-    </ul>
-
-    <h2 id="references">References</h2>
-    <ol>
-      <li id="ref1"><a class="backlink" href="#loop-definition">↑</a> Osmani, Addy. "Loop Harness Factory: The Three-Layer Agentic Engineering Stack." Technical Notes, 2026.</li>
-      <li id="ref2"><a class="backlink" href="#four-layers">↑</a> Weng, Lilian. "LLM Powered Autonomous Agents." <em>lilianweng.github.io</em>, 2023.</li>
-      <li id="ref3"><a class="backlink" href="#four-layers">↑</a> Mitra, Sampriti. <em>System Design for the LLM Era: Patterns and Principles for Production-Grade AI Architecture</em>. Packt Publishing, 2026. Ch. 2: "Core Architectural Patterns for LLM System Design."</li>
-      <li id="ref4"><a class="backlink" href="#four-layers">↑</a> Trivedy, Vivek. "The Anatomy of an Agent Harness." LangChain Engineering Blog, March 2026.</li>
-      <li id="ref5"><a class="backlink" href="#autonomy-tiers">↑</a> Anthropic. "Building Effective Agents: Workflow and Autonomous Patterns." Research Report, 2024.</li>
-      <li id="ref6"><a class="backlink" href="#autonomy-tiers">↑</a> Shinn, N., et al. "Reflexion: Language Agents with Verbal Reinforcement Learning." <em>NeurIPS</em>, 2023.</li>
-    </ol>
-
+<h2 id="first-principles">First principles and definitions</h2>
+<p>In Anthropic’s distinction, workflows follow predefined code paths; agents dynamically direct their tool use. A workflow can contain a retry loop without delegating action selection to a model.<span class="cite">[<a href="#ref1">1</a>]</span> Feedback can change the next action, but does not guarantee progress or a correct result.</p>
+<p>The <a href="/reference/agent-harness/">agent harness</a> executes tool calls and manages the surrounding runtime. Trivedy includes orchestration logic within the harness.<span class="cite">[<a href="#ref2">2</a>]</span> <a href="/reference/prompt-engineering/">Prompt engineering</a> shapes instructions; <a href="/reference/context-engineering/">context engineering</a> determines the information available during execution.</p>
+<figure class="diagram-box">
+<div class="loop-flow" role="img" aria-label="Observe, choose an action, execute an allowed tool, inspect the result, then repeat or stop. Stop outcomes include completion, exhausted budget or time, cancellation, unrecoverable failure, or human escalation.">
+<p>Task and current observations</p><p>↓</p><p>Model chooses an action</p><p>↓</p><p>Harness executes an allowed tool</p><p>↓</p><p>Inspect result and stopping conditions</p><p>↺ Continue with new observations</p><p>or ↓ Stop</p><p>Completion · Budget or time exhausted · Cancellation<br>Unrecoverable failure · Human escalation</p>
+</div><figcaption>Illustrative control flow. The host can interrupt execution independently of the model.</figcaption></figure>
+<h2 id="worked-example">Worked example</h2>
+<p>This illustrative research task uses read-only tools: find the publication year of a named paper and return its source.</p>
+<ol><li>The agent searches the title and receives several candidate records.</li><li>It opens the matching publisher record to check the title and year.</li><li>If the record describes a different edition, that observation changes its next search.</li><li>It returns the verified year and citation, or reports the unresolved question when its search limit is reached.</li></ol>
+<p>The changed query demonstrates feedback-driven action selection. The example does not require a filesystem write or another external mutation.</p>
+<h2 id="architecture-patterns">Architecture patterns</h2>
+<p>These patterns describe different responsibilities, not ranked autonomy levels.</p>
+<ul><li><a href="/reference/react/">ReAct</a> interleaves reasoning and actions within a task. Human approval is a separate deployment policy.<span class="cite">[<a href="#ref3">3</a>]</span></li>
+<li><a href="/reference/reflexion/">Reflexion</a> adds verbal reflection retained in <a href="/reference/agents/#core-subsystems">episodic memory</a> for later attempts. Its mechanism does not rewrite tools or update model weights.<span class="cite">[<a href="#ref4">4</a>]</span></li>
+<li>An <a href="/reference/agents/#multi-agent">orchestrator</a> can assign subtasks to workers and combine their results. An evaluator-optimizer workflow instead revises an output using evaluator feedback. Anthropic describes both patterns separately.<span class="cite">[<a href="#ref1">1</a>]</span></li></ul>
+<p>Weng describes planning, memory, and tool use as components of an LLM-powered agent.<span class="cite">[<a href="#ref5">5</a>]</span></p>
+<h2 id="design-considerations">Design considerations</h2>
+<p>Anthropic recommends starting with the simplest effective system and weighing added cost and latency against performance.<span class="cite">[<a href="#ref1">1</a>]</span> Task frequency affects that tradeoff; it is not a definition of an agentic loop.</p>
+<ul><li><strong>Feedback:</strong> Tests, tool results, human judgments, or model evaluations can guide another attempt. <a href="/reference/llm-evaluations/">Evaluation</a> must match the task; a passing check covers only what it measures.</li>
+<li><strong>Tools:</strong> Available operations can be read-only. Mutation permissions should match the task and be enforced by the host.</li>
+<li><strong>Bounds:</strong> Set limits on turns, time, and expenditure, with a defined outcome when a limit is reached.</li></ul>
+<p>The following stopping and recovery rules are illustrative engineering policies, not requirements of ReAct or Reflexion.</p>
+<h2 id="failure-modes">Failure modes and stopping</h2>
+<ul><li>Repeated failure: inspect the error, revise the plan or inputs, and cap retries. Escalate or stop when the failure remains unresolved.</li>
+<li>Lost task context: retain the goal and relevant evidence within the available <a href="/reference/context-window/">context window</a>. Record unresolved assumptions explicitly.</li>
+<li>Ambiguous tool outcomes: check whether a mutation took effect before retrying it, to avoid duplicate side effects.<span class="cite">[<a href="#ref6">6</a>]</span></li>
+<li>Untrusted instructions: treat retrieved content as evidence. <a href="/reference/prompt-injection/">Prompt injection</a> defenses and permission checks belong in the surrounding system; a prompt alone is not containment.</li></ul>
+<p>A <a href="/reference/fail-closed/">fail-closed</a> policy can stop restricted actions when authorization cannot be established. Cancellation, hard limits, and tool permissions should remain enforceable even when the model proposes continuing.</p>
+<h2 id="see-also">See also</h2><ul><li><a href="/reference/react/">ReAct (AI Agents)</a></li><li><a href="/reference/reflexion/">Reflexion (AI Agents)</a></li><li><a href="/reference/agent-harness/">Agent Harness</a></li><li><a href="/reference/agents/">Agents</a></li><li><a href="/reference/plan-approve-execute/">Plan-Approve-Execute</a></li><li><a href="/reference/ooda-loop/">OODA Loop</a></li></ul>
+<h2 id="references">References</h2><ol><li id="ref1">Anthropic. <a href="https://www.anthropic.com/engineering/building-effective-agents">“Building effective agents.”</a> 2024.</li><li id="ref2">Trivedy, Vivek. <a href="https://www.langchain.com/blog/the-anatomy-of-an-agent-harness">“The Anatomy of an Agent Harness.”</a> LangChain, 2026.</li><li id="ref3">Yao, Shunyu, et al. <a href="https://arxiv.org/abs/2210.03629">“ReAct: Synergizing Reasoning and Acting in Language Models.”</a> ICLR, 2023. <a href="https://react-lm.github.io/">Author project page</a>.</li><li id="ref4">Shinn, Noah, et al. <a href="https://arxiv.org/abs/2303.11366">“Reflexion: Language Agents with Verbal Reinforcement Learning.”</a> NeurIPS, 2023. <a href="https://arxiv.org/html/2303.11366v4">Full text</a>.</li><li id="ref5">Weng, Lilian. <a href="https://lilianweng.github.io/posts/2023-06-23-agent/">“LLM Powered Autonomous Agents.”</a> 2023.</li><li id="ref6">Amazon Web Services. <a href="https://aws.amazon.com/builders-library/making-retries-safe-with-idempotent-APIs/">“Making retries safe with idempotent APIs.”</a> Amazon Builders’ Library.</li></ol>
     <footer class="meta">
       <p><a href="#top">Back to top</a></p>
     </footer>

--- a/reference/index.html
+++ b/reference/index.html
@@ -385,8 +385,10 @@
       <div class="letter-group" id="R">
         <h2 class="letter-heading">R</h2>
         <ul>
+        <li><a href="/reference/react/">ReAct (AI Agents)</a></li>
         <li><a href="/reference/reasoning/">Reasoning in Language Models</a></li>
         <li><a href="/reference/recursion/">Recursion</a></li>
+        <li><a href="/reference/reflexion/">Reflexion (AI Agents)</a></li>
         <li><a href="/reference/reinforcement-learning/">Reinforcement Learning</a></li>
         <li><a href="/reference/retrieval-augmented-generation/">Retrieval-Augmented Generation</a></li>
         <li><a href="/reference/reward-hacking/">Reward Hacking</a></li>

--- a/reference/react/index.html
+++ b/reference/react/index.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ReAct (AI Agents) · Reference · Nestor G Pestelos Jr</title>
+  <meta name="description" content="ReAct interleaves language-model reasoning with actions and observations from an environment.">
+  <meta property="og:title" content="ReAct (AI Agents) · Reference">
+  <meta property="og:description" content="ReAct interleaves language-model reasoning with actions and observations from an environment.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://ngpestelos.com/reference/react/">
+  <link rel="canonical" href="https://ngpestelos.com/reference/react/">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=20260813f">
+  <link rel="icon" href="/favicon-192.png?v=20260813f" type="image/png" sizes="192x192">
+  <link rel="icon" href="/favicon-32.png?v=20260813f" type="image/png" sizes="32x32">
+  <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
+  <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="stylesheet" href="/style.css?v=20260903e">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TLBY8P4GG9');
+  </script>
+  <style>
+    
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
+    body {
+      line-height: 1.6;
+    }
+    main {
+      max-width: 46rem;
+      margin: 0 auto;
+      padding: 1.4rem 1.4rem 4rem;
+    }
+    .back {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .back a { color: var(--link); text-decoration: none; }
+    .back a:hover { text-decoration: underline; }
+    .kicker {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.78rem;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--mute);
+      margin-bottom: 0.3rem;
+    }
+    h1 {
+      font-size: clamp(1.9rem, 5vw, 2.4rem);
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.4rem;
+      margin-bottom: 1rem;
+    }
+    .updated {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.82rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .lede { margin-bottom: 1.6rem; }
+    .lede strong:first-child { font-weight: 700; }
+    .toc {
+      background: var(--well);
+      border: 1px solid var(--line);
+      border-radius: 4px;
+      padding: 1rem 1.4rem;
+      margin-bottom: 2rem;
+      max-width: 24rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.92rem;
+    }
+    .toc .toc-title {
+      font-weight: 700;
+      margin-bottom: 0.5rem;
+      text-align: center;
+    }
+    .toc ol { padding-left: 1.3rem; }
+    .toc li { margin: 0.2rem 0; }
+    .toc a { color: var(--link); text-decoration: none; }
+    .toc a:hover { text-decoration: underline; }
+    h2 {
+      font-size: 1.5rem;
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.3rem;
+      margin: 2rem 0 0.9rem;
+    }
+    p { margin-bottom: 0.9rem; }
+    a { color: var(--link); }
+    a:visited { color: var(--link-visited); }
+    code {
+      font-family: "SF Mono", Consolas, Monaco, monospace;
+      font-size: 0.9em;
+      background: var(--well);
+      padding: 0.1em 0.35em;
+      border-radius: 3px;
+    }
+    .cite {
+      font-size: 0.75em;
+      vertical-align: super;
+      line-height: 0;
+      text-decoration: none;
+    }
+    .cite a { text-decoration: none; }
+    #see-also ul, #references ol {
+      padding-left: 1.5rem;
+    }
+    #see-also li, #references li { margin-bottom: 0.5rem; }
+    #references { font-size: 0.95rem; }
+    #references .backlink { margin-right: 0.3rem; }
+    footer.meta {
+      margin-top: 3rem;
+      padding-top: 1.2rem;
+      border-top: 1px solid var(--line);
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+    }
+    footer.meta a { color: var(--link); }
+    @media print {
+      .back {font-family:"Segoe UI", Helvetica, Arial, sans-serif;display: none;}
+    }
+      .back-to-top {
+      position: fixed;
+      bottom: 1.5rem;
+      right: 1.5rem;
+      width: 2.6rem;
+      height: 2.6rem;
+      border-radius: 50%;
+      background: var(--bg);
+      color: var(--ink);
+      border: 1px solid var(--line);
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      opacity: 0;
+      visibility: hidden;
+      transform: translateY(8px);
+      transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease, background 0.15s ease, border-color 0.15s ease;
+      z-index: 100;
+    }
+    .back-to-top.visible {
+      opacity: 1;
+      visibility: visible;
+      transform: translateY(0);
+    }
+    .back-to-top:hover {
+      background: var(--well);
+      border-color: var(--link);
+      color: var(--link);
+    }
+    .back-to-top:focus-visible {
+      outline: 2px solid var(--link);
+      outline-offset: 2px;
+    }
+    @media print {
+      .back-to-top { display: none !important; }
+    }
+  </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"ReAct (AI Agents)","description":"ReAct interleaves language-model reasoning with actions and observations from an environment.","url":"https://ngpestelos.com/reference/react/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
+</head>
+<body class="reference">
+  <main id="top">
+    <p class="back"><a href="/reference/">← Reference</a> · <a href="/">Nestor G Pestelos Jr</a> · <a href="#" onclick="window.print(); return false;">Print this page</a></p>
+    <p class="kicker">Systems Architecture · Artificial Intelligence</p>
+    <h1>ReAct (AI Agents)</h1>
+    <p class="updated">Reference entry · last updated 20260910</p>
+
+<p class="lede"><strong>ReAct</strong> is a method that interleaves <a href="/reference/large-language-models/">language-model</a> <a href="/reference/reasoning/">reasoning</a> with actions and observations from an environment. Yao and colleagues introduced it for tasks requiring both deliberation and interaction.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+<nav class="toc" aria-label="Contents"><p class="toc-title">Contents</p><ol><li><a href="#first-principles">First principles and definitions</a></li><li><a href="#mechanism">Mechanism</a></li><li><a href="#evidence">Evidence and limits</a></li><li><a href="#see-also">See also</a></li><li><a href="#references">References</a></li></ol></nav>
+
+<h2 id="first-principles">First principles and definitions</h2>
+<p>An action can obtain evidence or change an environment. Its observation becomes input for later decisions in an <a href="/reference/agentic-loops/">agentic loop</a>. ReAct combines these interactions with generated reasoning traces.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+<h2 id="mechanism">Mechanism</h2>
+<p>The original method uses example trajectories to elicit reasoning and actions. Reasoning can be sparse; the method does not require a thought before every action.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+<p>Illustrative sequence: an agent searches a paper title, reads a candidate record, notices a title mismatch, and changes the query. Each observation is available when choosing what to do next.</p>
+<p>The <a href="/reference/agent-harness/">harness</a> executes requested tools. Approval checks and execution limits are separate runtime decisions.<span class="cite">[<a href="#ref2">2</a>]</span> ReAct itself does not require human approval for each action.</p>
+<h2 id="evidence">Evidence and limits</h2>
+<p>The paper evaluates question answering, fact verification, and interactive tasks using HotpotQA, FEVER, ALFWorld, and WebShop. Those results concern the tested settings.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+<p>ReAct can still choose an unhelpful action or draw a wrong conclusion. <a href="/reference/reflexion/">Reflexion</a> can add reflection across attempts.</p>
+<h2 id="see-also">See also</h2><ul><li><a href="/reference/agentic-loops/">Agentic Loops</a></li><li><a href="/reference/reflexion/">Reflexion (AI Agents)</a></li><li><a href="/reference/agents/">Agents</a></li><li><a href="/reference/llm-evaluations/">LLM Evaluations</a></li></ul>
+<h2 id="references">References</h2><ol><li id="ref1">Yao, Shunyu, et al. <a href="https://arxiv.org/abs/2210.03629">“ReAct: Synergizing Reasoning and Acting in Language Models.”</a> ICLR, 2023. <a href="https://react-lm.github.io/">Author project page</a>.</li><li id="ref2">Trivedy, Vivek. <a href="https://www.langchain.com/blog/the-anatomy-of-an-agent-harness">“The Anatomy of an Agent Harness.”</a> LangChain, 2026.</li></ol>
+    <footer class="meta">
+      <p><a href="#top">Back to top</a></p>
+    </footer>
+  </main>
+  <button id="backToTop" class="back-to-top" aria-label="Back to top" title="Back to top">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M18 15l-6-6-6 6"/>
+    </svg>
+  </button>
+
+  <script>
+    const btt = document.getElementById('backToTop');
+    window.addEventListener('scroll', () => {
+      if (window.scrollY > 250) {
+        btt.classList.add('visible');
+      } else {
+        btt.classList.remove('visible');
+      }
+    }, { passive: true });
+    btt.addEventListener('click', () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  </script>
+</body>
+</html>

--- a/reference/reflexion/index.html
+++ b/reference/reflexion/index.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Reflexion (AI Agents) · Reference · Nestor G Pestelos Jr</title>
+  <meta name="description" content="Reflexion retains verbal reflections in episodic memory to inform later task attempts without updating model weights.">
+  <meta property="og:title" content="Reflexion (AI Agents) · Reference">
+  <meta property="og:description" content="Reflexion retains verbal reflections in episodic memory to inform later task attempts without updating model weights.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://ngpestelos.com/reference/reflexion/">
+  <link rel="canonical" href="https://ngpestelos.com/reference/reflexion/">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=20260813f">
+  <link rel="icon" href="/favicon-192.png?v=20260813f" type="image/png" sizes="192x192">
+  <link rel="icon" href="/favicon-32.png?v=20260813f" type="image/png" sizes="32x32">
+  <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
+  <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="stylesheet" href="/style.css?v=20260903e">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TLBY8P4GG9');
+  </script>
+  <style>
+    
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
+    body {
+      line-height: 1.6;
+    }
+    main {
+      max-width: 46rem;
+      margin: 0 auto;
+      padding: 1.4rem 1.4rem 4rem;
+    }
+    .back {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .back a { color: var(--link); text-decoration: none; }
+    .back a:hover { text-decoration: underline; }
+    .kicker {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.78rem;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--mute);
+      margin-bottom: 0.3rem;
+    }
+    h1 {
+      font-size: clamp(1.9rem, 5vw, 2.4rem);
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.4rem;
+      margin-bottom: 1rem;
+    }
+    .updated {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.82rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .lede { margin-bottom: 1.6rem; }
+    .lede strong:first-child { font-weight: 700; }
+    .toc {
+      background: var(--well);
+      border: 1px solid var(--line);
+      border-radius: 4px;
+      padding: 1rem 1.4rem;
+      margin-bottom: 2rem;
+      max-width: 24rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.92rem;
+    }
+    .toc .toc-title {
+      font-weight: 700;
+      margin-bottom: 0.5rem;
+      text-align: center;
+    }
+    .toc ol { padding-left: 1.3rem; }
+    .toc li { margin: 0.2rem 0; }
+    .toc a { color: var(--link); text-decoration: none; }
+    .toc a:hover { text-decoration: underline; }
+    h2 {
+      font-size: 1.5rem;
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.3rem;
+      margin: 2rem 0 0.9rem;
+    }
+    p { margin-bottom: 0.9rem; }
+    a { color: var(--link); }
+    a:visited { color: var(--link-visited); }
+    code {
+      font-family: "SF Mono", Consolas, Monaco, monospace;
+      font-size: 0.9em;
+      background: var(--well);
+      padding: 0.1em 0.35em;
+      border-radius: 3px;
+    }
+    .cite {
+      font-size: 0.75em;
+      vertical-align: super;
+      line-height: 0;
+      text-decoration: none;
+    }
+    .cite a { text-decoration: none; }
+    #see-also ul, #references ol {
+      padding-left: 1.5rem;
+    }
+    #see-also li, #references li { margin-bottom: 0.5rem; }
+    #references { font-size: 0.95rem; }
+    #references .backlink { margin-right: 0.3rem; }
+    footer.meta {
+      margin-top: 3rem;
+      padding-top: 1.2rem;
+      border-top: 1px solid var(--line);
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+    }
+    footer.meta a { color: var(--link); }
+    @media print {
+      .back {font-family:"Segoe UI", Helvetica, Arial, sans-serif;display: none;}
+    }
+      .back-to-top {
+      position: fixed;
+      bottom: 1.5rem;
+      right: 1.5rem;
+      width: 2.6rem;
+      height: 2.6rem;
+      border-radius: 50%;
+      background: var(--bg);
+      color: var(--ink);
+      border: 1px solid var(--line);
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      opacity: 0;
+      visibility: hidden;
+      transform: translateY(8px);
+      transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease, background 0.15s ease, border-color 0.15s ease;
+      z-index: 100;
+    }
+    .back-to-top.visible {
+      opacity: 1;
+      visibility: visible;
+      transform: translateY(0);
+    }
+    .back-to-top:hover {
+      background: var(--well);
+      border-color: var(--link);
+      color: var(--link);
+    }
+    .back-to-top:focus-visible {
+      outline: 2px solid var(--link);
+      outline-offset: 2px;
+    }
+    @media print {
+      .back-to-top { display: none !important; }
+    }
+  </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Reflexion (AI Agents)","description":"Reflexion retains verbal reflections in episodic memory to inform later task attempts without updating model weights.","url":"https://ngpestelos.com/reference/reflexion/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
+</head>
+<body class="reference">
+  <main id="top">
+    <p class="back"><a href="/reference/">← Reference</a> · <a href="/">Nestor G Pestelos Jr</a> · <a href="#" onclick="window.print(); return false;">Print this page</a></p>
+    <p class="kicker">Systems Architecture · Artificial Intelligence</p>
+    <h1>Reflexion (AI Agents)</h1>
+    <p class="updated">Reference entry · last updated 20260910</p>
+
+<p class="lede"><strong>Reflexion</strong> is a framework in which a <a href="/reference/large-language-models/">language-model</a> agent reflects on feedback and stores verbal lessons in <a href="/reference/agents/#core-subsystems">episodic memory</a> to inform later attempts. This memory holds records of earlier attempts. Shinn and colleagues introduced it as verbal reinforcement learning.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+<nav class="toc" aria-label="Contents"><p class="toc-title">Contents</p><ol><li><a href="#first-principles">First principles and definitions</a></li><li><a href="#mechanism">Mechanism</a></li><li><a href="#evidence">Evidence and limits</a></li><li><a href="#see-also">See also</a></li><li><a href="#references">References</a></li></ol></nav>
+
+<h2 id="first-principles">First principles and definitions</h2>
+<p>Reflexion changes the information supplied to an agent across attempts without updating model weights. Its feedback may be a score or free-form text, supplied by external checks or generated internally.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+<h2 id="mechanism">Mechanism</h2>
+<p>An actor attempts a task. An evaluator assesses the result. A self-reflection component produces text retained in memory for a subsequent attempt. The actor can use <a href="/reference/react/">ReAct</a> within an attempt.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+<p>Illustrative sequence: a code candidate fails a boundary-case test. A reflection records the missed case. On the next attempt, the actor receives that note alongside the task. A new test run determines whether the revision fixes the failure.</p>
+<p>This example uses a test as feedback; the framework does not require every task to have a deterministic verifier. The mechanism also does not imply that the agent rewrites its tools.</p>
+<h2 id="evidence">Evidence and limits</h2>
+<p>The paper evaluates decision-making, reasoning, and programming tasks. A mistaken reflection can misdirect later attempts; retained text is not verified knowledge.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+<p>An <a href="/reference/agent-harness/">agent harness</a> still manages execution.<span class="cite">[<a href="#ref2">2</a>]</span> An <a href="/reference/agentic-loops/">agentic loop</a> using Reflexion needs its own stopping policy and task-appropriate <a href="/reference/llm-evaluations/">evaluation</a>.</p>
+<h2 id="see-also">See also</h2><ul><li><a href="/reference/agentic-loops/">Agentic Loops</a></li><li><a href="/reference/react/">ReAct (AI Agents)</a></li><li><a href="/reference/context-engineering/">Context Engineering</a></li><li><a href="/reference/llm-evaluations/">LLM Evaluations</a></li></ul>
+<h2 id="references">References</h2><ol><li id="ref1">Shinn, Noah, et al. <a href="https://arxiv.org/abs/2303.11366">“Reflexion: Language Agents with Verbal Reinforcement Learning.”</a> NeurIPS, 2023. <a href="https://arxiv.org/html/2303.11366v4">Full text</a>.</li><li id="ref2">Trivedy, Vivek. <a href="https://www.langchain.com/blog/the-anatomy-of-an-agent-harness">“The Anatomy of an Agent Harness.”</a> LangChain, 2026.</li></ol>
+    <footer class="meta">
+      <p><a href="#top">Back to top</a></p>
+    </footer>
+  </main>
+  <button id="backToTop" class="back-to-top" aria-label="Back to top" title="Back to top">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M18 15l-6-6-6 6"/>
+    </svg>
+  </button>
+
+  <script>
+    const btt = document.getElementById('backToTop');
+    window.addEventListener('scroll', () => {
+      if (window.scrollY > 250) {
+        btt.classList.add('visible');
+      } else {
+        btt.classList.remove('visible');
+      }
+    }, { passive: true });
+    btt.addEventListener('click', () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  </script>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1202,4 +1202,14 @@
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
+  <url>
+    <loc>https://ngpestelos.com/reference/react/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://ngpestelos.com/reference/reflexion/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
The agentic-loops entry attributed unsupported architectural hierarchies to its sources and treated deterministic verification and mutation access as universal requirements. This revision replaces those claims with sourced definitions, distinct architecture patterns, task-appropriate feedback, and bounded stopping and recovery policies.

Adds focused ReAct and Reflexion reference pages, links supporting concepts at their first useful mention, and registers both new entries in the reference index and sitemap. Preserves the pre-edit agentic-loops page at `/reference/agentic-loops-20260910/` with reciprocal version links.

Validation:
- `python3 scripts/test_site_discoverability.py`: 22 tests passed.
- Internal links, fragments, TOC coverage, metadata, and new-page registration checked.
- Archived source matches the original bytes after reversing only metadata and navigation changes.
- All four routes returned HTTP 200 in local Chrome at desktop and mobile widths, with no JavaScript errors or horizontal overflow.
- Citations checked against primary sources; prose trimmed for clarity.
