### PR TITLE
Align reference list markers within headings

### DIFF
--- a/style.css
+++ b/style.css
@@ -514,6 +514,12 @@ body.reference:not(:has(#reference)) {
   padding: 0;
 }
 
+body.reference main#top > ul,
+body.reference main#top > ol {
+  padding-inline-start: 1.5rem;
+  list-style-position: outside;
+}
+
 body:has(main.article) main,
 body:has(#writing) main {
   max-width: 40rem;


### PR DESCRIPTION
Reference-page bullets and reference numbers hang left of their section headings because the global reset removes list padding. Restore indentation for direct content lists while keeping wrapped text aligned beneath the first line.

Validation: 22 site tests pass. Clearing and Settlement checked at desktop and mobile widths; markers stay within the heading edge, wrapped text keeps its hanging indent, and no horizontal overflow occurs.
