### PR TITLE
docs(reference): reciprocal link embeddings <-> transformer-architecture

### DIFF
--- a/reference/embeddings/index.html
+++ b/reference/embeddings/index.html
@@ -296,6 +296,7 @@
         <li><a href="/reference/retrieval-augmented-generation/">Retrieval-Augmented Generation (RAG)</a> &middot; Grounding model generation on retrieved external context.</li>
         <li><a href="/reference/semantic-caching/">Semantic Caching</a> &middot; Caching query results via embedding distance thresholds.</li>
         <li><a href="/reference/large-language-models/">Large Language Models</a> &middot; Foundational Transformer architectures and self-attention.</li>
+        <li><a href="/reference/transformer-architecture/">Transformer Architecture</a> &middot; The decoder stack that consumes these vectors: tokenizer, attention, and the language modeling head.</li>
       </ul>
     </section>
 


### PR DESCRIPTION
## What

`reference/transformer-architecture/` already links to `/reference/embeddings/`
in its See Also list. `reference/embeddings/` did not link back — one-directional.

Adds the reciprocal entry, matching embeddings' own See Also pattern
(`<li><a>Title</a> &middot; description</li>`).

Fixes #112.

## Not in scope

Reciprocity between `embeddings`, `vector`, and `vector-search` — flagged in
#112 as a separate follow-up, not audited here.

## Verification

`cd scripts && python3 -m unittest discover -p 'test_*.py'` — 40/40 pass.
