### PR TITLE
docs(reference): complete vector/embeddings/transformer cross-link matrix

### DIFF
--- a/reference/embeddings/index.html
+++ b/reference/embeddings/index.html
@@ -297,6 +297,8 @@
         <li><a href="/reference/semantic-caching/">Semantic Caching</a> &middot; Caching query results via embedding distance thresholds.</li>
         <li><a href="/reference/large-language-models/">Large Language Models</a> &middot; Foundational Transformer architectures and self-attention.</li>
         <li><a href="/reference/transformer-architecture/">Transformer Architecture</a> &middot; The decoder stack that consumes these vectors: tokenizer, attention, and the language modeling head.</li>
+        <li><a href="/reference/vector/">Vector (Mathematics and Computing)</a> &middot; The linear-algebra object embeddings live in: vector spaces, norms, and inner products.</li>
+        <li><a href="/reference/vector-search/">Vector Search</a> &middot; Approximate nearest neighbor retrieval over embedding vectors at production scale.</li>
       </ul>
     </section>
 

--- a/reference/transformer-architecture/index.html
+++ b/reference/transformer-architecture/index.html
@@ -103,6 +103,8 @@
         <li><a href="/reference/kv-cache/">KV Cache</a></li>
         <li><a href="/reference/llm-inference/">LLM Inference</a></li>
         <li><a href="/reference/deep-neural-networks/">Deep Neural Networks</a></li>
+        <li><a href="/reference/vector/">Vector (Mathematics and Computing)</a></li>
+        <li><a href="/reference/vector-search/">Vector Search</a></li>
       </ul>
     </div>
 

--- a/reference/vector-search/index.html
+++ b/reference/vector-search/index.html
@@ -264,6 +264,7 @@
         <li><a href="/reference/retrieval-augmented-generation/">Retrieval-Augmented Generation (RAG)</a> &middot; Augmenting LLM context with retrieved vector search passages.</li>
         <li><a href="/reference/bm25/">BM25</a> &middot; Classical term-frequency lexical retrieval algorithm paired in hybrid search.</li>
         <li><a href="/reference/semantic-caching/">Semantic Caching</a> &middot; Caching queries via vector similarity thresholds.</li>
+        <li><a href="/reference/transformer-architecture/">Transformer Architecture</a> &middot; The decoder that produces the query and document vectors this page indexes and searches.</li>
       </ul>
     </section>
 

--- a/reference/vector-search/index.html
+++ b/reference/vector-search/index.html
@@ -264,7 +264,7 @@
         <li><a href="/reference/retrieval-augmented-generation/">Retrieval-Augmented Generation (RAG)</a> &middot; Augmenting LLM context with retrieved vector search passages.</li>
         <li><a href="/reference/bm25/">BM25</a> &middot; Classical term-frequency lexical retrieval algorithm paired in hybrid search.</li>
         <li><a href="/reference/semantic-caching/">Semantic Caching</a> &middot; Caching queries via vector similarity thresholds.</li>
-        <li><a href="/reference/transformer-architecture/">Transformer Architecture</a> &middot; The decoder that produces the query and document vectors this page indexes and searches.</li>
+        <li><a href="/reference/transformer-architecture/">Transformer Architecture</a> &middot; The encoder variants that produce the vectors indexed here, and the decoder-only LLMs that consume retrieved results in RAG.</li>
       </ul>
     </section>
 


### PR DESCRIPTION
## What

Follow-up to #112/#114. Full pairwise reciprocity audit across the 4 related
reference pages (`embeddings`, `vector`, `vector-search`,
`transformer-architecture`) found 4 more one-directional or missing pairs:

| Pair | Before | After |
|---|---|---|
| embeddings -> vector | missing (vector -> embeddings existed) | added |
| embeddings -> vector-search | missing (vector-search -> embeddings existed) | added |
| transformer-architecture -> vector | missing (vector -> transformer-architecture existed) | added |
| transformer-architecture <-> vector-search | missing both ways | added both ways |

`vector/index.html` already linked to all three others — untouched.

Each addition matches its target page's existing See Also markup (link +
description for embeddings/vector-search, link-only for
transformer-architecture's companion-box) rather than introducing a new
shared pattern.

## Verification

- `cd scripts && python3 -m unittest discover -p 'test_*.py'` — 40/40 pass.
- Zero em-dash / `&mdash;` introduced.
- `html.parser` parses all 3 changed files without exception.
- Every new `href` targets an existing `/reference/<slug>/` page.
