### PR TITLE
Revise online payments and add supporting references

### DIFF
--- a/reference/activemerchant/index.html
+++ b/reference/activemerchant/index.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ActiveMerchant (Ruby Payments Library) · Reference · Nestor G Pestelos Jr</title>
+  <meta name="description" content="ActiveMerchant gateway adapters, payment operations, monetary amounts, and provider-specific behavior.">
+  <meta property="og:title" content="ActiveMerchant (Ruby Payments Library) · Reference">
+  <meta property="og:description" content="ActiveMerchant gateway adapters, payment operations, monetary amounts, and provider-specific behavior.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://ngpestelos.com/reference/activemerchant/">
+  <link rel="canonical" href="https://ngpestelos.com/reference/activemerchant/">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=20260813f">
+  <link rel="icon" href="/favicon-192.png?v=20260813f" type="image/png" sizes="192x192">
+  <link rel="icon" href="/favicon-32.png?v=20260813f" type="image/png" sizes="32x32">
+  <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
+  <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="stylesheet" href="/style.css?v=20260903e">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TLBY8P4GG9');
+  </script>
+  <style>
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; -webkit-text-size-adjust:100%; text-size-adjust:100%; }
+body { line-height:1.65; }
+main { max-width:48rem; margin:auto; padding:1.4rem 1.4rem 4rem; }
+h1 { font-size:clamp(1.9rem,5vw,2.4rem); font-weight:400; line-height:1.2; border-bottom:1px solid var(--line); padding-bottom:.5rem; }
+h2 { font-weight:400; margin-top:2rem; font-size:1.45rem; border-bottom:1px solid var(--line); padding-bottom:.3rem; }
+p,li { margin-bottom:.7rem; }
+.back,.kicker,.updated,.toc,footer { font-family:"Segoe UI",Helvetica,Arial,sans-serif; }
+.back,.updated,footer { font-size:.85rem; color:var(--mute); }
+.kicker { font-size:.78rem; text-transform:uppercase; letter-spacing:.08em; font-weight:700; color:var(--mute); }
+.lede { margin:1.4rem 0; }
+.toc { background:var(--well); border:1px solid var(--line); border-radius:4px; padding:1rem 1.3rem; margin:1.7rem 0; font-size:.9rem; }
+.toc ol { margin-bottom:0; padding-left:1.5rem; }
+.toc li { margin-bottom:.25rem; }
+.cite { font-size:.75em; vertical-align:super; }
+.cite a { text-decoration:none; }
+#references ~ ol { font-size:.9rem; overflow-wrap:anywhere; }
+footer { border-top:1px solid var(--line); margin-top:2rem; }
+.back-to-top { position:fixed; bottom:1.5rem; right:1.5rem; width:2.6rem; height:2.6rem; border-radius:50%; background:var(--bg); color:var(--ink); border:1px solid var(--line); cursor:pointer; opacity:0; visibility:hidden; }
+.back-to-top.visible { opacity:1; visibility:visible; }
+@media print { .back,.back-to-top { display:none !important; } main { max-width:none; padding:0; } }
+  </style>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"DefinedTerm","name":"ActiveMerchant (Ruby Payments Library)","description":"ActiveMerchant gateway adapters, payment operations, monetary amounts, and provider-specific behavior.","url":"https://ngpestelos.com/reference/activemerchant/","inDefinedTermSet":"https://ngpestelos.com/reference/"}</script>
+</head>
+<body class="reference">
+<main id="top">
+<p class="back"><a href="/reference/">&larr; Reference</a> &middot; <a href="/">Home</a> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a></p>
+<p class="kicker">Finance · Payments</p>
+<h1>ActiveMerchant (Ruby Payments Library)</h1>
+<p class="updated">Reference entry &middot; last updated 20260910</p>
+<p class="lede"><strong>ActiveMerchant</strong> is an open-source Ruby payment library extracted from Shopify. It provides a common interface to supported payment gateways and can be used in Rails or standalone Ruby applications.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+<nav class="toc" aria-label="Contents"><strong>Contents</strong><ol>
+<li><a href="#first-principles">First principles: a gateway adapter</a></li>
+<li><a href="#operations">Payment operations</a></li>
+<li><a href="#amounts">Amounts and responses</a></li>
+<li><a href="#scope">Scope</a></li>
+<li><a href="#see-also">See also</a></li>
+<li><a href="#references">References</a></li>
+</ol></nav>
+<h2 id="first-principles">1. First principles: a gateway adapter</h2>
+<p>The library translates application calls into gateway-specific requests. A shared method name does not make all gateways support the same capabilities. The project maintains gateway-specific implementations and a supported-features table.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+<h2 id="operations">2. Payment operations</h2>
+<p>The base gateway documents operations including <code>authorize</code>, <code>capture</code>, <code>purchase</code>, <code>void</code>, and <code>refund</code>. Their arguments include amounts, payment credentials or authorization identifiers, and gateway options.<span class="cite">[<a href="#ref2">2</a>]</span></p><p>A gateway’s support for <a href="/reference/card-authorization-capture/">partial or multiple captures</a> must be checked separately.</p>
+<h2 id="amounts">3. Amounts and responses</h2>
+<p>The README’s dollar example passes integer cents: <code>1000</code> represents USD 10.00. Its purchase example checks <code>response.success?</code> and reads <code>response.message</code>.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+<h2 id="scope">4. Scope</h2>
+<p>ActiveMerchant is an integration library. Merchant acquiring arrangements, <a href="/reference/pci-dss/">card-data security responsibilities</a>, and <a href="/reference/chargebacks/">dispute processes</a> remain part of the payment system.</p>
+<h2 id="see-also">5. See also</h2>
+<ul><li><a href="/reference/online-payments/">Online Payments</a></li><li><a href="/reference/payment-service-providers/">Payment Service Providers (Merchant Payments)</a></li><li><a href="/reference/card-authorization-capture/">Card Authorization and Capture</a></li><li><a href="/reference/pci-dss/">PCI DSS (Payment Card Data Security)</a></li></ul>
+<h2 id="references">6. References</h2>
+<ol>
+<li id="ref1"><a href="https://github.com/activemerchant/active_merchant">ActiveMerchant. Project README and gateway feature links.</a></li>
+<li id="ref2"><a href="https://raw.githubusercontent.com/activemerchant/active_merchant/master/lib/active_merchant/billing/gateway.rb">ActiveMerchant. Billing gateway source and interface documentation.</a></li>
+</ol>
+<footer><p><a href="#top">Back to top</a></p></footer>
+</main>
+  <button id="backToTop" class="back-to-top" aria-label="Back to top" title="Back to top">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M18 15l-6-6-6 6"/>
+    </svg>
+  </button>
+
+  <script>
+    const btt = document.getElementById('backToTop');
+    window.addEventListener('scroll', () => {
+      if (window.scrollY > 250) {
+        btt.classList.add('visible');
+      } else {
+        btt.classList.remove('visible');
+      }
+    }, { passive: true });
+    btt.addEventListener('click', () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  </script>
+</body>
+</html>

--- a/reference/card-authorization-capture/index.html
+++ b/reference/card-authorization-capture/index.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Card Authorization and Capture · Reference · Nestor G Pestelos Jr</title>
+  <meta name="description" content="Card payment holds, capture, expiry, cancellation, and refunds.">
+  <meta property="og:title" content="Card Authorization and Capture · Reference">
+  <meta property="og:description" content="Card payment holds, capture, expiry, cancellation, and refunds.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://ngpestelos.com/reference/card-authorization-capture/">
+  <link rel="canonical" href="https://ngpestelos.com/reference/card-authorization-capture/">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=20260813f">
+  <link rel="icon" href="/favicon-192.png?v=20260813f" type="image/png" sizes="192x192">
+  <link rel="icon" href="/favicon-32.png?v=20260813f" type="image/png" sizes="32x32">
+  <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
+  <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="stylesheet" href="/style.css?v=20260903e">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TLBY8P4GG9');
+  </script>
+  <style>
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; -webkit-text-size-adjust:100%; text-size-adjust:100%; }
+body { line-height:1.65; }
+main { max-width:48rem; margin:auto; padding:1.4rem 1.4rem 4rem; }
+h1 { font-size:clamp(1.9rem,5vw,2.4rem); font-weight:400; line-height:1.2; border-bottom:1px solid var(--line); padding-bottom:.5rem; }
+h2 { font-weight:400; margin-top:2rem; font-size:1.45rem; border-bottom:1px solid var(--line); padding-bottom:.3rem; }
+p,li { margin-bottom:.7rem; }
+.back,.kicker,.updated,.toc,footer { font-family:"Segoe UI",Helvetica,Arial,sans-serif; }
+.back,.updated,footer { font-size:.85rem; color:var(--mute); }
+.kicker { font-size:.78rem; text-transform:uppercase; letter-spacing:.08em; font-weight:700; color:var(--mute); }
+.lede { margin:1.4rem 0; }
+.toc { background:var(--well); border:1px solid var(--line); border-radius:4px; padding:1rem 1.3rem; margin:1.7rem 0; font-size:.9rem; }
+.toc ol { margin-bottom:0; padding-left:1.5rem; }
+.toc li { margin-bottom:.25rem; }
+.cite { font-size:.75em; vertical-align:super; }
+.cite a { text-decoration:none; }
+#references ~ ol { font-size:.9rem; overflow-wrap:anywhere; }
+footer { border-top:1px solid var(--line); margin-top:2rem; }
+.back-to-top { position:fixed; bottom:1.5rem; right:1.5rem; width:2.6rem; height:2.6rem; border-radius:50%; background:var(--bg); color:var(--ink); border:1px solid var(--line); cursor:pointer; opacity:0; visibility:hidden; }
+.back-to-top.visible { opacity:1; visibility:visible; }
+@media print { .back,.back-to-top { display:none !important; } main { max-width:none; padding:0; } }
+  </style>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"DefinedTerm","name":"Card Authorization and Capture","description":"Card payment holds, capture, expiry, cancellation, and refunds.","url":"https://ngpestelos.com/reference/card-authorization-capture/","inDefinedTermSet":"https://ngpestelos.com/reference/"}</script>
+</head>
+<body class="reference">
+<main id="top">
+<p class="back"><a href="/reference/">&larr; Reference</a> &middot; <a href="/">Home</a> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a></p>
+<p class="kicker">Finance · Payments</p>
+<h1>Card Authorization and Capture</h1>
+<p class="updated">Reference entry &middot; last updated 20260910</p>
+<p class="lede"><strong>Card authorization</strong> is the issuer’s approval of a requested payment, typically with a hold on available funds or credit. <strong>Capture</strong> submits an authorized amount for collection.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+<nav class="toc" aria-label="Contents"><strong>Contents</strong><ol>
+<li><a href="#first-principles">First principles: approval and collection</a></li>
+<li><a href="#capture">Capture options</a></li>
+<li><a href="#cancel-refund">Cancellation and refund</a></li>
+<li><a href="#settlement">Settlement and payout</a></li>
+<li><a href="#see-also">See also</a></li>
+<li><a href="#references">References</a></li>
+</ol></nav>
+<h2 id="first-principles">1. First principles: approval and collection</h2>
+<p>An authorization creates a limited opportunity to capture a payment. Its validity depends on the card network and transaction type. An expired, uncaptured hold releases the reserved amount.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+<h2 id="capture">2. Capture options</h2>
+<p>A merchant can capture an eligible authorization in full or in part. Multiple captures require specific support; Stripe documents them as available for only some card payments. The gateway’s transaction status and capture deadline govern the next permitted operation.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+<h2 id="cancel-refund">3. Cancellation and refund</h2>
+<p>Cancellation stops an uncaptured payment. After capture, returning a payment generally uses a refund. Refund availability and processing depend on the payment’s status and provider.<span class="cite">[<a href="#ref2">2</a>]</span></p>
+<h2 id="settlement">4. Settlement and payout</h2>
+<p>Capture, <a href="/reference/clearing/">clearing</a>, <a href="/reference/settlement/">settlement</a>, and payout describe different stages. Adyen’s documented “Settled” status means it has received the funds; merchant payout is a separate event.<span class="cite">[<a href="#ref3">3</a>]</span></p>
+<h2 id="see-also">5. See also</h2>
+<ul><li><a href="/reference/online-payments/">Online Payments</a></li><li><a href="/reference/chargebacks/">Chargebacks (Card Payments)</a></li><li><a href="/reference/payment-service-providers/">Payment Service Providers (Merchant Payments)</a></li><li><a href="/reference/settlement/">Settlement</a></li></ul>
+<h2 id="references">6. References</h2>
+<ol>
+<li id="ref1"><a href="https://docs.stripe.com/payments/place-a-hold-on-a-payment-method">Stripe. Place a hold on a payment method.</a></li>
+<li id="ref2"><a href="https://docs.stripe.com/refunds">Stripe. Refund and cancel payments.</a></li>
+<li id="ref3"><a href="https://docs.adyen.com/account/payments-lifecycle/">Adyen. Payments lifecycle.</a></li>
+</ol>
+<footer><p><a href="#top">Back to top</a></p></footer>
+</main>
+  <button id="backToTop" class="back-to-top" aria-label="Back to top" title="Back to top">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M18 15l-6-6-6 6"/>
+    </svg>
+  </button>
+
+  <script>
+    const btt = document.getElementById('backToTop');
+    window.addEventListener('scroll', () => {
+      if (window.scrollY > 250) {
+        btt.classList.add('visible');
+      } else {
+        btt.classList.remove('visible');
+      }
+    }, { passive: true });
+    btt.addEventListener('click', () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  </script>
+</body>
+</html>

--- a/reference/chargebacks/index.html
+++ b/reference/chargebacks/index.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Chargebacks (Card Payments) · Reference · Nestor G Pestelos Jr</title>
+  <meta name="description" content="Card disputes, chargeback debits, evidence, and the distinction from refunds.">
+  <meta property="og:title" content="Chargebacks (Card Payments) · Reference">
+  <meta property="og:description" content="Card disputes, chargeback debits, evidence, and the distinction from refunds.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://ngpestelos.com/reference/chargebacks/">
+  <link rel="canonical" href="https://ngpestelos.com/reference/chargebacks/">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=20260813f">
+  <link rel="icon" href="/favicon-192.png?v=20260813f" type="image/png" sizes="192x192">
+  <link rel="icon" href="/favicon-32.png?v=20260813f" type="image/png" sizes="32x32">
+  <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
+  <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="stylesheet" href="/style.css?v=20260903e">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TLBY8P4GG9');
+  </script>
+  <style>
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; -webkit-text-size-adjust:100%; text-size-adjust:100%; }
+body { line-height:1.65; }
+main { max-width:48rem; margin:auto; padding:1.4rem 1.4rem 4rem; }
+h1 { font-size:clamp(1.9rem,5vw,2.4rem); font-weight:400; line-height:1.2; border-bottom:1px solid var(--line); padding-bottom:.5rem; }
+h2 { font-weight:400; margin-top:2rem; font-size:1.45rem; border-bottom:1px solid var(--line); padding-bottom:.3rem; }
+p,li { margin-bottom:.7rem; }
+.back,.kicker,.updated,.toc,footer { font-family:"Segoe UI",Helvetica,Arial,sans-serif; }
+.back,.updated,footer { font-size:.85rem; color:var(--mute); }
+.kicker { font-size:.78rem; text-transform:uppercase; letter-spacing:.08em; font-weight:700; color:var(--mute); }
+.lede { margin:1.4rem 0; }
+.toc { background:var(--well); border:1px solid var(--line); border-radius:4px; padding:1rem 1.3rem; margin:1.7rem 0; font-size:.9rem; }
+.toc ol { margin-bottom:0; padding-left:1.5rem; }
+.toc li { margin-bottom:.25rem; }
+.cite { font-size:.75em; vertical-align:super; }
+.cite a { text-decoration:none; }
+#references ~ ol { font-size:.9rem; overflow-wrap:anywhere; }
+footer { border-top:1px solid var(--line); margin-top:2rem; }
+.back-to-top { position:fixed; bottom:1.5rem; right:1.5rem; width:2.6rem; height:2.6rem; border-radius:50%; background:var(--bg); color:var(--ink); border:1px solid var(--line); cursor:pointer; opacity:0; visibility:hidden; }
+.back-to-top.visible { opacity:1; visibility:visible; }
+@media print { .back,.back-to-top { display:none !important; } main { max-width:none; padding:0; } }
+  </style>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"DefinedTerm","name":"Chargebacks (Card Payments)","description":"Card disputes, chargeback debits, evidence, and the distinction from refunds.","url":"https://ngpestelos.com/reference/chargebacks/","inDefinedTermSet":"https://ngpestelos.com/reference/"}</script>
+</head>
+<body class="reference">
+<main id="top">
+<p class="back"><a href="/reference/">&larr; Reference</a> &middot; <a href="/">Home</a> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a></p>
+<p class="kicker">Finance · Payments</p>
+<h1>Chargebacks (Card Payments)</h1>
+<p class="updated">Reference entry &middot; last updated 20260910</p>
+<p class="lede">A <strong>chargeback</strong> is a debit initiated through the cardholder’s issuer in response to a disputed card payment. The disputed funds can be held while the case is resolved.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+<nav class="toc" aria-label="Contents"><strong>Contents</strong><ol>
+<li><a href="#first-principles">First principles: a disputed transaction</a></li>
+<li><a href="#outcome">Debit and final outcome</a></li>
+<li><a href="#refund">Relationship to refunds</a></li>
+<li><a href="#authentication">Authentication and liability</a></li>
+<li><a href="#see-also">See also</a></li>
+<li><a href="#references">References</a></li>
+</ol></nav>
+<h2 id="first-principles">1. First principles: a disputed transaction</h2>
+<p>A cardholder can contest a payment for reasons such as fraud or goods not received. The issuer handles the cardholder’s complaint through the applicable network process. A merchant can accept the dispute or submit evidence where the process allows.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+<h2 id="outcome">2. Debit and final outcome</h2>
+<p>A chargeback debit does not by itself establish the final outcome. Evidence, deadlines, reason codes, and network rules affect the result. A preliminary inquiry can also request information before a financial chargeback.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+<h2 id="refund">3. Relationship to refunds</h2>
+<p>A refund is a merchant-initiated return of a payment. An open dispute follows its own workflow; issuing another refund can create duplicate reimbursement risk. Stripe directs merchants to resolve a disputed payment through its dispute process.<span class="cite">[<a href="#ref2">2</a>]</span></p>
+<h2 id="authentication">4. Authentication and liability</h2>
+<p><a href="/reference/emv-3ds/">EMV 3DS</a> can affect fraud liability under applicable rules. Non-fraud disputes, including goods not received, can still proceed after authentication.<span class="cite">[<a href="#ref3">3</a>]</span></p>
+<h2 id="see-also">5. See also</h2>
+<ul><li><a href="/reference/online-payments/">Online Payments</a></li><li><a href="/reference/card-authorization-capture/">Card Authorization and Capture</a></li><li><a href="/reference/emv-3ds/">EMV 3-D Secure (Online Card Authentication)</a></li></ul>
+<h2 id="references">6. References</h2>
+<ol>
+<li id="ref1"><a href="https://docs.stripe.com/disputes/how-disputes-work">Stripe. How disputes work.</a></li>
+<li id="ref2"><a href="https://docs.stripe.com/refunds">Stripe. Refund and cancel payments.</a></li>
+<li id="ref3"><a href="https://docs.stripe.com/payments/3d-secure/authentication-flow">Stripe. 3D Secure authentication flow: disputes and liability shift.</a></li>
+</ol>
+<footer><p><a href="#top">Back to top</a></p></footer>
+</main>
+  <button id="backToTop" class="back-to-top" aria-label="Back to top" title="Back to top">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M18 15l-6-6-6 6"/>
+    </svg>
+  </button>
+
+  <script>
+    const btt = document.getElementById('backToTop');
+    window.addEventListener('scroll', () => {
+      if (window.scrollY > 250) {
+        btt.classList.add('visible');
+      } else {
+        btt.classList.remove('visible');
+      }
+    }, { passive: true });
+    btt.addEventListener('click', () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  </script>
+</body>
+</html>

--- a/reference/emv-3ds/index.html
+++ b/reference/emv-3ds/index.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EMV 3-D Secure (Online Card Authentication) · Reference · Nestor G Pestelos Jr</title>
+  <meta name="description" content="EMV 3DS authentication, frictionless and challenge flows, and conditional fraud-liability effects.">
+  <meta property="og:title" content="EMV 3-D Secure (Online Card Authentication) · Reference">
+  <meta property="og:description" content="EMV 3DS authentication, frictionless and challenge flows, and conditional fraud-liability effects.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://ngpestelos.com/reference/emv-3ds/">
+  <link rel="canonical" href="https://ngpestelos.com/reference/emv-3ds/">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=20260813f">
+  <link rel="icon" href="/favicon-192.png?v=20260813f" type="image/png" sizes="192x192">
+  <link rel="icon" href="/favicon-32.png?v=20260813f" type="image/png" sizes="32x32">
+  <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
+  <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="stylesheet" href="/style.css?v=20260903e">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TLBY8P4GG9');
+  </script>
+  <style>
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; -webkit-text-size-adjust:100%; text-size-adjust:100%; }
+body { line-height:1.65; }
+main { max-width:48rem; margin:auto; padding:1.4rem 1.4rem 4rem; }
+h1 { font-size:clamp(1.9rem,5vw,2.4rem); font-weight:400; line-height:1.2; border-bottom:1px solid var(--line); padding-bottom:.5rem; }
+h2 { font-weight:400; margin-top:2rem; font-size:1.45rem; border-bottom:1px solid var(--line); padding-bottom:.3rem; }
+p,li { margin-bottom:.7rem; }
+.back,.kicker,.updated,.toc,footer { font-family:"Segoe UI",Helvetica,Arial,sans-serif; }
+.back,.updated,footer { font-size:.85rem; color:var(--mute); }
+.kicker { font-size:.78rem; text-transform:uppercase; letter-spacing:.08em; font-weight:700; color:var(--mute); }
+.lede { margin:1.4rem 0; }
+.toc { background:var(--well); border:1px solid var(--line); border-radius:4px; padding:1rem 1.3rem; margin:1.7rem 0; font-size:.9rem; }
+.toc ol { margin-bottom:0; padding-left:1.5rem; }
+.toc li { margin-bottom:.25rem; }
+.cite { font-size:.75em; vertical-align:super; }
+.cite a { text-decoration:none; }
+#references ~ ol { font-size:.9rem; overflow-wrap:anywhere; }
+footer { border-top:1px solid var(--line); margin-top:2rem; }
+.back-to-top { position:fixed; bottom:1.5rem; right:1.5rem; width:2.6rem; height:2.6rem; border-radius:50%; background:var(--bg); color:var(--ink); border:1px solid var(--line); cursor:pointer; opacity:0; visibility:hidden; }
+.back-to-top.visible { opacity:1; visibility:visible; }
+@media print { .back,.back-to-top { display:none !important; } main { max-width:none; padding:0; } }
+  </style>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"DefinedTerm","name":"EMV 3-D Secure (Online Card Authentication)","description":"EMV 3DS authentication, frictionless and challenge flows, and conditional fraud-liability effects.","url":"https://ngpestelos.com/reference/emv-3ds/","inDefinedTermSet":"https://ngpestelos.com/reference/"}</script>
+</head>
+<body class="reference">
+<main id="top">
+<p class="back"><a href="/reference/">&larr; Reference</a> &middot; <a href="/">Home</a> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a></p>
+<p class="kicker">Finance · Payments</p>
+<h1>EMV 3-D Secure (Online Card Authentication)</h1>
+<p class="updated">Reference entry &middot; last updated 20260910</p>
+<p class="lede"><strong>EMV 3-D Secure (EMV 3DS)</strong> is a protocol for authenticating consumers during card-not-present payments. It enables merchants and card issuers to exchange transaction, payment, and device information.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+<nav class="toc" aria-label="Contents"><strong>Contents</strong><ol>
+<li><a href="#first-principles">First principles: authentication</a></li>
+<li><a href="#flows">Frictionless and challenge flows</a></li>
+<li><a href="#liability">Fraud-liability effects</a></li>
+<li><a href="#sca">Strong customer authentication</a></li>
+<li><a href="#see-also">See also</a></li>
+<li><a href="#references">References</a></li>
+</ol></nav>
+<h2 id="first-principles">1. First principles: authentication</h2>
+<p>Authentication assesses whether the person using a card is its legitimate user. <a href="/reference/card-authorization-capture/">Authorization</a> is the payment approval stage. An authenticated customer can still encounter a declined payment.<span class="cite">[<a href="#ref2">2</a>]</span></p>
+<h2 id="flows">2. Frictionless and challenge flows</h2>
+<p>The issuer uses supplied information to assess a transaction. Authentication may complete without an extra customer step, or the issuer may request a challenge such as a one-time code or biometric check.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+<h2 id="liability">3. Fraud-liability effects</h2>
+<p>Successful 3DS authentication can shift liability for eligible fraud-related <a href="/reference/chargebacks/">chargebacks</a> to the issuer. Network rules, transaction eligibility, and exceptions determine the result. Authentication does not remove non-fraud disputes or the need to respond to an inquiry.<span class="cite">[<a href="#ref2">2</a>]</span></p>
+<h2 id="sca">4. Strong customer authentication</h2>
+<p>EMV 3DS can support strong customer authentication requirements, including those associated with European PSD2 rules. The protocol is used beyond that jurisdiction; its use alone does not establish regulatory compliance for every transaction.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+<h2 id="see-also">5. See also</h2>
+<ul><li><a href="/reference/online-payments/">Online Payments</a></li><li><a href="/reference/card-authorization-capture/">Card Authorization and Capture</a></li><li><a href="/reference/chargebacks/">Chargebacks (Card Payments)</a></li><li><a href="/reference/pci-dss/">PCI DSS (Payment Card Data Security)</a></li></ul>
+<h2 id="references">6. References</h2>
+<ol>
+<li id="ref1"><a href="https://www.emvco.com/emv-technologies/3-d-secure/">EMVCo. EMV 3-D Secure.</a></li>
+<li id="ref2"><a href="https://docs.stripe.com/payments/3d-secure/authentication-flow">Stripe. 3D Secure authentication flow.</a></li>
+</ol>
+<footer><p><a href="#top">Back to top</a></p></footer>
+</main>
+  <button id="backToTop" class="back-to-top" aria-label="Back to top" title="Back to top">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M18 15l-6-6-6 6"/>
+    </svg>
+  </button>
+
+  <script>
+    const btt = document.getElementById('backToTop');
+    window.addEventListener('scroll', () => {
+      if (window.scrollY > 250) {
+        btt.classList.add('visible');
+      } else {
+        btt.classList.remove('visible');
+      }
+    }, { passive: true });
+    btt.addEventListener('click', () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  </script>
+</body>
+</html>

--- a/reference/index.html
+++ b/reference/index.html
@@ -200,13 +200,14 @@
         <ul>
         <li><a href="/reference/acceleration-whiplash/">Acceleration Whiplash</a></li>
         <li><a href="/reference/ach/">ACH (United States)</a></li>
+        <li><a href="/reference/activemerchant/">ActiveMerchant (Ruby Payments Library)</a></li>
         <li><a href="/reference/adversarial-agent-review/">Adversarial Review</a></li>
         <li><a href="/reference/russell-norvig-agent/">Agent (Russell and Norvig Definition)</a></li>
         <li><a href="/reference/agent-harness/">Agent Harness</a></li>
         <li><a href="/reference/agent-substrate/">Agent Substrate</a></li>
         <li><a href="/reference/agentic-loops/">Agentic Loops</a></li>
-        <li><a href="/reference/agents/">AI Agents (LLM-Based)</a></li>
         <li><a href="/reference/ai-agent-observability/">AI Agent Observability</a></li>
+        <li><a href="/reference/agents/">AI Agents (LLM-Based)</a></li>
         <li><a href="/reference/amdahls-law/">Amdahl's Law</a></li>
         <li><a href="/reference/amps/">Amps (Electric Current)</a></li>
         <li><a href="/reference/andy-matuschak/">Andy Matuschak</a></li>
@@ -230,7 +231,9 @@
       <div class="letter-group" id="C">
         <h2 class="letter-heading">C</h2>
         <ul>
+        <li><a href="/reference/card-authorization-capture/">Card Authorization and Capture</a></li>
         <li><a href="/reference/chain-of-thought/">Chain-of-Thought</a></li>
+        <li><a href="/reference/chargebacks/">Chargebacks (Card Payments)</a></li>
         <li><a href="/reference/chiquito/">Chiquito (Actor)</a></li>
         <li><a href="/reference/chunked-prefill/">Chunked Prefill</a></li>
         <li><a href="/reference/clearing/">Clearing (Payments)</a></li>
@@ -261,6 +264,7 @@
         <ul>
         <li><a href="/reference/eastern-han/">Eastern Han</a></li>
         <li><a href="/reference/embeddings/">Embeddings</a></li>
+        <li><a href="/reference/emv-3ds/">EMV 3-D Secure (Online Card Authentication)</a></li>
         <li><a href="/reference/epistemology/">Epistemology</a></li>
         <li><a href="/reference/evergreen-notes/">Evergreen Notes</a></li>
         <li><a href="/reference/exponential-backoff/">Exponential Backoff</a></li>
@@ -364,6 +368,8 @@
         <h2 class="letter-heading">P</h2>
         <ul>
         <li><a href="/reference/parallelism/">Parallelism</a></li>
+        <li><a href="/reference/payment-service-providers/">Payment Service Providers (Merchant Payments)</a></li>
+        <li><a href="/reference/pci-dss/">PCI DSS (Payment Card Data Security)</a></li>
         <li><a href="/reference/perception/">Perception</a></li>
         <li><a href="/reference/perpetual-futures/">Perpetual Futures (Cryptocurrency)</a></li>
         <li><a href="/reference/personal-knowledge-management/">Personal Knowledge Management</a></li>

--- a/reference/online-payments-20260910/index.html
+++ b/reference/online-payments-20260910/index.html
@@ -1,0 +1,570 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Online Payments (Archived 20260910) · Reference · Nestor G Pestelos Jr</title>
+  <meta name="description" content="A citable ground-truth reference for online payments: card lifecycle, 4-party mechanics, CNP liability, PCI DSS, ActiveMerchant, and US/PH payment rails.">
+  <meta property="og:title" content="Online Payments (Archived 20260910) · Reference">
+  <meta property="og:description" content="A citable ground-truth reference for online payments: card lifecycle, 4-party mechanics, CNP liability, PCI DSS, ActiveMerchant, and US/PH payment rails.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://ngpestelos.com/reference/online-payments-20260910/">
+  <link rel="canonical" href="https://ngpestelos.com/reference/online-payments-20260910/">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=20260813f">
+  <link rel="icon" href="/favicon-192.png?v=20260813f" type="image/png" sizes="192x192">
+  <link rel="icon" href="/favicon-32.png?v=20260813f" type="image/png" sizes="32x32">
+  <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
+  <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="stylesheet" href="/style.css?v=20260903e">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TLBY8P4GG9');
+  </script>
+  <style>
+    :root {
+      --table-border: #eaecf0;
+      --table-header: #f2f4f7;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; scroll-behavior: smooth; }
+    body {
+      line-height: 1.6;
+    }
+    main {
+      max-width: 48rem;
+      margin: 0 auto;
+      padding: 1.4rem 1.4rem 4rem;
+    }
+    .back {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .back a { color: var(--link); text-decoration: none; }
+    .back a:hover { text-decoration: underline; }
+    .kicker {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.78rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--mute);
+      margin-bottom: 0.2rem;
+    }
+    h1 {
+      font-size: clamp(1.9rem, 5vw, 2.4rem);
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.4rem;
+      margin-bottom: 0.8rem;
+    }
+    .subtitle {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 1rem;
+      color: var(--mute);
+      margin-bottom: 1.6rem;
+      line-height: 1.5;
+    }
+    .toc {
+      background: var(--well);
+      border: 1px solid var(--line);
+      border-radius: 4px;
+      padding: 1.1rem 1.4rem;
+      margin-bottom: 2rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.9rem;
+    }
+    .toc h2 {
+      font-size: 1rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: 0.5rem;
+      color: var(--ink);
+    }
+    .toc-grid {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.3rem 0.6rem;
+      line-height: 1.4;
+    }
+    .toc-grid a {
+      color: var(--link);
+      text-decoration: none;
+    }
+    .toc-grid a:hover {
+      text-decoration: underline;
+    }
+    h2 {
+      font-size: 1.45rem;
+      font-weight: 700;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.3rem;
+      margin-top: 2.2rem;
+      margin-bottom: 0.9rem;
+      color: var(--ink);
+    }
+    h3 {
+      font-size: 1.15rem;
+      font-weight: 700;
+      margin-top: 1.4rem;
+      margin-bottom: 0.3rem;
+      color: var(--ink);
+    }
+    p {
+      margin-bottom: 1rem;
+    }
+    ul, ol {
+      margin-bottom: 1rem;
+      padding-left: 1.5rem;
+    }
+    li {
+      margin-bottom: 0.4rem;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1.2rem 0 1.8rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.88rem;
+    }
+    th, td {
+      border: 1px solid var(--line);
+      padding: 0.55rem 0.75rem;
+      text-align: left;
+      vertical-align: top;
+    }
+    th {
+      background: var(--well);
+      font-weight: 600;
+    }
+    code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.88em;
+      background: #f1f3f5;
+      padding: 0.15em 0.35em;
+      border-radius: 3px;
+    }
+    .def-box {
+      margin-bottom: 1.4rem;
+      padding-bottom: 0.8rem;
+      border-bottom: 1px dashed #d0d7de;
+    }
+    .def-box:last-child {
+      border-bottom: none;
+    }
+    .essays-box {
+      background: var(--well);
+      border: 1px solid var(--line);
+      border-left: 4px solid var(--link);
+      border-radius: 4px;
+      padding: 1rem 1.3rem;
+      margin-bottom: 1.8rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+    }
+    .essays-box h2 {
+      font-size: 0.95rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-top: 0;
+      margin-bottom: 0.5rem;
+      border-bottom: none;
+      padding-bottom: 0;
+      color: var(--ink);
+    }
+    .essays-box ul {
+      list-style: none;
+      padding-left: 0;
+      margin-bottom: 0;
+      font-size: 0.92rem;
+    }
+    .essays-box li {
+      margin-bottom: 0.4rem;
+    }
+    .essays-box li:last-child {
+      margin-bottom: 0;
+    }
+    .essays-box a {
+      color: var(--link);
+      text-decoration: none;
+    }
+    .essays-box a:hover {
+      text-decoration: underline;
+    }
+    .term-title {
+      font-weight: 700;
+      font-size: 1.05rem;
+      display: inline;
+    }
+    .term-desc {
+      display: inline;
+      margin-left: 0.35rem;
+    }
+    .related-links {
+      margin-top: 0.35rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.82rem;
+      color: var(--mute);
+    }
+    .related-links a {
+      color: var(--link);
+      text-decoration: none;
+    }
+    .related-links a:hover {
+      text-decoration: underline;
+    }
+    footer {
+      border-top: 1px solid var(--line);
+      margin-top: 3rem;
+      padding-top: 1.4rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+    }
+    footer h3 {
+      font-size: 0.95rem;
+      margin-top: 0;
+      margin-bottom: 0.5rem;
+    }
+    @media print {
+      .back {font-family:"Segoe UI", Helvetica, Arial, sans-serif;display: none;}
+    }
+      .back-to-top {
+      position: fixed;
+      bottom: 1.5rem;
+      right: 1.5rem;
+      width: 2.6rem;
+      height: 2.6rem;
+      border-radius: 50%;
+      background: var(--bg);
+      color: var(--ink);
+      border: 1px solid var(--line);
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      opacity: 0;
+      visibility: hidden;
+      transform: translateY(8px);
+      transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease, background 0.15s ease, border-color 0.15s ease;
+      z-index: 100;
+    }
+    .back-to-top.visible {
+      opacity: 1;
+      visibility: visible;
+      transform: translateY(0);
+    }
+    .back-to-top:hover {
+      background: var(--well);
+      border-color: var(--link);
+      color: var(--link);
+    }
+    .back-to-top:focus-visible {
+      outline: 2px solid var(--link);
+      outline-offset: 2px;
+    }
+    @media print {
+      .back-to-top { display: none !important; }
+    }
+  </style>
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"DefinedTerm","name":"Online Payments (Archived 20260910)","description":"A citable ground-truth reference for online payments: card lifecycle, 4-party mechanics, CNP liability, PCI DSS, ActiveMerchant, and US/PH payment rails.","url":"https://ngpestelos.com/reference/online-payments-20260910/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
+</head>
+<body class="reference">
+  <main>
+    <p class="back">Archived 20260910. This version preserves earlier claims. <a href="/reference/online-payments/">Read the current entry</a>.</p>
+    <p class="back"><a href="/reference/">← Reference</a> · <a href="/">Nestor G Pestelos Jr</a> · <a href="#" onclick="window.print(); return false;">Print this page</a></p>
+    <p class="kicker">Financial Technology · Payment Systems</p>
+    <h1>Online Payments</h1>
+    <p class="subtitle">A citable reference on how electronic money moves: 4-party card flows, CNP fraud mechanics, PCI DSS compliance, Ruby adapter abstractions, and US vs. Philippine interbank settlement rails.</p>
+
+    <div class="essays-box">
+      <h2>Essays in this Series (Travel Guide to Philippine Payments)</h2>
+      <ul>
+        <li>📖 <a href="/writing/us-and-philippine-payment-rails/"><strong>US and Philippine Payment Rails</strong></a> — Mapping equivalent wholesale, batch, and instant rails.</li>
+        <li>📖 <a href="/writing/instapay-is-not-ach/"><strong>InstaPay is Not ACH</strong></a> — Why customer-instant settlement is not RTGS interbank posting.</li>
+        <li>📖 <a href="/writing/payments-glossary/"><strong>Payments Glossary</strong></a> — The foundational vocabulary and stable anchor addresses for the series.</li>
+        <li>🌳 <a href="/trees/online-payments/"><strong>Online Payments Knowledge Tree</strong></a> — Prerequisite dependency graph and mastery frontier.</li>
+      </ul>
+    </div>
+
+    <div class="toc">
+      <h2>Jump to Section</h2>
+      <div class="toc-grid">
+        <a href="#core-model">Core Model</a> &middot;
+        <a href="#four-party">Four-Party Flow</a> &middot;
+        <a href="#lifecycle">Card Lifecycle</a> &middot;
+        <a href="#cnp-security">CNP &amp; Security</a> &middot;
+        <a href="#software-adapters">Software Adapters</a> &middot;
+        <a href="#rails-comparison">US vs. PH Rails</a> &middot;
+        <a href="#glossary-index">Term Glossary</a> &middot;
+        <a href="#sources">Sources</a>
+      </div>
+    </div>
+
+    <!-- Section 1: Core Model -->
+    <h2 id="core-model">1. The Core Split: Private Card Overlays vs. Public Rails</h2>
+    <p>
+      An electronic payment belongs to one of two fundamental architectures (detailed in <a href="/writing/us-and-philippine-payment-rails/">US and Philippine Payment Rails</a>):
+    </p>
+    <ol>
+      <li>
+        <strong>Private Card Overlays (Visa, Mastercard, Amex):</strong> The network operates a messaging switch. The cardholder's bank issues credit or debit; the merchant's bank receives funds days later. Authorization is an instantaneous hold, not a settlement.
+      </li>
+      <li>
+        <strong>Public Interbank Settlement Rails (Fedwire, PhilPaSSplus, ACH, InstaPay):</strong> Banks maintain reserve accounts directly with the central bank (Federal Reserve or Bangko Sentral ng Pilipinas). Settlement transfers sovereign central bank balances between depository institutions.
+      </li>
+    </ol>
+
+    <!-- Section 2: Four-Party Flow -->
+    <h2 id="four-party">2. The Four-Party Card Model</h2>
+    <p>
+      Open card networks operate across four distinct entities connected by the network switch:
+    </p>
+    <table>
+      <thead>
+        <tr>
+          <th>Role</th>
+          <th>Definition</th>
+          <th>Key Responsibility</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><strong id="cardholder">Cardholder</strong></td>
+          <td>The consumer presenting a Primary Account Number (PAN).</td>
+          <td>Initiates purchase; pays issuing bank per billing agreement.</td>
+        </tr>
+        <tr>
+          <td><strong id="merchant">Merchant</strong></td>
+          <td>The seller of goods or services.</td>
+          <td>Collects order details; presents auth request via gateway; pays merchant discount rate (MDR).</td>
+        </tr>
+        <tr>
+          <td><strong id="acquirer">Acquirer</strong></td>
+          <td>The merchant's acquiring bank.</td>
+          <td>Underwrites merchant risk; routes transactions through the card network; funds merchant bank accounts.</td>
+        </tr>
+        <tr>
+          <td><strong id="issuing-bank">Issuing Bank</strong></td>
+          <td>The cardholder's bank.</td>
+          <td>Holds cardholder account; approves/declines authorizations; holds default credit risk; receives interchange.</td>
+        </tr>
+        <tr>
+          <td><strong id="card-network">Card Network (Scheme)</strong></td>
+          <td>Visa, Mastercard, Discover (or 3-party closed loop Amex).</td>
+          <td>Maintains switch hardware and rules; routes messages; sets interchange tables and scheme assessments.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3 id="psp-collapse">The Payment Service Provider (PSP) Collapse</h3>
+    <p>
+      In legacy setups, merchants contracted separately with a <strong>Gateway</strong> (message encryption/routing), a <strong>Processor</strong> (network formatting), and an <strong>Acquirer</strong> (merchant account underwriting). Modern PSPs (e.g., Stripe, Adyen, Braintree) collapse all three into a single API contract and single payout schedule.
+    </p>
+
+    <!-- Section 3: Card Lifecycle -->
+    <h2 id="lifecycle">3. Card Transaction Lifecycle</h2>
+    <p>
+      A card transaction moves through three distinct chronological phases:
+    </p>
+    <table>
+      <thead>
+        <tr>
+          <th>Phase</th>
+          <th>Timeframe</th>
+          <th>What Actually Happens</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><strong id="authorization">1. Authorization</strong></td>
+          <td>1–3 seconds</td>
+          <td>Issuer checks credit limit and fraud rules. Reserves funds on the cardholder account and returns an auth code. <em>No money moves between banks.</em></td>
+        </tr>
+        <tr>
+          <td><strong id="capture">2. Capture</strong></td>
+          <td>At shipment or EOD</td>
+          <td>Merchant signals that goods were delivered and claims the authorized hold. Can capture full, partial, or multiple amounts against an open authorization.</td>
+        </tr>
+        <tr>
+          <td><strong id="settlement">3. Clearing &amp; Settlement</strong></td>
+          <td>1–3 business days</td>
+          <td>Acquirer submits captured batch to network. Network nets positions across banks. Issuer debits cardholder; acquirer credits merchant minus interchange and fees.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <!-- Section 4: CNP & Security -->
+    <h2 id="cnp-security">4. Card-Not-Present (CNP) &amp; Security Regime</h2>
+    
+    <h3 id="merchant-liability">CNP Fraud &amp; Liability</h3>
+    <p>
+      In <strong>Card-Present (CP)</strong> transactions with EMV chip-and-PIN, fraud liability rests with the party failing to support EMV (usually the issuer). In <strong>Card-Not-Present (CNP)</strong> e-commerce transactions, fraudulent chargebacks land by default on the <strong>merchant</strong>, who loses both the merchandise and the purchase price, plus a penalty fee.
+    </p>
+
+    <h3 id="3-d-secure">3-D Secure (EMV 3DS) &amp; PSD2 SCA</h3>
+    <p>
+      3-D Secure (3DS v2) is an XML/JSON messaging protocol that enables authentication directly between the consumer and their issuing bank prior to authorization.
+    </p>
+    <ul>
+      <li><strong>Frictionless Flow:</strong> Merchant passes device and behavioral telemetry to the issuer. If risk is low, authentication passes invisibly.</li>
+      <li><strong>Challenge Flow:</strong> High-risk transactions trigger step-up authentication (biometric, SMS OTP, or banking app approval).</li>
+      <li><strong>Liability Shift:</strong> Passing 3DS shifts the liability for fraudulent chargebacks from the merchant to the issuing bank.</li>
+    </ul>
+
+    <h3 id="pci-dss">PCI DSS &amp; Scope Reduction</h3>
+    <p>
+      The Payment Card Industry Data Security Standard (PCI DSS) mandates security controls for entities storing, processing, or transmitting Cardholder Data (CHD).
+    </p>
+    <ul>
+      <li><strong>SAQ A (Hosted Fields / iFrames):</strong> Merchant servers never touch or receive the Primary Account Number (PAN). Card data is captured directly by PSP JavaScript into secure iframes. Self-Assessment Questionnaire A is minimal (~22 requirements).</li>
+      <li><strong>SAQ D (Direct API Intake):</strong> Card PAN touches merchant servers before forwarding. Requires full PCI DSS validation (~300+ technical controls and annual penetration testing).</li>
+    </ul>
+
+    <!-- Section 5: Software Adapters -->
+    <h2 id="software-adapters">5. Software Abstractions: ActiveMerchant &amp; Rails</h2>
+    <p>
+      <strong id="activemerchant">ActiveMerchant</strong> is an open-source Ruby payment library extracted by Shopify in June 2006. It standardizes disparate bank APIs behind a unified object-oriented interface:
+    </p>
+    <ul>
+      <li><strong>Standard Verbs:</strong> <code>authorize(money, credit_card, options)</code>, <code>capture(money, authorization, options)</code>, <code>purchase(money, credit_card, options)</code>, <code>void(authorization, options)</code>, <code>refund(money, identification, options)</code>.</li>
+      <li><strong>Integer Cents Rule:</strong> All monetary amounts are passed as integers representing the currency subunit (e.g. <code>4000</code> for $40.00 USD) to prevent floating-point arithmetic errors.</li>
+      <li><strong>Response Envelope:</strong> Returns a standardized <code>Response</code> object indicating <code>success?</code>, <code>authorization</code> token, raw error messages, and AVS/CVC match codes.</li>
+    </ul>
+
+    <!-- Section 6: Rails Comparison -->
+    <h2 id="rails-comparison">6. Interbank Rails: United States vs. Philippines</h2>
+    <p>
+      A detailed architectural comparison of US and Philippine settlement mechanisms is explored in <a href="/writing/us-and-philippine-payment-rails/">US and Philippine Payment Rails</a> and <a href="/writing/instapay-is-not-ach/">InstaPay is Not ACH</a>.
+    </p>
+    <table>
+      <thead>
+        <tr>
+          <th>Payment Job</th>
+          <th>United States Rail</th>
+          <th>Philippine Rail</th>
+          <th>Settlement Mechanism</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><strong>Wholesale / High-Value RTGS</strong></td>
+          <td><strong id="fedwire">Fedwire Funds</strong> (Federal Reserve)</td>
+          <td><strong id="philpassplus">PhilPaSSplus</strong> (BSP)</td>
+          <td>Real-time gross settlement; immediate central bank account debit/credit.</td>
+        </tr>
+        <tr>
+          <td><strong>Planned Batch ACH</strong></td>
+          <td><strong id="ach">ACH</strong> (FedACH / EPN; Nacha rules)</td>
+          <td><strong id="pesonet">PESONet</strong> (PCHC; NRPS policy)</td>
+          <td>Net settlement across multiple scheduled batch windows during business days.</td>
+        </tr>
+        <tr>
+          <td><strong>Instant Retail Account-to-Account</strong></td>
+          <td><strong id="fednow">FedNow</strong> / RTP (The Clearing House)</td>
+          <td><strong id="instapay">InstaPay</strong> (BancNet switch; PhilPaSSplus net)</td>
+          <td>FedNow settles instantly per item at Fed; InstaPay settles customer instant 24/7 with prefunded collateral nets on PhilPaSSplus.</td>
+        </tr>
+        <tr>
+          <td><strong>QR Interoperability Standard</strong></td>
+          <td>Proprietary (Venmo, Zelle, Cash App)</td>
+          <td><strong id="qr-ph">QR Ph</strong> (EMVCo national QR standard)</td>
+          <td>Routes P2P and P2M transactions across participating banks and e-wallets via InstaPay/PESONet.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <!-- Section 7: Glossary Index -->
+    <h2 id="glossary-index">7. Comprehensive Glossary Index</h2>
+
+    <div class="def-box">
+      <h3 class="term-title" id="avs-and-cvc">AVS and CVC:</h3>
+      <p class="term-desc">Address Verification Service checks the cardholder's numeric street address and ZIP against issuer records. Card Verification Code (CVV2/CVC2) checks the 3- or 4-digit code on the card. Both reduce fraud but do not trigger liability shifts.</p>
+    </div>
+
+    <div class="def-box">
+      <h3 class="term-title" id="bancnet">BancNet:</h3>
+      <p class="term-desc">The consortium and technical switch operator designated by the Bangko Sentral ng Pilipinas to process InstaPay retail transactions in the Philippines.</p>
+    </div>
+
+    <div class="def-box">
+      <h3 class="term-title" id="chargeback">Chargeback:</h3>
+      <p class="term-desc">A forced reversal of funds initiated by the issuing bank on behalf of the cardholder, citing fraud, non-delivery, or authorization error.</p>
+    </div>
+
+    <div class="def-box">
+      <h3 class="term-title" id="interchange-fee">Interchange Fee:</h3>
+      <p class="term-desc">The fee paid by the acquiring bank to the issuing bank on every card transaction to compensate the issuer for credit risk and processing costs.</p>
+    </div>
+
+    <div class="def-box">
+      <h3 class="term-title" id="nacha">Nacha:</h3>
+      <p class="term-desc">National Automated Clearinghouse Association. The private governance body that authors operating rules and formats for the US ACH network.</p>
+    </div>
+
+    <div class="def-box">
+      <h3 class="term-title" id="nrps">NRPS:</h3>
+      <p class="term-desc">National Retail Payment System. The regulatory policy framework established by BSP Circular 980 in 2017 governing interoperable Philippine retail electronic payment schemes (InstaPay and PESONet).</p>
+    </div>
+
+    <div class="def-box">
+      <h3 class="term-title" id="pan">PAN:</h3>
+      <p class="term-desc">Primary Account Number. The 15- or 16-digit number embossed on a payment card that identifies the card scheme, issuer bank identification number (BIN), and individual account.</p>
+    </div>
+
+    <div class="def-box">
+      <h3 class="term-title" id="pchc">PCHC:</h3>
+      <p class="term-desc">Philippine Clearing House Corporation. The clearing operator for checks, PESONet batch electronic transfers, PDDTS (domestic USD transfers), and PhP-USD PvP.</p>
+    </div>
+
+    <div class="def-box">
+      <h3 class="term-title" id="ra-11127">RA 11127:</h3>
+      <p class="term-desc">The National Payment Systems Act of 2018. The Philippine statute granting Bangko Sentral ng Pilipinas comprehensive regulatory oversight, licensing, and operational authority over all national payment systems.</p>
+    </div>
+
+    <!-- Section 8: Sources -->
+    <footer id="sources">
+      <h3>Sources &amp; Primary Authorities</h3>
+      <ul>
+        <li>Federal Reserve: <a href="https://www.federalreserve.gov/paymentsystems.htm" target="_blank" rel="noopener">Payment System Overview &amp; Research</a></li>
+        <li>Nacha: <a href="https://www.nacha.org/rules" target="_blank" rel="noopener">Nacha Operating Rules &amp; Guidelines</a></li>
+        <li>Bangko Sentral ng Pilipinas: <a href="https://www.bsp.gov.ph/Regulations/Issuances/2017/c980.pdf" target="_blank" rel="noopener">BSP Circular 980 (NRPS Framework)</a> &middot; <a href="https://www.bsp.gov.ph/Pages/Regulations/RA11127.pdf" target="_blank" rel="noopener">RA 11127 (NPSA)</a></li>
+        <li>PCI Security Standards Council: <a href="https://www.pcisecuritystandards.org/" target="_blank" rel="noopener">PCI DSS v4.0 Specification</a></li>
+        <li>EMVCo: <a href="https://www.emvco.com/emv-technologies/3d-secure/" target="_blank" rel="noopener">EMV 3-D Secure Protocol and Core Functions</a></li>
+        <li>Shopify / ActiveMerchant: <a href="https://github.com/activemerchant/active_merchant" target="_blank" rel="noopener">ActiveMerchant GitHub Repository</a></li>
+      </ul>
+      <p style="margin-top: 1rem;">
+        Related: <a href="/trees/online-payments/">Online Payments Knowledge Tree</a> &middot; <a href="/writing/payments-glossary/">Payments Glossary</a> &middot; <a href="/writing/us-and-philippine-payment-rails/">US &amp; PH Payment Rails</a>
+      </p>
+    </footer>
+  </main>
+  <button id="backToTop" class="back-to-top" aria-label="Back to top" title="Back to top">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M18 15l-6-6-6 6"/>
+    </svg>
+  </button>
+
+  <script>
+    const btt = document.getElementById('backToTop');
+    window.addEventListener('scroll', () => {
+      if (window.scrollY > 250) {
+        btt.classList.add('visible');
+      } else {
+        btt.classList.remove('visible');
+      }
+    }, { passive: true });
+    btt.addEventListener('click', () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  </script>
+</body>
+</html>

--- a/reference/online-payments/index.html
+++ b/reference/online-payments/index.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Online Payments · Reference · Nestor G Pestelos Jr</title>
-  <meta name="description" content="A citable ground-truth reference for online payments: card lifecycle, 4-party mechanics, CNP liability, PCI DSS, ActiveMerchant, and US/PH payment rails.">
+  <meta name="description" content="Online payment instruments, participants, card processing, security, and Philippine payment systems.">
   <meta property="og:title" content="Online Payments · Reference">
-  <meta property="og:description" content="A citable ground-truth reference for online payments: card lifecycle, 4-party mechanics, CNP liability, PCI DSS, ActiveMerchant, and US/PH payment rails.">
+  <meta property="og:description" content="Online payment instruments, participants, card processing, security, and Philippine payment systems.">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://ngpestelos.com/reference/online-payments/">
   <link rel="canonical" href="https://ngpestelos.com/reference/online-payments/">
@@ -25,527 +25,92 @@
     gtag('config', 'G-TLBY8P4GG9');
   </script>
   <style>
-    :root {
-      --table-border: #eaecf0;
-      --table-header: #f2f4f7;
-    }
-    * { box-sizing: border-box; margin: 0; padding: 0; }
-    html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; scroll-behavior: smooth; }
-    body {
-      line-height: 1.6;
-    }
-    main {
-      max-width: 48rem;
-      margin: 0 auto;
-      padding: 1.4rem 1.4rem 4rem;
-    }
-    .back {
-      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
-      font-size: 0.85rem;
-      color: var(--mute);
-      margin-bottom: 1.4rem;
-    }
-    .back a { color: var(--link); text-decoration: none; }
-    .back a:hover { text-decoration: underline; }
-    .kicker {
-      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
-      font-size: 0.78rem;
-      font-weight: 700;
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-      color: var(--mute);
-      margin-bottom: 0.2rem;
-    }
-    h1 {
-      font-size: clamp(1.9rem, 5vw, 2.4rem);
-      font-weight: 400;
-      border-bottom: 1px solid var(--line);
-      padding-bottom: 0.4rem;
-      margin-bottom: 0.8rem;
-    }
-    .subtitle {
-      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
-      font-size: 1rem;
-      color: var(--mute);
-      margin-bottom: 1.6rem;
-      line-height: 1.5;
-    }
-    .toc {
-      background: var(--well);
-      border: 1px solid var(--line);
-      border-radius: 4px;
-      padding: 1.1rem 1.4rem;
-      margin-bottom: 2rem;
-      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
-      font-size: 0.9rem;
-    }
-    .toc h2 {
-      font-size: 1rem;
-      font-weight: 700;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-      margin-bottom: 0.5rem;
-      color: var(--ink);
-    }
-    .toc-grid {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.3rem 0.6rem;
-      line-height: 1.4;
-    }
-    .toc-grid a {
-      color: var(--link);
-      text-decoration: none;
-    }
-    .toc-grid a:hover {
-      text-decoration: underline;
-    }
-    h2 {
-      font-size: 1.45rem;
-      font-weight: 700;
-      border-bottom: 1px solid var(--line);
-      padding-bottom: 0.3rem;
-      margin-top: 2.2rem;
-      margin-bottom: 0.9rem;
-      color: var(--ink);
-    }
-    h3 {
-      font-size: 1.15rem;
-      font-weight: 700;
-      margin-top: 1.4rem;
-      margin-bottom: 0.3rem;
-      color: var(--ink);
-    }
-    p {
-      margin-bottom: 1rem;
-    }
-    ul, ol {
-      margin-bottom: 1rem;
-      padding-left: 1.5rem;
-    }
-    li {
-      margin-bottom: 0.4rem;
-    }
-    table {
-      width: 100%;
-      border-collapse: collapse;
-      margin: 1.2rem 0 1.8rem;
-      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
-      font-size: 0.88rem;
-    }
-    th, td {
-      border: 1px solid var(--line);
-      padding: 0.55rem 0.75rem;
-      text-align: left;
-      vertical-align: top;
-    }
-    th {
-      background: var(--well);
-      font-weight: 600;
-    }
-    code {
-      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-      font-size: 0.88em;
-      background: #f1f3f5;
-      padding: 0.15em 0.35em;
-      border-radius: 3px;
-    }
-    .def-box {
-      margin-bottom: 1.4rem;
-      padding-bottom: 0.8rem;
-      border-bottom: 1px dashed #d0d7de;
-    }
-    .def-box:last-child {
-      border-bottom: none;
-    }
-    .essays-box {
-      background: var(--well);
-      border: 1px solid var(--line);
-      border-left: 4px solid var(--link);
-      border-radius: 4px;
-      padding: 1rem 1.3rem;
-      margin-bottom: 1.8rem;
-      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
-    }
-    .essays-box h2 {
-      font-size: 0.95rem;
-      font-weight: 700;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-      margin-top: 0;
-      margin-bottom: 0.5rem;
-      border-bottom: none;
-      padding-bottom: 0;
-      color: var(--ink);
-    }
-    .essays-box ul {
-      list-style: none;
-      padding-left: 0;
-      margin-bottom: 0;
-      font-size: 0.92rem;
-    }
-    .essays-box li {
-      margin-bottom: 0.4rem;
-    }
-    .essays-box li:last-child {
-      margin-bottom: 0;
-    }
-    .essays-box a {
-      color: var(--link);
-      text-decoration: none;
-    }
-    .essays-box a:hover {
-      text-decoration: underline;
-    }
-    .term-title {
-      font-weight: 700;
-      font-size: 1.05rem;
-      display: inline;
-    }
-    .term-desc {
-      display: inline;
-      margin-left: 0.35rem;
-    }
-    .related-links {
-      margin-top: 0.35rem;
-      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
-      font-size: 0.82rem;
-      color: var(--mute);
-    }
-    .related-links a {
-      color: var(--link);
-      text-decoration: none;
-    }
-    .related-links a:hover {
-      text-decoration: underline;
-    }
-    footer {
-      border-top: 1px solid var(--line);
-      margin-top: 3rem;
-      padding-top: 1.4rem;
-      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
-      font-size: 0.85rem;
-      color: var(--mute);
-    }
-    footer h3 {
-      font-size: 0.95rem;
-      margin-top: 0;
-      margin-bottom: 0.5rem;
-    }
-    @media print {
-      .back {font-family:"Segoe UI", Helvetica, Arial, sans-serif;display: none;}
-    }
-      .back-to-top {
-      position: fixed;
-      bottom: 1.5rem;
-      right: 1.5rem;
-      width: 2.6rem;
-      height: 2.6rem;
-      border-radius: 50%;
-      background: var(--bg);
-      color: var(--ink);
-      border: 1px solid var(--line);
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      cursor: pointer;
-      opacity: 0;
-      visibility: hidden;
-      transform: translateY(8px);
-      transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease, background 0.15s ease, border-color 0.15s ease;
-      z-index: 100;
-    }
-    .back-to-top.visible {
-      opacity: 1;
-      visibility: visible;
-      transform: translateY(0);
-    }
-    .back-to-top:hover {
-      background: var(--well);
-      border-color: var(--link);
-      color: var(--link);
-    }
-    .back-to-top:focus-visible {
-      outline: 2px solid var(--link);
-      outline-offset: 2px;
-    }
-    @media print {
-      .back-to-top { display: none !important; }
-    }
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; -webkit-text-size-adjust:100%; text-size-adjust:100%; }
+body { line-height:1.65; }
+main { max-width:48rem; margin:auto; padding:1.4rem 1.4rem 4rem; }
+h1 { font-size:clamp(1.9rem,5vw,2.4rem); font-weight:400; line-height:1.2; border-bottom:1px solid var(--line); padding-bottom:.5rem; }
+h2 { font-weight:400; margin-top:2rem; font-size:1.45rem; border-bottom:1px solid var(--line); padding-bottom:.3rem; }
+p,li { margin-bottom:.7rem; }
+.back,.kicker,.updated,.toc,footer { font-family:"Segoe UI",Helvetica,Arial,sans-serif; }
+.back,.updated,footer { font-size:.85rem; color:var(--mute); }
+.kicker { font-size:.78rem; text-transform:uppercase; letter-spacing:.08em; font-weight:700; color:var(--mute); }
+.lede { margin:1.4rem 0; }
+.toc { background:var(--well); border:1px solid var(--line); border-radius:4px; padding:1rem 1.3rem; margin:1.7rem 0; font-size:.9rem; }
+.toc ol { margin-bottom:0; padding-left:1.5rem; }
+.toc li { margin-bottom:.25rem; }
+.cite { font-size:.75em; vertical-align:super; }
+.cite a { text-decoration:none; }
+#references ~ ol { font-size:.9rem; overflow-wrap:anywhere; }
+footer { border-top:1px solid var(--line); margin-top:2rem; }
+.back-to-top { position:fixed; bottom:1.5rem; right:1.5rem; width:2.6rem; height:2.6rem; border-radius:50%; background:var(--bg); color:var(--ink); border:1px solid var(--line); cursor:pointer; opacity:0; visibility:hidden; }
+.back-to-top.visible { opacity:1; visibility:visible; }
+@media print { .back,.back-to-top { display:none !important; } main { max-width:none; padding:0; } }
   </style>
-  <script type="application/ld+json">
-{"@context":"https://schema.org","@type":"DefinedTerm","name":"Online Payments","description":"A citable ground-truth reference for online payments: card lifecycle, 4-party mechanics, CNP liability, PCI DSS, ActiveMerchant, and US/PH payment rails.","url":"https://ngpestelos.com/reference/online-payments/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
-  </script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"DefinedTerm","name":"Online Payments","description":"Online payment instruments, participants, card processing, security, and Philippine payment systems.","url":"https://ngpestelos.com/reference/online-payments/","inDefinedTermSet":"https://ngpestelos.com/reference/"}</script>
 </head>
 <body class="reference">
-  <main>
-    <p class="back"><a href="/reference/">← Reference</a> · <a href="/">Nestor G Pestelos Jr</a> · <a href="#" onclick="window.print(); return false;">Print this page</a></p>
-    <p class="kicker">Financial Technology · Payment Systems</p>
-    <h1>Online Payments</h1>
-    <p class="subtitle">A citable reference on how electronic money moves: 4-party card flows, CNP fraud mechanics, PCI DSS compliance, Ruby adapter abstractions, and US vs. Philippine interbank settlement rails.</p>
-
-    <div class="essays-box">
-      <h2>Essays in this Series (Travel Guide to Philippine Payments)</h2>
-      <ul>
-        <li>📖 <a href="/writing/us-and-philippine-payment-rails/"><strong>US and Philippine Payment Rails</strong></a> — Mapping equivalent wholesale, batch, and instant rails.</li>
-        <li>📖 <a href="/writing/instapay-is-not-ach/"><strong>InstaPay is Not ACH</strong></a> — Why customer-instant settlement is not RTGS interbank posting.</li>
-        <li>📖 <a href="/writing/payments-glossary/"><strong>Payments Glossary</strong></a> — The foundational vocabulary and stable anchor addresses for the series.</li>
-        <li>🌳 <a href="/trees/online-payments/"><strong>Online Payments Knowledge Tree</strong></a> — Prerequisite dependency graph and mastery frontier.</li>
-      </ul>
-    </div>
-
-    <div class="toc">
-      <h2>Jump to Section</h2>
-      <div class="toc-grid">
-        <a href="#core-model">Core Model</a> &middot;
-        <a href="#four-party">Four-Party Flow</a> &middot;
-        <a href="#lifecycle">Card Lifecycle</a> &middot;
-        <a href="#cnp-security">CNP &amp; Security</a> &middot;
-        <a href="#software-adapters">Software Adapters</a> &middot;
-        <a href="#rails-comparison">US vs. PH Rails</a> &middot;
-        <a href="#glossary-index">Term Glossary</a> &middot;
-        <a href="#sources">Sources</a>
-      </div>
-    </div>
-
-    <!-- Section 1: Core Model -->
-    <h2 id="core-model">1. The Core Split: Private Card Overlays vs. Public Rails</h2>
-    <p>
-      An electronic payment belongs to one of two fundamental architectures (detailed in <a href="/writing/us-and-philippine-payment-rails/">US and Philippine Payment Rails</a>):
-    </p>
-    <ol>
-      <li>
-        <strong>Private Card Overlays (Visa, Mastercard, Amex):</strong> The network operates a messaging switch. The cardholder's bank issues credit or debit; the merchant's bank receives funds days later. Authorization is an instantaneous hold, not a settlement.
-      </li>
-      <li>
-        <strong>Public Interbank Settlement Rails (Fedwire, PhilPaSSplus, ACH, InstaPay):</strong> Banks maintain reserve accounts directly with the central bank (Federal Reserve or Bangko Sentral ng Pilipinas). Settlement transfers sovereign central bank balances between depository institutions.
-      </li>
-    </ol>
-
-    <!-- Section 2: Four-Party Flow -->
-    <h2 id="four-party">2. The Four-Party Card Model</h2>
-    <p>
-      Open card networks operate across four distinct entities connected by the network switch:
-    </p>
-    <table>
-      <thead>
-        <tr>
-          <th>Role</th>
-          <th>Definition</th>
-          <th>Key Responsibility</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><strong id="cardholder">Cardholder</strong></td>
-          <td>The consumer presenting a Primary Account Number (PAN).</td>
-          <td>Initiates purchase; pays issuing bank per billing agreement.</td>
-        </tr>
-        <tr>
-          <td><strong id="merchant">Merchant</strong></td>
-          <td>The seller of goods or services.</td>
-          <td>Collects order details; presents auth request via gateway; pays merchant discount rate (MDR).</td>
-        </tr>
-        <tr>
-          <td><strong id="acquirer">Acquirer</strong></td>
-          <td>The merchant's acquiring bank.</td>
-          <td>Underwrites merchant risk; routes transactions through the card network; funds merchant bank accounts.</td>
-        </tr>
-        <tr>
-          <td><strong id="issuing-bank">Issuing Bank</strong></td>
-          <td>The cardholder's bank.</td>
-          <td>Holds cardholder account; approves/declines authorizations; holds default credit risk; receives interchange.</td>
-        </tr>
-        <tr>
-          <td><strong id="card-network">Card Network (Scheme)</strong></td>
-          <td>Visa, Mastercard, Discover (or 3-party closed loop Amex).</td>
-          <td>Maintains switch hardware and rules; routes messages; sets interchange tables and scheme assessments.</td>
-        </tr>
-      </tbody>
-    </table>
-
-    <h3 id="psp-collapse">The Payment Service Provider (PSP) Collapse</h3>
-    <p>
-      In legacy setups, merchants contracted separately with a <strong>Gateway</strong> (message encryption/routing), a <strong>Processor</strong> (network formatting), and an <strong>Acquirer</strong> (merchant account underwriting). Modern PSPs (e.g., Stripe, Adyen, Braintree) collapse all three into a single API contract and single payout schedule.
-    </p>
-
-    <!-- Section 3: Card Lifecycle -->
-    <h2 id="lifecycle">3. Card Transaction Lifecycle</h2>
-    <p>
-      A card transaction moves through three distinct chronological phases:
-    </p>
-    <table>
-      <thead>
-        <tr>
-          <th>Phase</th>
-          <th>Timeframe</th>
-          <th>What Actually Happens</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><strong id="authorization">1. Authorization</strong></td>
-          <td>1–3 seconds</td>
-          <td>Issuer checks credit limit and fraud rules. Reserves funds on the cardholder account and returns an auth code. <em>No money moves between banks.</em></td>
-        </tr>
-        <tr>
-          <td><strong id="capture">2. Capture</strong></td>
-          <td>At shipment or EOD</td>
-          <td>Merchant signals that goods were delivered and claims the authorized hold. Can capture full, partial, or multiple amounts against an open authorization.</td>
-        </tr>
-        <tr>
-          <td><strong id="settlement">3. Clearing &amp; Settlement</strong></td>
-          <td>1–3 business days</td>
-          <td>Acquirer submits captured batch to network. Network nets positions across banks. Issuer debits cardholder; acquirer credits merchant minus interchange and fees.</td>
-        </tr>
-      </tbody>
-    </table>
-
-    <!-- Section 4: CNP & Security -->
-    <h2 id="cnp-security">4. Card-Not-Present (CNP) &amp; Security Regime</h2>
-    
-    <h3 id="merchant-liability">CNP Fraud &amp; Liability</h3>
-    <p>
-      In <strong>Card-Present (CP)</strong> transactions with EMV chip-and-PIN, fraud liability rests with the party failing to support EMV (usually the issuer). In <strong>Card-Not-Present (CNP)</strong> e-commerce transactions, fraudulent chargebacks land by default on the <strong>merchant</strong>, who loses both the merchandise and the purchase price, plus a penalty fee.
-    </p>
-
-    <h3 id="3-d-secure">3-D Secure (EMV 3DS) &amp; PSD2 SCA</h3>
-    <p>
-      3-D Secure (3DS v2) is an XML/JSON messaging protocol that enables authentication directly between the consumer and their issuing bank prior to authorization.
-    </p>
-    <ul>
-      <li><strong>Frictionless Flow:</strong> Merchant passes device and behavioral telemetry to the issuer. If risk is low, authentication passes invisibly.</li>
-      <li><strong>Challenge Flow:</strong> High-risk transactions trigger step-up authentication (biometric, SMS OTP, or banking app approval).</li>
-      <li><strong>Liability Shift:</strong> Passing 3DS shifts the liability for fraudulent chargebacks from the merchant to the issuing bank.</li>
-    </ul>
-
-    <h3 id="pci-dss">PCI DSS &amp; Scope Reduction</h3>
-    <p>
-      The Payment Card Industry Data Security Standard (PCI DSS) mandates security controls for entities storing, processing, or transmitting Cardholder Data (CHD).
-    </p>
-    <ul>
-      <li><strong>SAQ A (Hosted Fields / iFrames):</strong> Merchant servers never touch or receive the Primary Account Number (PAN). Card data is captured directly by PSP JavaScript into secure iframes. Self-Assessment Questionnaire A is minimal (~22 requirements).</li>
-      <li><strong>SAQ D (Direct API Intake):</strong> Card PAN touches merchant servers before forwarding. Requires full PCI DSS validation (~300+ technical controls and annual penetration testing).</li>
-    </ul>
-
-    <!-- Section 5: Software Adapters -->
-    <h2 id="software-adapters">5. Software Abstractions: ActiveMerchant &amp; Rails</h2>
-    <p>
-      <strong id="activemerchant">ActiveMerchant</strong> is an open-source Ruby payment library extracted by Shopify in June 2006. It standardizes disparate bank APIs behind a unified object-oriented interface:
-    </p>
-    <ul>
-      <li><strong>Standard Verbs:</strong> <code>authorize(money, credit_card, options)</code>, <code>capture(money, authorization, options)</code>, <code>purchase(money, credit_card, options)</code>, <code>void(authorization, options)</code>, <code>refund(money, identification, options)</code>.</li>
-      <li><strong>Integer Cents Rule:</strong> All monetary amounts are passed as integers representing the currency subunit (e.g. <code>4000</code> for $40.00 USD) to prevent floating-point arithmetic errors.</li>
-      <li><strong>Response Envelope:</strong> Returns a standardized <code>Response</code> object indicating <code>success?</code>, <code>authorization</code> token, raw error messages, and AVS/CVC match codes.</li>
-    </ul>
-
-    <!-- Section 6: Rails Comparison -->
-    <h2 id="rails-comparison">6. Interbank Rails: United States vs. Philippines</h2>
-    <p>
-      A detailed architectural comparison of US and Philippine settlement mechanisms is explored in <a href="/writing/us-and-philippine-payment-rails/">US and Philippine Payment Rails</a> and <a href="/writing/instapay-is-not-ach/">InstaPay is Not ACH</a>.
-    </p>
-    <table>
-      <thead>
-        <tr>
-          <th>Payment Job</th>
-          <th>United States Rail</th>
-          <th>Philippine Rail</th>
-          <th>Settlement Mechanism</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><strong>Wholesale / High-Value RTGS</strong></td>
-          <td><strong id="fedwire">Fedwire Funds</strong> (Federal Reserve)</td>
-          <td><strong id="philpassplus">PhilPaSSplus</strong> (BSP)</td>
-          <td>Real-time gross settlement; immediate central bank account debit/credit.</td>
-        </tr>
-        <tr>
-          <td><strong>Planned Batch ACH</strong></td>
-          <td><strong id="ach">ACH</strong> (FedACH / EPN; Nacha rules)</td>
-          <td><strong id="pesonet">PESONet</strong> (PCHC; NRPS policy)</td>
-          <td>Net settlement across multiple scheduled batch windows during business days.</td>
-        </tr>
-        <tr>
-          <td><strong>Instant Retail Account-to-Account</strong></td>
-          <td><strong id="fednow">FedNow</strong> / RTP (The Clearing House)</td>
-          <td><strong id="instapay">InstaPay</strong> (BancNet switch; PhilPaSSplus net)</td>
-          <td>FedNow settles instantly per item at Fed; InstaPay settles customer instant 24/7 with prefunded collateral nets on PhilPaSSplus.</td>
-        </tr>
-        <tr>
-          <td><strong>QR Interoperability Standard</strong></td>
-          <td>Proprietary (Venmo, Zelle, Cash App)</td>
-          <td><strong id="qr-ph">QR Ph</strong> (EMVCo national QR standard)</td>
-          <td>Routes P2P and P2M transactions across participating banks and e-wallets via InstaPay/PESONet.</td>
-        </tr>
-      </tbody>
-    </table>
-
-    <!-- Section 7: Glossary Index -->
-    <h2 id="glossary-index">7. Comprehensive Glossary Index</h2>
-
-    <div class="def-box">
-      <h3 class="term-title" id="avs-and-cvc">AVS and CVC:</h3>
-      <p class="term-desc">Address Verification Service checks the cardholder's numeric street address and ZIP against issuer records. Card Verification Code (CVV2/CVC2) checks the 3- or 4-digit code on the card. Both reduce fraud but do not trigger liability shifts.</p>
-    </div>
-
-    <div class="def-box">
-      <h3 class="term-title" id="bancnet">BancNet:</h3>
-      <p class="term-desc">The consortium and technical switch operator designated by the Bangko Sentral ng Pilipinas to process InstaPay retail transactions in the Philippines.</p>
-    </div>
-
-    <div class="def-box">
-      <h3 class="term-title" id="chargeback">Chargeback:</h3>
-      <p class="term-desc">A forced reversal of funds initiated by the issuing bank on behalf of the cardholder, citing fraud, non-delivery, or authorization error.</p>
-    </div>
-
-    <div class="def-box">
-      <h3 class="term-title" id="interchange-fee">Interchange Fee:</h3>
-      <p class="term-desc">The fee paid by the acquiring bank to the issuing bank on every card transaction to compensate the issuer for credit risk and processing costs.</p>
-    </div>
-
-    <div class="def-box">
-      <h3 class="term-title" id="nacha">Nacha:</h3>
-      <p class="term-desc">National Automated Clearinghouse Association. The private governance body that authors operating rules and formats for the US ACH network.</p>
-    </div>
-
-    <div class="def-box">
-      <h3 class="term-title" id="nrps">NRPS:</h3>
-      <p class="term-desc">National Retail Payment System. The regulatory policy framework established by BSP Circular 980 in 2017 governing interoperable Philippine retail electronic payment schemes (InstaPay and PESONet).</p>
-    </div>
-
-    <div class="def-box">
-      <h3 class="term-title" id="pan">PAN:</h3>
-      <p class="term-desc">Primary Account Number. The 15- or 16-digit number embossed on a payment card that identifies the card scheme, issuer bank identification number (BIN), and individual account.</p>
-    </div>
-
-    <div class="def-box">
-      <h3 class="term-title" id="pchc">PCHC:</h3>
-      <p class="term-desc">Philippine Clearing House Corporation. The clearing operator for checks, PESONet batch electronic transfers, PDDTS (domestic USD transfers), and PhP-USD PvP.</p>
-    </div>
-
-    <div class="def-box">
-      <h3 class="term-title" id="ra-11127">RA 11127:</h3>
-      <p class="term-desc">The National Payment Systems Act of 2018. The Philippine statute granting Bangko Sentral ng Pilipinas comprehensive regulatory oversight, licensing, and operational authority over all national payment systems.</p>
-    </div>
-
-    <!-- Section 8: Sources -->
-    <footer id="sources">
-      <h3>Sources &amp; Primary Authorities</h3>
-      <ul>
-        <li>Federal Reserve: <a href="https://www.federalreserve.gov/paymentsystems.htm" target="_blank" rel="noopener">Payment System Overview &amp; Research</a></li>
-        <li>Nacha: <a href="https://www.nacha.org/rules" target="_blank" rel="noopener">Nacha Operating Rules &amp; Guidelines</a></li>
-        <li>Bangko Sentral ng Pilipinas: <a href="https://www.bsp.gov.ph/Regulations/Issuances/2017/c980.pdf" target="_blank" rel="noopener">BSP Circular 980 (NRPS Framework)</a> &middot; <a href="https://www.bsp.gov.ph/Pages/Regulations/RA11127.pdf" target="_blank" rel="noopener">RA 11127 (NPSA)</a></li>
-        <li>PCI Security Standards Council: <a href="https://www.pcisecuritystandards.org/" target="_blank" rel="noopener">PCI DSS v4.0 Specification</a></li>
-        <li>EMVCo: <a href="https://www.emvco.com/emv-technologies/3d-secure/" target="_blank" rel="noopener">EMV 3-D Secure Protocol and Core Functions</a></li>
-        <li>Shopify / ActiveMerchant: <a href="https://github.com/activemerchant/active_merchant" target="_blank" rel="noopener">ActiveMerchant GitHub Repository</a></li>
-      </ul>
-      <p style="margin-top: 1rem;">
-        Related: <a href="/trees/online-payments/">Online Payments Knowledge Tree</a> &middot; <a href="/writing/payments-glossary/">Payments Glossary</a> &middot; <a href="/writing/us-and-philippine-payment-rails/">US &amp; PH Payment Rails</a>
-      </p>
-    </footer>
-  </main>
+<main id="top">
+<p class="back"><a href="/reference/">&larr; Reference</a> &middot; <a href="/">Home</a> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a></p>
+<p class="kicker">Finance · Payments</p>
+<h1>Online Payments</h1>
+<p class="updated">Reference entry &middot; last updated 20260910</p>
+<p class="back">Previous version: <a href="/reference/online-payments-20260910/">20260910 archive</a>.</p>
+<p class="lede"><strong>Online payments</strong> are payments initiated through internet-connected services. A checkout can use card payments or account transfers, each with its own processing, settlement, and dispute arrangements.</p>
+<nav class="toc" aria-label="Contents"><strong>Contents</strong><ol>
+<li><a href="#first-principles">First principles: payment layers</a></li>
+<li><a href="#four-party">The four-party card model</a></li>
+<li><a href="#lifecycle">Card payment lifecycle</a></li>
+<li><a href="#cnp-security">Online card security</a></li>
+<li><a href="#rails-comparison">Philippine and US payment systems</a></li>
+<li><a href="#software-adapters">Software adapters</a></li>
+<li><a href="#glossary-index">Related payment terms</a></li>
+<li><a href="#see-also">See also</a></li>
+<li><a href="#references">References</a></li>
+</ol></nav>
+<h2 id="first-principles">1. First principles: payment layers</h2>
+<p><span id="core-model">An online payment can be described through its instrument, participants, instructions, and movement of funds.</span> The following is an explanatory organization of those concepts:</p><ul><li><strong>Instrument:</strong> the means used to initiate a payment, such as a card or account transfer.</li><li><strong>Participants:</strong> the payer, payee, and institutions providing the service.</li><li><a href="/reference/clearing/">Clearing</a> establishes and reconciles payment obligations.<span class="cite">[<a href="#ref1">1</a>]</span></li><li><a href="/reference/settlement/">Settlement</a> discharges obligations; merchant payout identifies delivery of funds to the merchant.<span class="cite">[<a href="#ref2">2</a>]</span><span class="cite">[<a href="#ref3">3</a>]</span></li></ul><p>Ownership and payment function are separate dimensions. The Clearing House’s EPN, for example, is a private-sector <a href="/reference/ach/">ACH</a> operator.<span class="cite">[<a href="#ref4">4</a>]</span></p>
+<h2 id="four-party">2. The four-party card model</h2>
+<p>The four parties are the <span id="cardholder">cardholder</span>, <span id="merchant">merchant</span>, <span id="issuing-bank">issuer</span>, and <span id="acquirer">acquirer</span>. The <span id="card-network">card network</span> connects issuing and acquiring institutions under its rules. The issuer provides the card account; the acquirer serves the merchant.<span class="cite">[<a href="#ref5">5</a>]</span></p><p><span id="psp-collapse">A <a href="/reference/payment-service-providers/">PSP</a> can combine services, including processing and acquiring. Its exact role depends on the region and arrangement.</span><span class="cite">[<a href="#ref6">6</a>]</span></p>
+<h2 id="lifecycle">3. Card payment lifecycle</h2>
+<ul><li><span id="authorization"><a href="/reference/card-authorization-capture/">Authorization</a></span> approves a request and can reserve funds or credit. An uncaptured authorization can expire or be canceled.<span class="cite">[<a href="#ref7">7</a>]</span></li><li><span id="capture">Capture</span> submits an authorized amount for collection. Partial and multiple captures depend on provider and transaction support.<span class="cite">[<a href="#ref7">7</a>]</span></li><li><span id="settlement">Clearing and institutional settlement</span> establish and discharge obligations.<span class="cite">[<a href="#ref1">1</a>]</span><span class="cite">[<a href="#ref2">2</a>]</span> Payout to the merchant is a separate stage; Adyen explicitly distinguishes its “Settled” status from merchant payout.<span class="cite">[<a href="#ref3">3</a>]</span></li><li>A refund returns a captured payment through the provider’s refund process. A <span id="chargeback"><a href="/reference/chargebacks/">chargeback</a></span> arises through the issuer’s dispute process, with its own evidence and outcome.<span class="cite">[<a href="#ref8">8</a>]</span><span class="cite">[<a href="#ref9">9</a>]</span></li></ul>
+<h2 id="cnp-security">4. Online card security</h2>
+<p><span id="merchant-liability">Fraud liability depends on applicable network rules and transaction circumstances. An initial dispute debit does not necessarily mean a final merchant loss.</span><span class="cite">[<a href="#ref9">9</a>]</span></p><p><span id="3-d-secure"><a href="/reference/emv-3ds/">EMV 3DS</a></span> authenticates consumers for card-not-present payments. Eligible transactions can receive a fraud-liability shift; exceptions and non-fraud disputes remain.<span class="cite">[<a href="#ref10">10</a>]</span></p><p><span id="pci-dss"><a href="/reference/pci-dss/">PCI DSS</a></span> governs payment-account data security. Version 4.0.1 and current SAQ eligibility criteria apply to the actual integration; an iframe alone does not establish eligibility for SAQ A.<span class="cite">[<a href="#ref11">11</a>]</span></p>
+<h2 id="rails-comparison">5. Philippine and US payment systems</h2>
+<p><span id="nrps"><a href="/reference/nrps/">NRPS</a></span> provides the Philippine retail-payment framework under <a href="/reference/bsp/">BSP</a> oversight.<span class="cite">[<a href="#ref12">12</a>]</span> <span id="instapay"><a href="/reference/instapay/">InstaPay</a></span> and <span id="pesonet"><a href="/reference/pesonet/">PESONet</a></span> are covered in separate entries.</p><p><span id="bancnet">BancNet</span> and <span id="pchc">PCHC</span> merged effective 20260601. BSP lists Payments Network of the Philippines, Inc. (PNPI) as the operator of InstaPay and PESONet. <span id="philpassplus"><a href="/reference/philpassplus/">PhilPaSSplus</a></span> is BSP’s peso settlement system.<span class="cite">[<a href="#ref13">13</a>]</span></p><p><span id="qr-ph"><a href="/reference/qr-ph/">QR Ph</a></span> identifies a national QR standard and the merchant-payment brand. BSP’s 20260729 FAQ uses InstaPay QR for person-to-person payments; both retain the national standard.<span class="cite">[<a href="#ref14">14</a>]</span></p><p><span id="ach">US <a href="/reference/ach/">ACH</a></span> includes the privately operated EPN.<span class="cite">[<a href="#ref4">4</a>]</span> <span id="fedwire">Fedwire Funds</span> provides real-time gross settlement.<span class="cite">[<a href="#ref17">17</a>]</span> <span id="fednow">FedNow</span> processes instant payments around the clock.<span class="cite">[<a href="#ref18">18</a>]</span></p>
+<h2 id="software-adapters">6. Software adapters</h2>
+<p><span id="activemerchant"><a href="/reference/activemerchant/">ActiveMerchant</a></span> provides Ruby adapters for payment gateways.<span class="cite">[<a href="#ref15">15</a>]</span></p>
+<h2 id="glossary-index">7. Related payment terms</h2>
+<p>Related account-entry definitions include <a href="/reference/credit/">credit</a> and <a href="/reference/debit/">debit</a>.</p><p><span id="avs-and-cvc">AVS and CVC</span> are address and card-verification checks. Issuer support and the data collected affect the available results.<span class="cite">[<a href="#ref16">16</a>]</span></p><p><span id="interchange-fee">Interchange</span> is a fee between acquiring and issuing institutions under the relevant card arrangement.<span class="cite">[<a href="#ref5">5</a>]</span></p><p><span id="pan">PAN</span> means primary account number.<span class="cite">[<a href="#ref19">19</a>]</span> The <a href="/reference/pci-dss/">PCI DSS entry</a> covers payment-account data security. <span id="nacha">Nacha</span> maintains US ACH rules.<span class="cite">[<a href="#ref20">20</a>]</span> See <a href="/reference/ach/">ACH</a>. <span id="ra-11127">Republic Act No. 11127</span> is the Philippine National Payment Systems Act.<span class="cite">[<a href="#ref21">21</a>]</span></p>
+<h2 id="see-also">8. See also</h2>
+<ul><li><a href="/reference/card-authorization-capture/">Card Authorization and Capture</a></li><li><a href="/reference/chargebacks/">Chargebacks (Card Payments)</a></li><li><a href="/reference/emv-3ds/">EMV 3-D Secure (Online Card Authentication)</a></li><li><a href="/reference/pci-dss/">PCI DSS (Payment Card Data Security)</a></li><li><a href="/reference/payment-service-providers/">Payment Service Providers (Merchant Payments)</a></li><li><a href="/reference/activemerchant/">ActiveMerchant (Ruby Payments Library)</a></li><li><a href="/reference/instapay/">InstaPay</a></li><li><a href="/reference/nrps/">National Retail Payment System</a></li><li><a href="/reference/settlement/">Settlement</a></li><li><a href="/writing/us-and-philippine-payment-rails/">US and Philippine Payment Rails</a></li><li><a href="/writing/instapay-is-not-ach/">InstaPay Is Not ACH</a></li><li><a href="/writing/payments-glossary/">Payments Glossary</a></li><li><a href="/trees/online-payments/">Online Payments Knowledge Tree</a></li></ul>
+<span id="sources"></span>
+<h2 id="references">9. References</h2>
+<ol>
+<li id="ref1"><a href="https://www.ecb.europa.eu/services/glossary/html/act7c.en.html">European Central Bank. Glossary: clearing.</a></li>
+<li id="ref2"><a href="https://www.ecb.europa.eu/services/glossary/html/act7s.en.html">European Central Bank. Glossary: settlement.</a></li>
+<li id="ref3"><a href="https://docs.adyen.com/account/payments-lifecycle/">Adyen. Payments lifecycle.</a></li>
+<li id="ref4"><a href="https://www.theclearinghouse.org/payment-systems/ach">The Clearing House. EPN ACH services.</a></li>
+<li id="ref5"><a href="https://www.mastercard.com/europe/en/for-the-world/about-us/eu-regulations.html">Mastercard. European regulations and four-party business model.</a></li>
+<li id="ref6"><a href="https://help.adyen.com/knowledge/payment-methods/explore-payment-methods/what-is-an-acquirer">Adyen. What is an acquirer?</a></li>
+<li id="ref7"><a href="https://docs.stripe.com/payments/place-a-hold-on-a-payment-method">Stripe. Place a hold on a payment method.</a></li>
+<li id="ref8"><a href="https://docs.stripe.com/refunds">Stripe. Refund and cancel payments.</a></li>
+<li id="ref9"><a href="https://docs.stripe.com/disputes/how-disputes-work">Stripe. How disputes work.</a></li>
+<li id="ref10"><a href="https://docs.stripe.com/payments/3d-secure/authentication-flow">Stripe. 3D Secure authentication flow.</a></li>
+<li id="ref11"><a href="https://www.pcisecuritystandards.org/faqs/1588/">PCI SSC. FAQ 1588: SAQ A eligibility criteria for scripts.</a></li>
+<li id="ref12"><a href="https://www.bsp.gov.ph/Regulations/Issuances/2017/c980.pdf">BSP. Circular No. 980: NRPS framework (2017).</a></li>
+<li id="ref13"><a href="https://www.bsp.gov.ph/PaymentAndSettlement/List_of_Operators_of_Designated_Payment_Systems.pdf">BSP. List of operators of designated payment systems.</a></li>
+<li id="ref14"><a href="https://www.bsp.gov.ph/Media_And_Research/Primers%20Faqs/FAQs-QR-Ph-Rebranding.pdf">BSP. QR Ph rebranding FAQs (20260729).</a></li>
+<li id="ref15"><a href="https://github.com/activemerchant/active_merchant">ActiveMerchant. Project README.</a></li>
+<li id="ref16"><a href="https://docs.stripe.com/disputes/prevention/verification">Stripe. Card verification checks.</a></li>
+<li id="ref17"><a href="https://www.federalreserve.gov/paymentsystems/fedfunds_about.htm">Federal Reserve. Fedwire Funds Service.</a></li>
+<li id="ref18"><a href="https://www.federalreserve.gov/paymentsystems/fednow-additional-questions-and-answers.htm">Federal Reserve. FedNow additional questions and answers.</a></li>
+<li id="ref19"><a href="https://www.pcisecuritystandards.org/glossary/">PCI SSC. Glossary: PAN.</a></li>
+<li id="ref20"><a href="https://www.nacha.org/newrules">Nacha. Operating rules.</a></li>
+<li id="ref21"><a href="https://www.bsp.gov.ph/PaymentAndSettlement/RA11127.pdf">Republic Act No. 11127: National Payment Systems Act.</a></li>
+</ol>
+<footer><p><a href="#top">Back to top</a></p></footer>
+</main>
   <button id="backToTop" class="back-to-top" aria-label="Back to top" title="Back to top">
     <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
       <path d="M18 15l-6-6-6 6"/>

--- a/reference/payment-service-providers/index.html
+++ b/reference/payment-service-providers/index.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Payment Service Providers (Merchant Payments) · Reference · Nestor G Pestelos Jr</title>
+  <meta name="description" content="PSPs, acquiring roles, processing, and merchant payouts.">
+  <meta property="og:title" content="Payment Service Providers (Merchant Payments) · Reference">
+  <meta property="og:description" content="PSPs, acquiring roles, processing, and merchant payouts.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://ngpestelos.com/reference/payment-service-providers/">
+  <link rel="canonical" href="https://ngpestelos.com/reference/payment-service-providers/">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=20260813f">
+  <link rel="icon" href="/favicon-192.png?v=20260813f" type="image/png" sizes="192x192">
+  <link rel="icon" href="/favicon-32.png?v=20260813f" type="image/png" sizes="32x32">
+  <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
+  <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="stylesheet" href="/style.css?v=20260903e">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TLBY8P4GG9');
+  </script>
+  <style>
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; -webkit-text-size-adjust:100%; text-size-adjust:100%; }
+body { line-height:1.65; }
+main { max-width:48rem; margin:auto; padding:1.4rem 1.4rem 4rem; }
+h1 { font-size:clamp(1.9rem,5vw,2.4rem); font-weight:400; line-height:1.2; border-bottom:1px solid var(--line); padding-bottom:.5rem; }
+h2 { font-weight:400; margin-top:2rem; font-size:1.45rem; border-bottom:1px solid var(--line); padding-bottom:.3rem; }
+p,li { margin-bottom:.7rem; }
+.back,.kicker,.updated,.toc,footer { font-family:"Segoe UI",Helvetica,Arial,sans-serif; }
+.back,.updated,footer { font-size:.85rem; color:var(--mute); }
+.kicker { font-size:.78rem; text-transform:uppercase; letter-spacing:.08em; font-weight:700; color:var(--mute); }
+.lede { margin:1.4rem 0; }
+.toc { background:var(--well); border:1px solid var(--line); border-radius:4px; padding:1rem 1.3rem; margin:1.7rem 0; font-size:.9rem; }
+.toc ol { margin-bottom:0; padding-left:1.5rem; }
+.toc li { margin-bottom:.25rem; }
+.cite { font-size:.75em; vertical-align:super; }
+.cite a { text-decoration:none; }
+#references ~ ol { font-size:.9rem; overflow-wrap:anywhere; }
+footer { border-top:1px solid var(--line); margin-top:2rem; }
+.back-to-top { position:fixed; bottom:1.5rem; right:1.5rem; width:2.6rem; height:2.6rem; border-radius:50%; background:var(--bg); color:var(--ink); border:1px solid var(--line); cursor:pointer; opacity:0; visibility:hidden; }
+.back-to-top.visible { opacity:1; visibility:visible; }
+@media print { .back,.back-to-top { display:none !important; } main { max-width:none; padding:0; } }
+  </style>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"DefinedTerm","name":"Payment Service Providers (Merchant Payments)","description":"PSPs, acquiring roles, processing, and merchant payouts.","url":"https://ngpestelos.com/reference/payment-service-providers/","inDefinedTermSet":"https://ngpestelos.com/reference/"}</script>
+</head>
+<body class="reference">
+<main id="top">
+<p class="back"><a href="/reference/">&larr; Reference</a> &middot; <a href="/">Home</a> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a></p>
+<p class="kicker">Finance · Payments</p>
+<h1>Payment Service Providers (Merchant Payments)</h1>
+<p class="updated">Reference entry &middot; last updated 20260910</p>
+<p class="lede">A <strong>payment service provider (PSP)</strong> supplies services that help merchants accept payments. Its offering can combine payment processing and acquiring, with availability that depends on the provider and region.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+<nav class="toc" aria-label="Contents"><strong>Contents</strong><ol>
+<li><a href="#first-principles">First principles: distinct service roles</a></li>
+<li><a href="#integration">Integration and coverage</a></li>
+<li><a href="#payout">Settlement and payout</a></li>
+<li><a href="#data">Payment data responsibilities</a></li>
+<li><a href="#see-also">See also</a></li>
+<li><a href="#references">References</a></li>
+</ol></nav>
+<h2 id="first-principles">1. First principles: distinct service roles</h2>
+<p>An acquirer is a financial institution that processes and settles card payments for merchants. It can process transactions itself or work with a processor. A PSP may also act as an acquirer in regions where it provides that service.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+<h2 id="integration">2. Integration and coverage</h2>
+<p>A <strong>gateway</strong> transmits payment data from the merchant to the acquiring side. A <strong>processor</strong> handles technical communication with banks and card networks.<span class="cite">[<a href="#ref4">4</a>]</span></p>
+<h2 id="payout">3. Settlement and payout</h2>
+<p>The provider receiving funds and the merchant receiving a payout are separate events. Adyen documents different payout models and frequencies; a successful payment does not imply a universal payout deadline.<span class="cite">[<a href="#ref2">2</a>]</span></p>
+<h2 id="data">4. Payment data responsibilities</h2>
+<p>The checkout integration also determines which systems handle card data. <a href="/reference/pci-dss/">PCI DSS</a> scope and self-assessment eligibility depend on that environment.<span class="cite">[<a href="#ref3">3</a>]</span></p>
+<h2 id="see-also">5. See also</h2>
+<ul><li><a href="/reference/online-payments/">Online Payments</a></li><li><a href="/reference/card-authorization-capture/">Card Authorization and Capture</a></li><li><a href="/reference/settlement/">Settlement</a></li><li><a href="/reference/pci-dss/">PCI DSS (Payment Card Data Security)</a></li></ul>
+<h2 id="references">6. References</h2>
+<ol>
+<li id="ref1"><a href="https://help.adyen.com/knowledge/payment-methods/explore-payment-methods/what-is-an-acquirer">Adyen. What is an acquirer?</a></li>
+<li id="ref2"><a href="https://docs.adyen.com/account/getting-paid">Adyen. Getting paid.</a></li>
+<li id="ref3"><a href="https://www.pcisecuritystandards.org/standards/pci-dss/">PCI SSC. PCI Data Security Standard.</a></li>
+<li id="ref4"><a href="https://www.adyen.com/knowledge-hub/payment-service-provider">Adyen. Payment service providers: gateway and processor roles.</a></li>
+</ol>
+<footer><p><a href="#top">Back to top</a></p></footer>
+</main>
+  <button id="backToTop" class="back-to-top" aria-label="Back to top" title="Back to top">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M18 15l-6-6-6 6"/>
+    </svg>
+  </button>
+
+  <script>
+    const btt = document.getElementById('backToTop');
+    window.addEventListener('scroll', () => {
+      if (window.scrollY > 250) {
+        btt.classList.add('visible');
+      } else {
+        btt.classList.remove('visible');
+      }
+    }, { passive: true });
+    btt.addEventListener('click', () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  </script>
+</body>
+</html>

--- a/reference/pci-dss/index.html
+++ b/reference/pci-dss/index.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>PCI DSS (Payment Card Data Security) · Reference · Nestor G Pestelos Jr</title>
+  <meta name="description" content="PCI DSS v4.0.1 scope and e-commerce self-assessment eligibility.">
+  <meta property="og:title" content="PCI DSS (Payment Card Data Security) · Reference">
+  <meta property="og:description" content="PCI DSS v4.0.1 scope and e-commerce self-assessment eligibility.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://ngpestelos.com/reference/pci-dss/">
+  <link rel="canonical" href="https://ngpestelos.com/reference/pci-dss/">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=20260813f">
+  <link rel="icon" href="/favicon-192.png?v=20260813f" type="image/png" sizes="192x192">
+  <link rel="icon" href="/favicon-32.png?v=20260813f" type="image/png" sizes="32x32">
+  <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
+  <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="stylesheet" href="/style.css?v=20260903e">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TLBY8P4GG9');
+  </script>
+  <style>
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; -webkit-text-size-adjust:100%; text-size-adjust:100%; }
+body { line-height:1.65; }
+main { max-width:48rem; margin:auto; padding:1.4rem 1.4rem 4rem; }
+h1 { font-size:clamp(1.9rem,5vw,2.4rem); font-weight:400; line-height:1.2; border-bottom:1px solid var(--line); padding-bottom:.5rem; }
+h2 { font-weight:400; margin-top:2rem; font-size:1.45rem; border-bottom:1px solid var(--line); padding-bottom:.3rem; }
+p,li { margin-bottom:.7rem; }
+.back,.kicker,.updated,.toc,footer { font-family:"Segoe UI",Helvetica,Arial,sans-serif; }
+.back,.updated,footer { font-size:.85rem; color:var(--mute); }
+.kicker { font-size:.78rem; text-transform:uppercase; letter-spacing:.08em; font-weight:700; color:var(--mute); }
+.lede { margin:1.4rem 0; }
+.toc { background:var(--well); border:1px solid var(--line); border-radius:4px; padding:1rem 1.3rem; margin:1.7rem 0; font-size:.9rem; }
+.toc ol { margin-bottom:0; padding-left:1.5rem; }
+.toc li { margin-bottom:.25rem; }
+.cite { font-size:.75em; vertical-align:super; }
+.cite a { text-decoration:none; }
+#references ~ ol { font-size:.9rem; overflow-wrap:anywhere; }
+footer { border-top:1px solid var(--line); margin-top:2rem; }
+.back-to-top { position:fixed; bottom:1.5rem; right:1.5rem; width:2.6rem; height:2.6rem; border-radius:50%; background:var(--bg); color:var(--ink); border:1px solid var(--line); cursor:pointer; opacity:0; visibility:hidden; }
+.back-to-top.visible { opacity:1; visibility:visible; }
+@media print { .back,.back-to-top { display:none !important; } main { max-width:none; padding:0; } }
+  </style>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"DefinedTerm","name":"PCI DSS (Payment Card Data Security)","description":"PCI DSS v4.0.1 scope and e-commerce self-assessment eligibility.","url":"https://ngpestelos.com/reference/pci-dss/","inDefinedTermSet":"https://ngpestelos.com/reference/"}</script>
+</head>
+<body class="reference">
+<main id="top">
+<p class="back"><a href="/reference/">&larr; Reference</a> &middot; <a href="/">Home</a> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a></p>
+<p class="kicker">Finance · Payments</p>
+<h1>PCI DSS (Payment Card Data Security)</h1>
+<p class="updated">Reference entry &middot; last updated 20260910</p>
+<p class="lede">The <strong>Payment Card Industry Data Security Standard (PCI DSS)</strong> specifies technical and operational requirements for protecting payment account data. The PCI SSC document library lists version 4.0.1 as the current standard checked on 20260910.<span class="cite">[<a href="#ref1">1</a>]</span><span class="cite">[<a href="#ref2">2</a>]</span></p>
+<nav class="toc" aria-label="Contents"><strong>Contents</strong><ol>
+<li><a href="#first-principles">First principles: the data environment</a></li>
+<li><a href="#saq">Self-assessment eligibility</a></li>
+<li><a href="#scripts">Embedded payment forms</a></li>
+<li><a href="#validation">Validation responsibility</a></li>
+<li><a href="#see-also">See also</a></li>
+<li><a href="#references">References</a></li>
+</ol></nav>
+<h2 id="first-principles">1. First principles: the data environment</h2>
+<p>Scope includes organizations that store, process, or transmit cardholder or sensitive authentication data, and those that can affect the security of the cardholder data environment. Outsourcing a payment function changes which systems handle the data; the remaining responsibilities still require assessment.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+<h2 id="saq">2. Self-assessment eligibility</h2>
+<p>A self-assessment questionnaire (SAQ) applies to a defined payment environment. SAQ selection requires meeting all eligibility criteria. Hosted fields or an iframe alone do not establish SAQ A eligibility.<span class="cite">[<a href="#ref3">3</a>]</span></p>
+<h2 id="scripts">3. Embedded payment forms</h2>
+<p>For embedded third-party payment forms, SAQ A requires merchants to confirm that their site is not susceptible to script attacks affecting their e-commerce systems. That specific criterion does not apply to redirect-based or fully outsourced payment flows. The FAQ explicitly leaves other eligibility criteria in force.<span class="cite">[<a href="#ref3">3</a>]</span></p>
+<h2 id="validation">4. Validation responsibility</h2>
+<p>Payment brands, acquirers, or other organizations that manage compliance programs determine validation requirements. The applicable questionnaire and evidence depend on the actual integration and program.<span class="cite">[<a href="#ref1">1</a>]</span></p>
+<h2 id="see-also">5. See also</h2>
+<ul><li><a href="/reference/online-payments/">Online Payments</a></li><li><a href="/reference/payment-service-providers/">Payment Service Providers (Merchant Payments)</a></li><li><a href="/reference/emv-3ds/">EMV 3-D Secure (Online Card Authentication)</a></li></ul>
+<h2 id="references">6. References</h2>
+<ol>
+<li id="ref1"><a href="https://www.pcisecuritystandards.org/standards/pci-dss/">PCI SSC. PCI Data Security Standard.</a></li>
+<li id="ref2"><a href="https://www.pcisecuritystandards.org/document_library/">PCI SSC. Document library: PCI DSS v4.0.1.</a></li>
+<li id="ref3"><a href="https://www.pcisecuritystandards.org/faqs/1588/">PCI SSC. FAQ 1588: SAQ A eligibility criteria for scripts.</a></li>
+</ol>
+<footer><p><a href="#top">Back to top</a></p></footer>
+</main>
+  <button id="backToTop" class="back-to-top" aria-label="Back to top" title="Back to top">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M18 15l-6-6-6 6"/>
+    </svg>
+  </button>
+
+  <script>
+    const btt = document.getElementById('backToTop');
+    window.addEventListener('scroll', () => {
+      if (window.scrollY > 250) {
+        btt.classList.add('visible');
+      } else {
+        btt.classList.remove('visible');
+      }
+    }, { passive: true });
+    btt.addEventListener('click', () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  </script>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1257,4 +1257,34 @@
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
+  <url>
+    <loc>https://ngpestelos.com/reference/card-authorization-capture/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://ngpestelos.com/reference/chargebacks/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://ngpestelos.com/reference/emv-3ds/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://ngpestelos.com/reference/pci-dss/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://ngpestelos.com/reference/payment-service-providers/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://ngpestelos.com/reference/activemerchant/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
The online-payments reference conflated payment ownership, clearing, settlement, and merchant payouts, and overstated security and provider guarantees. Rewrite it as a sourced overview with distinct payment layers, a qualified card lifecycle, current Philippine operator names, and conditional 3DS/PCI explanations.

Add six linked references: card authorization and capture, chargebacks, EMV 3DS, PCI DSS, payment service providers, and ActiveMerchant. Preserve the previous page at `/reference/online-payments-20260910/`, with reciprocal history links and existing current-page anchors. Register the six current entries in the reference index and sitemap.

Validation: site discoverability tests; local links, fragments, TOC, metadata and archive fidelity checks; desktop/mobile checks for all seven current pages; independent prose and primary-source reviews. The archive retains its historical content and layout.
