### PR TITLE
fix(reference): suppress redundant list numbers on numbered table of contents

### DIFF
--- a/reference/chunked-prefill/index.html
+++ b/reference/chunked-prefill/index.html
@@ -110,7 +110,7 @@
       border-bottom: none;
       padding-bottom: 0;
     }
-    .toc ol { padding-left: 1.3rem; }
+    .toc ol { list-style: none; padding-left: 0; }
     .toc li { margin: 0.2rem 0; }
     .toc a { color: var(--link); text-decoration: none; }
     .toc a:hover { text-decoration: underline; }

--- a/reference/computer-vision/index.html
+++ b/reference/computer-vision/index.html
@@ -127,7 +127,8 @@
       margin-top: 0;
     }
     .toc ol {
-      padding-left: 1.3rem;
+      list-style: none;
+      padding-left: 0;
       margin-bottom: 0;
     }
     .toc ol ol {

--- a/reference/jude-1-2/index.html
+++ b/reference/jude-1-2/index.html
@@ -94,7 +94,8 @@
       margin-top: 0;
     }
     .toc ol {
-      padding-left: 1.3rem;
+      list-style: none;
+      padding-left: 0;
       margin-bottom: 0;
     }
     .toc li { margin: 0.25rem 0; }

--- a/reference/matrix/index.html
+++ b/reference/matrix/index.html
@@ -110,7 +110,7 @@
       border-bottom: none;
       padding-bottom: 0;
     }
-    .toc ol { padding-left: 1.3rem; }
+    .toc ol { list-style: none; padding-left: 0; }
     .toc li { margin: 0.2rem 0; }
     .toc a { color: var(--link); text-decoration: none; }
     .toc a:hover { text-decoration: underline; }

--- a/reference/mixture-of-experts/index.html
+++ b/reference/mixture-of-experts/index.html
@@ -110,7 +110,7 @@
       border-bottom: none;
       padding-bottom: 0;
     }
-    .toc ol { padding-left: 1.3rem; }
+    .toc ol { list-style: none; padding-left: 0; }
     .toc li { margin: 0.2rem 0; }
     .toc a { color: var(--link); text-decoration: none; }
     .toc a:hover { text-decoration: underline; }

--- a/reference/neuroplasticity/index.html
+++ b/reference/neuroplasticity/index.html
@@ -110,7 +110,7 @@
       border-bottom: none;
       padding-bottom: 0;
     }
-    .toc ol { padding-left: 1.3rem; }
+    .toc ol { list-style: none; padding-left: 0; }
     .toc li { margin: 0.2rem 0; }
     .toc a { color: var(--link); text-decoration: none; }
     .toc a:hover { text-decoration: underline; }

--- a/reference/reinforcement-learning/index.html
+++ b/reference/reinforcement-learning/index.html
@@ -128,7 +128,8 @@
       margin-top: 0;
     }
     .toc ol {
-      padding-left: 1.3rem;
+      list-style: none;
+      padding-left: 0;
       margin-bottom: 0;
     }
     .toc ol ol {

--- a/reference/speculative-decoding/index.html
+++ b/reference/speculative-decoding/index.html
@@ -110,7 +110,7 @@
       border-bottom: none;
       padding-bottom: 0;
     }
-    .toc ol { padding-left: 1.3rem; }
+    .toc ol { list-style: none; padding-left: 0; }
     .toc li { margin: 0.2rem 0; }
     .toc a { color: var(--link); text-decoration: none; }
     .toc a:hover { text-decoration: underline; }

--- a/reference/supervised-learning/index.html
+++ b/reference/supervised-learning/index.html
@@ -127,7 +127,8 @@
       margin-top: 0;
     }
     .toc ol {
-      padding-left: 1.3rem;
+      list-style: none;
+      padding-left: 0;
       margin-bottom: 0;
     }
     .toc ol ol {

--- a/reference/tensor/index.html
+++ b/reference/tensor/index.html
@@ -110,7 +110,7 @@
       border-bottom: none;
       padding-bottom: 0;
     }
-    .toc ol { padding-left: 1.3rem; }
+    .toc ol { list-style: none; padding-left: 0; }
     .toc li { margin: 0.2rem 0; }
     .toc a { color: var(--link); text-decoration: none; }
     .toc a:hover { text-decoration: underline; }

--- a/reference/time-per-output-token/index.html
+++ b/reference/time-per-output-token/index.html
@@ -110,7 +110,7 @@
       border-bottom: none;
       padding-bottom: 0;
     }
-    .toc ol { padding-left: 1.3rem; }
+    .toc ol { list-style: none; padding-left: 0; }
     .toc li { margin: 0.2rem 0; }
     .toc a { color: var(--link); text-decoration: none; }
     .toc a:hover { text-decoration: underline; }

--- a/reference/top-k/index.html
+++ b/reference/top-k/index.html
@@ -110,7 +110,7 @@
       border-bottom: none;
       padding-bottom: 0;
     }
-    .toc ol { padding-left: 1.3rem; }
+    .toc ol { list-style: none; padding-left: 0; }
     .toc li { margin: 0.2rem 0; }
     .toc a { color: var(--link); text-decoration: none; }
     .toc a:hover { text-decoration: underline; }

--- a/reference/unsupervised-learning/index.html
+++ b/reference/unsupervised-learning/index.html
@@ -127,7 +127,8 @@
       margin-top: 0;
     }
     .toc ol {
-      padding-left: 1.3rem;
+      list-style: none;
+      padding-left: 0;
       margin-bottom: 0;
     }
     .toc ol ol {

--- a/reference/vector/index.html
+++ b/reference/vector/index.html
@@ -127,7 +127,8 @@
       margin-top: 0;
     }
     .toc ol {
-      padding-left: 1.3rem;
+      list-style: none;
+      padding-left: 0;
       margin-bottom: 0;
     }
     .toc ol ol {

--- a/reference/working-memory/index.html
+++ b/reference/working-memory/index.html
@@ -117,7 +117,7 @@
       border-bottom: none;
       padding-bottom: 0;
     }
-    .toc ol { padding-left: 1.3rem; }
+    .toc ol { list-style: none; padding-left: 0; }
     .toc li { margin: 0.2rem 0; }
     .toc a { color: var(--link); text-decoration: none; }
     .toc a:hover { text-decoration: underline; }

--- a/scripts/test_site_discoverability.py
+++ b/scripts/test_site_discoverability.py
@@ -520,6 +520,21 @@ class ReferenceSeoTests(unittest.TestCase):
         self.assertIn('"@type":"DefinedTerm"', entry_html)
         self.assertIn('id="first-principles"', entry_html)
 
+    def test_reference_numbered_toc_suppresses_list_style(self):
+        for path in sorted(REF.glob("*/index.html")):
+            html = path.read_text(encoding="utf-8")
+            m = re.search(r"<nav class=[\"\']toc[\"\'][^>]*>(.*?)</nav>", html, re.S)
+            if not m:
+                continue
+            toc_html = m.group(1)
+            if re.search(r"<li>\s*<a[^>]*>\s*\d+\.", toc_html):
+                with self.subTest(slug=path.parent.name):
+                    self.assertRegex(
+                        html,
+                        r"\.toc\s+ol\s*\{[^}]*list-style:\s*none",
+                        f"Numbered TOC in {path.parent.name} missing 'list-style: none' styling",
+                    )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Fix Table of Contents CSS styling on reference pages where item text already contains section numbers (e.g. `1. First principles...`).
- Add `list-style: none; padding-left: 0;` to `.toc ol` across 15 reference entries, removing redundant browser decimal numbers (`1. 1. ...`).
- Reference entries without numbered items remain untouched and continue to use standard numbered list markers.
- Add regression test `test_reference_numbered_toc_suppresses_list_style` to `scripts/test_site_discoverability.py`.