### PR TITLE
Add reference page for self-attention

### DIFF
--- a/reference/attention/index.html
+++ b/reference/attention/index.html
@@ -424,6 +424,8 @@
       <li><a href="/reference/working-memory/">Reference: Working Memory</a></li>
       <li><a href="/reference/neuroplasticity/">Reference: Neuroplasticity</a></li>
       <li><a href="/reference/transformer-architecture/">Reference: Transformer Architecture</a></li>
+      <li><a href="/reference/self-attention/">Self-Attention (Transformers)</a></li>
+      <li><a href="/reference/sliding-window-attention/">Sliding-Window Attention (Transformers)</a></li>
       <li><a href="/reference/matrix/">Reference: Matrix (Linear Algebra)</a></li>
       <li><a href="/reference/context-window/">Reference: Context Windows</a></li>
       <li><a href="/reference/context-engineering/">Reference: Context Engineering</a></li>

--- a/reference/index.html
+++ b/reference/index.html
@@ -433,6 +433,7 @@
       <div class="letter-group" id="S">
         <h2 class="letter-heading">S</h2>
         <ul>
+        <li><a href="/reference/self-attention/">Self-Attention (Transformers)</a></li>
         <li><a href="/reference/semantic-caching/">Semantic Caching</a></li>
         <li><a href="/reference/settlement/">Settlement (Payments)</a></li>
         <li><a href="/reference/shisa-kanko/">Shisa Kanko (Pointing and Calling)</a></li>

--- a/reference/self-attention/index.html
+++ b/reference/self-attention/index.html
@@ -1,0 +1,327 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Self-Attention (Transformers) &middot; Reference &middot; Nestor G Pestelos Jr</title>
+  <meta name="description" content="Self-attention relates different positions within a single sequence to compute contextual token representations through scaled dot-product operations and parallel attention heads.">
+  <meta property="og:title" content="Self-Attention (Transformers) &middot; Reference">
+  <meta property="og:description" content="Definition, first principles, scaled dot-product formulation, attention heads, multi-head projections, and complexity bounds in self-attention layers.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://ngpestelos.com/reference/self-attention/">
+  <link rel="canonical" href="https://ngpestelos.com/reference/self-attention/">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=20260813f">
+  <link rel="icon" href="/favicon-192.png?v=20260813f" type="image/png" sizes="192x192">
+  <link rel="icon" href="/favicon-32.png?v=20260813f" type="image/png" sizes="32x32">
+  <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
+  <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="stylesheet" href="/style.css?v=20260903e">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css" crossorigin="anonymous">
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"></script>
+  <script>
+    document.addEventListener("DOMContentLoaded", function () {
+      renderMathInElement(document.body, {
+        delimiters: [
+          {left: "$$", right: "$$", display: true},
+          {left: "\\[", right: "\\]", display: true},
+          {left: "\\(", right: "\\)", display: false}
+        ],
+        throwOnError: false
+      });
+    });
+  </script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag("js", new Date());
+    gtag("config", "G-TLBY8P4GG9");
+  </script>
+  <script type="application/ld+json">
+  {"@context":"https://schema.org","@type":"DefinedTerm","name":"Self-Attention","description":"Self-attention is an attention mechanism relating different positions of a single sequence to compute a contextual representation of the sequence.","url":"https://ngpestelos.com/reference/self-attention/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; scroll-behavior: smooth; }
+    body { line-height: 1.6; }
+    main { max-width: 48rem; margin: 0 auto; padding: 1.4rem 1.4rem 4rem; }
+    .back {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .back a { color: var(--link); text-decoration: none; }
+    .back a:hover { text-decoration: underline; }
+    .kicker {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.78rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--mute);
+      margin-bottom: 0.2rem;
+    }
+    h1 {
+      font-size: clamp(1.9rem, 5vw, 2.4rem);
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.4rem;
+      margin-bottom: 0.8rem;
+    }
+    .updated {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.82rem;
+      color: var(--mute);
+      margin-bottom: 1.4rem;
+    }
+    .unattributed {
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.85rem;
+      color: var(--mute);
+      font-style: italic;
+    }
+    .lede { margin-bottom: 1.6rem; }
+    .lede strong:first-child { font-weight: 700; }
+    .toc {
+      background: var(--well);
+      border: 1px solid var(--line);
+      border-radius: 4px;
+      padding: 1.1rem 1.4rem;
+      margin-bottom: 2rem;
+      font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 0.9rem;
+    }
+    .toc h2 {
+      font-size: 1rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: 0.5rem;
+      color: var(--ink);
+      border-bottom: none;
+      padding-bottom: 0;
+    }
+    .toc ol { padding-left: 1.3rem; }
+    .toc li { margin: 0.2rem 0; }
+    .toc a { color: var(--link); text-decoration: none; }
+    .toc a:hover { text-decoration: underline; }
+    h2 {
+      font-size: 1.45rem;
+      font-weight: 400;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 0.3rem;
+      margin: 2.2rem 0 0.9rem;
+    }
+    h3 {
+      font-size: 1.15rem;
+      font-weight: 700;
+      margin: 1.5rem 0 0.6rem;
+    }
+    p { margin-bottom: 0.9rem; }
+    ul, ol { margin-bottom: 1rem; padding-left: 1.5rem; }
+    li { margin-bottom: 0.35rem; }
+    a { color: var(--link); }
+    a:visited { color: var(--link-visited); }
+    code {
+      font-family: "SF Mono", Consolas, Monaco, monospace;
+      font-size: 0.9em;
+      background: var(--well);
+      padding: 0.1em 0.35em;
+      border-radius: 3px;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1.2rem 0 1.6rem;
+      font-size: 0.92rem;
+    }
+    th, td {
+      border: 1px solid var(--line);
+      padding: 0.5rem 0.75rem;
+      text-align: left;
+    }
+    th { background: var(--well); font-weight: 700; }
+    .cite { font-size: 0.75em; vertical-align: super; line-height: 0; text-decoration: none; }
+    .cite a { text-decoration: none; }
+    #see-also ul, #references ol { padding-left: 1.5rem; }
+    #see-also li, #references li { margin-bottom: 0.5rem; }
+    #references { font-size: 0.92rem; }
+    #references .backlink { margin-right: 0.3rem; text-decoration: none; }
+    .back-to-top {
+      position: fixed;
+      bottom: 2rem;
+      right: 2rem;
+      padding: 0.5rem 0.8rem;
+      font-size: 0.85rem;
+      background: var(--well);
+      color: var(--ink);
+      border: 1px solid var(--line);
+      border-radius: 4px;
+      cursor: pointer;
+      display: none;
+      opacity: 0.8;
+      transition: opacity 0.2s;
+    }
+    .back-to-top:hover { opacity: 1; }
+    @media print {
+      .back, .back-to-top { display: none !important; }
+    }
+  </style>
+</head>
+<body class="reference">
+  <main>
+    <nav class="back" aria-label="Breadcrumb">
+      <a href="/reference/">&larr; Reference</a> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a>
+    </nav>
+
+    <p class="kicker">Machine Learning &middot; Transformers</p>
+    <h1>Self-Attention (Transformers)</h1>
+    <p class="updated">Reference entry &middot; last updated September 12, 2026</p>
+
+    <p class="lede"><strong>Self-attention</strong> (sometimes called intra-attention) is an attention mechanism relating different positions of a single sequence in order to compute a representation of the sequence.<span class="cite">[<a href="#ref-1">1</a>]</span> Unlike recurrence, which processes tokens sequentially step by step, self-attention computes direct pairwise interaction scores across all positions in parallel, yielding a constant \(O(1)\) sequential path length between any two tokens.<span class="cite">[<a href="#ref-1">1</a>]</span></p>
+
+    <nav class="toc" aria-label="Contents">
+      <h2>Contents</h2>
+      <ol>
+        <li><a href="#first-principles">First principles and scaled dot-product</a></li>
+        <li><a href="#attention-heads">Attention heads and multi-head attention</a></li>
+        <li><a href="#complexity">Computational complexity and KV cache</a></li>
+        <li><a href="#masking">Directionality and causal masking</a></li>
+        <li><a href="#cross-attention">Comparison with cross-attention</a></li>
+        <li><a href="#see-also">See also</a></li>
+        <li><a href="#references">References</a></li>
+      </ol>
+    </nav>
+
+    <h2 id="first-principles">1. First Principles: Sequence Alignment and Scaled Dot-Product</h2>
+    <p>Given an input matrix \(X \in \mathbb{R}^{n \times d_{\text{model}}}\) representing a sequence of \(n\) token embeddings, self-attention first applies three learned linear projections to map the inputs into Query (\(Q\)), Key (\(K\)), and Value (\(V\)) representations:</p>
+    \[
+    Q = X W_Q, \quad K = X W_K, \quad V = X W_V
+    \]
+    <p>where \(W_Q \in \mathbb{R}^{d_{\text{model}} \times d_k}\), \(W_K \in \mathbb{R}^{d_{\text{model}} \times d_k}\), and \(W_V \in \mathbb{R}^{d_{\text{model}} \times d_v}\) are parameter matrices. Each token vector produces three specialized roles: a query that searches for relevant context, a key that advertises attributes for matching, and a value that contains the retrievable content.</p>
+    <p>The relevance of token \(j\) to token \(i\) is quantified by the inner product of query vector \(q_i\) with key vector \(k_j\). The matrix product \(Q K^\top \in \mathbb{R}^{n \times n}\) yields unnormalized alignment scores across all pairs. When the projection dimension \(d_k\) is large, dot products grow large in magnitude, pushing the softmax function into regions with near-zero gradients. To preserve variance, the dot products are divided by the scaling factor \(\sqrt{d_k}\):<span class="cite">[<a href="#ref-1">1</a>]</span></p>
+    \[
+    \text{Attention}(Q, K, V) = \text{softmax}\left(\frac{Q K^\top}{\sqrt{d_k}}\right) V
+    \]
+    <p>The row-wise softmax normalizes the scaled scores so that weights along each row are non-negative and sum to 1. Each output vector is a weighted sum of the value vectors, directly pooling context from across the entire sequence into an updated representation.</p>
+
+    <h2 id="attention-heads">2. Attention Heads and Multi-Head Attention</h2>
+    <p>An <strong>attention head</strong> is an independent computational unit within a self-attention layer that calculates attention patterns across tokens using its own projection matrices \((W_i^Q, W_i^K, W_i^V)\). A single attention head projects tokens into one subspace, producing a single distribution of attention weights across the sequence.</p>
+    <p>Rather than computing a single attention function with \(d_{\text{model}}\)-dimensional queries, keys, and values, the Transformer employs <strong>multi-head attention</strong>.<span class="cite">[<a href="#ref-1">1</a>]</span> Multi-head attention runs \(h\) separate attention heads in parallel within the same layer. The dimensionality of each head is typically set to \(d_k = d_v = d_{\text{model}} / h\), keeping total computational cost similar to a single full-dimensional attention pass.</p>
+
+    <h3>Contextual Specialization</h3>
+    <p>Running multiple heads simultaneously allows the model to attend to distinct types of relational patterns at the same time:<span class="cite">[<a href="#ref-4">4</a>]</span></p>
+    <ul>
+      <li><strong>Syntactic dependencies:</strong> Specific heads learn to connect verbs to subjects or verbs to objects (such as linking the verb <em>chased</em> directly to the subject <em>dog</em>).</li>
+      <li><strong>Coreference resolution:</strong> In ambiguous sentences such as <em>The dog chased the cat because it was fast</em>, an attention head can route high weight from the pronoun <em>it</em> back to the noun <em>dog</em>, resolving reference before subsequent feed-forward processing.</li>
+      <li><strong>Positional and boundary framing:</strong> Heads attend to previous or subsequent adjacent tokens, sentence delimiters, or special tokens like <code>[CLS]</code> and <code>[SEP]</code>.</li>
+    </ul>
+
+    <h3>Output Integration</h3>
+    <p>Each head \(i \in \{1, \dots, h\}\) computes its own head output \(\text{head}_i = \text{Attention}(Q W_i^Q, K W_i^K, V W_i^V)\). The outputs of all individual attention heads are concatenated along the feature dimension and mapped back to the model dimension by a linear projection matrix \(W^O \in \mathbb{R}^{h d_v \times d_{\text{model}}}\):<span class="cite">[<a href="#ref-1">1</a>]</span></p>
+    \[
+    \text{MultiHead}(Q, K, V) = \text{Concat}(\text{head}_1, \dots, \text{head}_h) W^O
+    \]
+    <p>This linear projection integrates the distinct representations discovered by each head before the activations pass into residual connections and the feed-forward sublayer.</p>
+
+    <h2 id="complexity">3. Computational Complexity and KV Cache</h2>
+    <p>The core computational trade-offs of self-attention govern both model scaling and serving efficiency:</p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Layer Type</th>
+          <th>Complexity per Layer</th>
+          <th>Sequential Operations</th>
+          <th>Maximum Path Length</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Self-Attention</td>
+          <td>\(O(n^2 \cdot d)\)</td>
+          <td>\(O(1)\)</td>
+          <td>\(O(1)\)</td>
+        </tr>
+        <tr>
+          <td>Recurrent (RNN)</td>
+          <td>\(O(n \cdot d^2)\)</td>
+          <td>\(O(n)\)</td>
+          <td>\(O(n)\)</td>
+        </tr>
+        <tr>
+          <td>Convolutional</td>
+          <td>\(O(k \cdot n \cdot d^2)\)</td>
+          <td>\(O(1)\)</td>
+          <td>\(O(\log_k(n))\)</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <p>Computing the matrix product \(Q K^\top\) requires evaluating an \(n \times n\) matrix of scores per head. Consequently, time and activation memory scale quadratically with sequence length \(n\). While this quadratic factor bounds context length on fixed accelerator memory, self-attention eliminates the sequential bottleneck of recurrent networks, allowing full parallelization across training tokens.<span class="cite">[<a href="#ref-1">1</a>]</span></p>
+
+    <h3>Inference and Key-Value Caching</h3>
+    <p>During autoregressive decoding, tokens are generated one at a time. Evaluating all positions from scratch at step \(t\) would repeat past calculations, resulting in \(O(t^2)\) operations per step. By storing the key and value vectors of previously computed tokens in a Key-Value (KV) cache, each new step needs only project the single new query vector \(q_t\) and compute attention against the cached keys and values. This reduces step latency to \(O(t)\) while requiring dedicated high-bandwidth memory proportional to sequence length and layer count.</p>
+
+    <h2 id="masking">4. Directionality and Causal Masking</h2>
+    <p>Self-attention supports two primary directional regimes:</p>
+    <ul>
+      <li><strong>Bidirectional self-attention:</strong> Every token attends to all positions in the sequence, both left and right. This unconstrained visibility is standard in encoder architectures like BERT,<span class="cite">[<a href="#ref-3">3</a>]</span> making it suitable for classification, extraction, and whole-sequence embedding.</li>
+      <li><strong>Causal (masked) self-attention:</strong> Autoregressive decoders must not look ahead into future positions that have not yet been generated. A causal mask \(M \in \mathbb{R}^{n \times n}\) is added to the attention logits prior to the softmax operation:
+      \[
+      M_{ij} = \begin{cases} 0 & \text{if } j \le i \\ -\infty & \text{if } j > i \end{cases}
+      \]
+      Positions with \(-\infty\) evaluate to zero probability under the softmax function, strictly preventing information leakage from future tokens.</li>
+    </ul>
+
+    <h2 id="cross-attention">5. Comparison with Cross-Attention</h2>
+    <p>Self-attention and cross-attention use the same scaled dot-product formulation but differ in the provenance of their inputs:</p>
+    <ul>
+      <li><strong>Self-Attention:</strong> The query, key, and value vectors all derive from the same sequence representation \(X\). The mechanism maps intra-sequence relationships within a single context.</li>
+      <li><strong>Cross-Attention:</strong> Queries derive from the target sequence (such as decoder hidden states), while keys and values derive from an external source sequence (such as encoder outputs). The mechanism aligns two distinct sequences, as in sequence-to-sequence translation or multimodal conditioning.</li>
+    </ul>
+
+    <div id="see-also">
+      <h2>See also</h2>
+      <ul>
+        <li><a href="/reference/attention/">Attention (Neurological and Computational)</a></li>
+        <li><a href="/reference/transformer-architecture/">Transformer Architecture</a></li>
+        <li><a href="/reference/sliding-window-attention/">Sliding-Window Attention</a></li>
+        <li><a href="/reference/softmax/">Softmax</a></li>
+        <li><a href="/reference/tokens/">Tokens</a></li>
+        <li><a href="/reference/embeddings/">Embeddings</a></li>
+        <li><a href="/reference/kv-cache/">KV Cache</a></li>
+        <li><a href="/reference/context-window/">Context Window</a></li>
+      </ul>
+    </div>
+
+    <div id="references">
+      <h2>References</h2>
+      <ol>
+        <li id="ref-1"><a class="backlink" href="#first-principles">&uarr;</a> A. Vaswani, N. Shazeer, N. Parmar, J. Uszkoreit, L. Jones, A. N. Gomez, Ł. Kaiser, and I. Polosukhin, &ldquo;Attention Is All You Need,&rdquo; in <em>Advances in Neural Information Processing Systems</em>, vol. 30, 2017. Free full text: <a href="https://arxiv.org/abs/1706.03762">https://arxiv.org/abs/1706.03762</a></li>
+        <li id="ref-2"><a class="backlink" href="#first-principles">&uarr;</a> D. Bahdanau, K. Cho, and Y. Bengio, &ldquo;Neural Machine Translation by Jointly Learning to Align and Translate,&rdquo; in <em>International Conference on Learning Representations (ICLR)</em>, 2015. Free full text: <a href="https://arxiv.org/abs/1409.0473">https://arxiv.org/abs/1409.0473</a></li>
+        <li id="ref-3"><a class="backlink" href="#masking">&uarr;</a> J. Devlin, M. W. Chang, K. Lee, and K. Toutanova, &ldquo;BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding,&rdquo; in <em>Proceedings of NAACL-HLT</em>, 2019, pp. 4171–4186. Free full text: <a href="https://arxiv.org/abs/1810.04805">https://arxiv.org/abs/1810.04805</a></li>
+        <li id="ref-4"><a class="backlink" href="#attention-heads">&uarr;</a> K. Clark, U. Khandelwal, O. Levy, and C. D. Manning, &ldquo;What Does BERT Look At? An Analysis of Attention,&rdquo; in <em>Proceedings of the 2019 ACL Workshop BlackboxNLP</em>, 2019, pp. 276–286. Free full text: <a href="https://arxiv.org/abs/1906.04341">https://arxiv.org/abs/1906.04341</a></li>
+      </ol>
+    </div>
+  </main>
+
+  <button id="backToTop" class="back-to-top" aria-label="Back to top">Back to top</button>
+  <script>
+    const btt = document.getElementById("backToTop");
+    window.addEventListener("scroll", () => {
+      if (window.scrollY > 300) {
+        btt.style.display = "block";
+      } else {
+        btt.style.display = "none";
+      }
+    });
+    btt.addEventListener("click", () => {
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    });
+  </script>
+</body>
+</html>

--- a/reference/transformer-architecture/index.html
+++ b/reference/transformer-architecture/index.html
@@ -159,7 +159,7 @@
     <!-- Section 3: Scaled Dot-Product Attention -->
     <h2 id="scaled-dot-product">3. Scaled Dot-Product Attention</h2>
     <p>
-      The primary primitive of the Transformer is <strong>scaled dot-product attention</strong>. Given input representations packed into Query matrix \(Q\), Key matrix \(K\), and Value matrix \(V\), attention computes weighted averages of values based on query-key inner products:
+      The primary primitive of the Transformer is <strong>scaled dot-product attention</strong> (see <a href="/reference/self-attention/">Self-Attention</a>). Given input representations packed into Query matrix \(Q\), Key matrix \(K\), and Value matrix \(V\), attention computes weighted averages of values based on query-key inner products:
     </p>
     <p style="text-align: center; margin: 1.2rem 0; background: var(--well); padding: 0.8rem; border-radius: 4px; border: 1px solid var(--line);">
       $$\text{Attention}(Q, K, V) = \text{softmax}\left(\frac{QK^T}{\sqrt{d_k}}\right)V$$
@@ -204,7 +204,7 @@
     <!-- Section 4: Multi-Head Attention -->
     <h2 id="multi-head-attention">4. Multi-Head Attention</h2>
     <p>
-      Rather than computing a single attention distribution with dimension \(d_{\text{model}}\), multi-head attention projects queries, keys, and values \(h\) times using learned parameter matrices:
+      Rather than computing a single attention distribution with dimension \(d_{\text{model}}\), <a href="/reference/self-attention/">multi-head self-attention</a> projects queries, keys, and values \(h\) times using learned parameter matrices:
     </p>
     <p style="text-align: center; margin: 1.2rem 0; background: var(--well); padding: 0.8rem; border-radius: 4px; border: 1px solid var(--line);">
       $$\text{MultiHead}(Q, K, V) = \text{Concat}(\text{head}_1, \dots, \text{head}_h)W^O$$

--- a/scripts/test_site_discoverability.py
+++ b/scripts/test_site_discoverability.py
@@ -520,6 +520,20 @@ class ReferenceSeoTests(unittest.TestCase):
         self.assertIn('"@type":"DefinedTerm"', entry_html)
         self.assertIn('id="first-principles"', entry_html)
 
+    def test_self_attention_reference_registered(self):
+        html = (REF / "index.html").read_text(encoding="utf-8")
+        locs = sitemap_locs(SITEMAP.read_text(encoding="utf-8"))
+        self.assertIn('href="/reference/self-attention/"', html, "Missing from reference/index.html: self-attention")
+        self.assertIn("https://ngpestelos.com/reference/self-attention/", locs, "Missing from sitemap.xml: self-attention")
+        entry_html = (REF / "self-attention" / "index.html").read_text(encoding="utf-8")
+        self.assertIn("application/ld+json", entry_html)
+        self.assertIn('"@type":"DefinedTerm"', entry_html)
+        self.assertIn('<h2 id="first-principles">', entry_html)
+        att_html = (REF / "attention" / "index.html").read_text(encoding="utf-8")
+        self.assertIn('href="/reference/self-attention/"', att_html)
+        trans_html = (REF / "transformer-architecture" / "index.html").read_text(encoding="utf-8")
+        self.assertIn('href="/reference/self-attention/"', trans_html)
+
     def test_reference_numbered_toc_suppresses_list_style(self):
         for path in sorted(REF.glob("*/index.html")):
             html = path.read_text(encoding="utf-8")

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1353,6 +1353,11 @@
     <priority>0.5</priority>
   </url>
   <url>
+    <loc>https://ngpestelos.com/reference/self-attention/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
     <loc>https://ngpestelos.com/reference/prefill/</loc>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>


### PR DESCRIPTION
## Summary
Adds a citable, ground-truth reference entry for self-attention in Transformers at `/reference/self-attention/` (resolving #113).

- Details scaled dot-product attention formulation, query/key/value projections, and scaling factor rationale.
- Details attention heads and multi-head attention mechanism: parallel specialization across syntactic dependencies, coreference resolution, and positional framing, followed by concatenation and linear output projection.
- Analyzes computational complexity ($O(n^2 \cdot d)$), $O(1)$ sequential path length, and autoregressive inference with KV caching.
- Explains causal masking vs. bidirectional attention and contrasts self-attention with cross-attention.
- Registers entry in `reference/index.html` and `sitemap.xml`.
- Cross-links reciprocally with `/reference/attention/` and `/reference/transformer-architecture/`.
- Passes discoverability, theme, and mechanical KaTeX/control-byte/voice scans.

Closes #113