### PR TITLE
Create foundational geometry reference pages: triangle and polygon perimeter (#124)

### DIFF
--- a/reference/index.html
+++ b/reference/index.html
@@ -392,6 +392,7 @@
         <li><a href="/reference/pesonet/">PESONet (Philippine Batch Payments)</a></li>
         <li><a href="/reference/philpassplus/">PhilPaSSplus (Philippine Peso Settlement)</a></li>
         <li><a href="/reference/plan-approve-execute/">Plan-Approve-Execute</a></li>
+        <li><a href="/reference/polygon-perimeter/">Polygon Perimeter (Geometry)</a></li>
         <li><a href="/reference/pomdp/">POMDPs for AI Agents</a></li>
         <li><a href="/reference/pre-training/">Pre-Training</a></li>
         <li><a href="/reference/prefill/">Prefill (LLM Inference)</a></li>
@@ -465,6 +466,8 @@
         <li><a href="/reference/tokens/">Tokens and Tokenization</a></li>
         <li><a href="/reference/top-k/">Top-k Selection and Sampling</a></li>
         <li><a href="/reference/transformer-architecture/">Transformer Architecture</a></li>
+        <li><a href="/reference/triangle-inequality-theorem/">Triangle Inequality Theorem</a></li>
+        <li><a href="/reference/triangle-perimeter/">Triangle Perimeter (Geometry)</a></li>
         </ul>
       </div>
 

--- a/reference/polygon-perimeter/index.html
+++ b/reference/polygon-perimeter/index.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Polygon Perimeter (Geometry) &middot; Reference &middot; Nestor G Pestelos Jr</title>
+  <meta name="description" content="The perimeter of a polygon is the total length of its outer boundary, computed as the scalar sum of all its edge lengths. Formulas, regular polygons, and decompositions.">
+  <meta property="og:title" content="Polygon Perimeter (Geometry) &middot; Reference">
+  <meta property="og:description" content="Formulas for regular and irregular polygons, coordinate geometry boundary lengths, and composite shape perimeters.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://ngpestelos.com/reference/polygon-perimeter/">
+  <link rel="canonical" href="https://ngpestelos.com/reference/polygon-perimeter/">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=20260813f">
+  <link rel="icon" href="/favicon-192.png?v=20260813f" type="image/png" sizes="192x192">
+  <link rel="icon" href="/favicon-32.png?v=20260813f" type="image/png" sizes="32x32">
+  <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
+  <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="stylesheet" href="/style.css?v=20260903e">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css" crossorigin="anonymous">
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"></script>
+  <script>
+    document.addEventListener("DOMContentLoaded", function () {
+      renderMathInElement(document.body, {
+        delimiters: [
+          {left: "$$", right: "$$", display: true},
+          {left: "\\[", right: "\\]", display: true},
+          {left: "\\(", right: "\\)", display: false}
+        ],
+        throwOnError: false
+      });
+    });
+  </script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag("js", new Date());
+    gtag("config", "G-TLBY8P4GG9");
+  </script>
+  <script type="application/ld+json">
+  {"@context":"https://schema.org","@type":"DefinedTerm","name":"Polygon Perimeter (Geometry)","description":"The perimeter of a polygon is the total length of its outer boundary, computed as the scalar sum of all its edge lengths.","url":"https://ngpestelos.com/reference/polygon-perimeter/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; scroll-behavior: smooth; }
+    body { line-height: 1.6; }
+    main { max-width: 48rem; margin: 0 auto; padding: 1.4rem 1.4rem 4rem; }
+    .back { font-family: "Segoe UI", Helvetica, Arial, sans-serif; font-size: 0.85rem; color: var(--mute); margin-bottom: 1.4rem; }
+    .back a { color: var(--link); text-decoration: none; }
+    .back a:hover { text-decoration: underline; }
+    .kicker { font-family: "Segoe UI", Helvetica, Arial, sans-serif; font-size: 0.78rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; color: var(--mute); margin-bottom: 0.2rem; }
+    h1 { font-size: clamp(1.9rem, 5vw, 2.4rem); font-weight: 400; border-bottom: 1px solid var(--line); padding-bottom: 0.4rem; margin-bottom: 0.8rem; }
+    .updated { font-family: "Segoe UI", Helvetica, Arial, sans-serif; font-size: 0.82rem; color: var(--mute); margin-bottom: 1.4rem; }
+    .unattributed { font-family: "Segoe UI", Helvetica, Arial, sans-serif; font-size: 0.85rem; color: var(--mute); font-style: italic; }
+    .lede { margin-bottom: 1.6rem; }
+    .lede strong:first-child { font-weight: 700; }
+    .toc { background: var(--well); border: 1px solid var(--line); border-radius: 4px; padding: 1.1rem 1.4rem; margin-bottom: 2rem; font-family: "Segoe UI", Helvetica, Arial, sans-serif; font-size: 0.9rem; }
+    .toc h2 { font-size: 1rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 0.5rem; color: var(--ink); border-bottom: none; padding-bottom: 0; }
+    .toc ol { list-style: none; padding-left: 0; }
+    .toc li { margin: 0.2rem 0; }
+    .toc a { color: var(--link); text-decoration: none; }
+    .toc a:hover { text-decoration: underline; }
+    h2 { font-size: 1.5rem; font-weight: 400; border-bottom: 1px solid var(--line); padding-bottom: 0.3rem; margin: 2rem 0 0.9rem; }
+    p { margin-bottom: 0.9rem; }
+    a { color: var(--link); }
+    a:visited { color: var(--link-visited); }
+    ul, ol { padding-left: 1.5rem; margin-bottom: 0.9rem; }
+    li { margin-bottom: 0.3rem; }
+    .cite { font-size: 0.75em; vertical-align: super; line-height: 0; text-decoration: none; }
+    .cite a { text-decoration: none; }
+    #see-also ul, #references ol { padding-left: 1.5rem; }
+    #see-also li, #references li { margin-bottom: 0.5rem; }
+    #references { font-size: 0.92rem; }
+    #references .backlink { margin-right: 0.3rem; text-decoration: none; }
+    @media print { .back { display: none !important; } }
+  </style>
+</head>
+<body class="reference">
+  <main>
+    <nav class="back" aria-label="Breadcrumb">
+      <a href="/reference/">&larr; Reference</a> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a>
+    </nav>
+
+    <p class="kicker">Mathematics · Euclidean Geometry</p>
+    <h1>Polygon Perimeter (Geometry)</h1>
+    <p class="updated">Reference entry &middot; last updated September 13, 2026</p>
+
+    <p class="lede"><strong>Polygon perimeter</strong> denotes the total linear distance around the boundary of a closed two-dimensional polygon, defined as the sum of all its consecutive side lengths <span class="cite">[<a href="#ref-1">1</a>]</span>.</p>
+
+    <nav class="toc" aria-label="Table of contents">
+      <h2>Contents</h2>
+      <ol>
+        <li><a href="#first-principles">1. First principles and general definition</a></li>
+        <li><a href="#regular-polygons">2. Regular polygons and equilateral figures</a></li>
+        <li><a href="#quadrilaterals">3. Standard quadrilaterals</a></li>
+        <li><a href="#composite-shapes">4. Perimeter of composite shapes</a></li>
+        <li><a href="#see-also">See also</a></li>
+        <li><a href="#references">References</a></li>
+      </ol>
+    </nav>
+
+    <h2 id="first-principles">1. First principles and general definition</h2>
+    <p>A polygon in the Euclidean plane is bounded by a finite sequence of straight line segments called edges or sides. For an \(n\)-sided polygon with side lengths \(s_1, s_2, \dots, s_n\), the perimeter \(P\) is the scalar sum of all edge lengths <span class="cite">[<a href="#ref-1">1</a>]</span>:</p>
+    <p>$$P = \sum_{i=1}^{n} s_i = s_1 + s_2 + \dots + s_n$$</p>
+    <p>Given the coordinates of vertices \((x_1, y_1), (x_2, y_2), \dots, (x_n, y_n)\) in cyclic order, the perimeter evaluates as:</p>
+    <p>$$P = \sum_{i=1}^{n} \sqrt{(x_{i+1} - x_i)^2 + (y_{i+1} - y_i)^2}, \quad \text{where } (x_{n+1}, y_{n+1}) = (x_1, y_1)$$</p>
+
+    <h2 id="regular-polygons">2. Regular polygons and equilateral figures</h2>
+    <p>A polygon is regular when all \(n\) sides are equal in length and all interior angles are congruent. Let \(s\) denote the common side length <span class="cite">[<a href="#ref-1">1</a>]</span>:</p>
+    <p>$$P = n \cdot s$$</p>
+    <p>If a regular \(n\)-gon has circumradius \(R\) (distance from center to each vertex) or inradius / apothem \(r\) (distance from center to edge midpoint):</p>
+    <p>$$s = 2R \sin\left(\frac{\pi}{n}\right) = 2r \tan\left(\frac{\pi}{n}\right)$$</p>
+    <p>$$P = 2nR \sin\left(\frac{\pi}{n}\right) = 2nr \tan\left(\frac{\pi}{n}\right)$$</p>
+    <p class="unattributed">As \(n \to \infty\) with fixed circumradius \(R\), \(P \to 2\pi R\), recovering the circumference of a circle.</p>
+
+    <h2 id="quadrilaterals">3. Standard quadrilaterals</h2>
+    <p>For four-sided polygons (\(n = 4\)), geometric constraints simplify perimeter computation <span class="cite">[<a href="#ref-2">2</a>]</span>:</p>
+    <ul>
+      <li><strong>Square</strong>: Four congruent sides of length \(s\):
+        <p>$$P = 4s$$</p>
+      </li>
+      <li><strong>Rectangle / Parallelogram</strong>: Adjacent sides of length \(l\) and \(w\):
+        <p>$$P = 2(l + w) = 2l + 2w$$</p>
+      </li>
+      <li><strong>Rhombus</strong>: Four congruent sides of length \(s\):
+        <p>$$P = 4s$$</p>
+      </li>
+      <li><strong>Trapezoid</strong>: Two parallel bases \(b_1, b_2\) and two non-parallel legs \(c, d\):
+        <p>$$P = b_1 + b_2 + c + d$$</p>
+      </li>
+    </ul>
+
+    <h2 id="composite-shapes">4. Perimeter of composite shapes</h2>
+    <p>A composite shape is formed by joining two or more standard geometric figures along shared boundary segments. The perimeter of a composite shape accounts strictly for the <em>exterior boundary</em> <span class="cite">[<a href="#ref-2">2</a>]</span>.</p>
+    <p>When two shapes \(A\) and \(B\) share an internal interface of length \(L_{\text{shared}}\), the resulting composite perimeter satisfies:</p>
+    <p>$$P_{\text{composite}} = P_A + P_B - 2 \cdot L_{\text{shared}}$$</p>
+    <p>Internal dividing segments must not be added to the perimeter calculation because they do not form part of the outer perimeter boundary.</p>
+
+    <h2 id="see-also">See also</h2>
+    <ul id="see-also-list">
+      <li><a href="/reference/triangle-perimeter/">Triangle Perimeter (Geometry)</a></li>
+      <li><a href="/reference/triangle-inequality-theorem/">Triangle Inequality Theorem</a></li>
+    </ul>
+
+    <h2 id="references">References</h2>
+    <ol id="references-list">
+      <li id="ref-1"><span class="backlink">^</span>Euclid, <em>Elements</em>, Book I, Definitions 19–23 (Polygons and Regular Figures).</li>
+      <li id="ref-2"><span class="backlink">^</span>H.S.M. Coxeter, <em>Introduction to Geometry</em>, 2nd ed., John Wiley &amp; Sons, 1969.</li>
+    </ol>
+  </main>
+</body>
+</html>

--- a/reference/triangle-inequality-theorem/index.html
+++ b/reference/triangle-inequality-theorem/index.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Triangle Inequality Theorem &middot; Reference &middot; Nestor G Pestelos Jr</title>
+  <meta name="description" content="The triangle inequality theorem states that the sum of the lengths of any two sides of a triangle must be strictly greater than the length of the remaining side.">
+  <meta property="og:title" content="Triangle Inequality Theorem &middot; Reference">
+  <meta property="og:description" content="Geometric statement, metric space generalization, existence criteria, and degenerate limits of the triangle inequality theorem.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://ngpestelos.com/reference/triangle-inequality-theorem/">
+  <link rel="canonical" href="https://ngpestelos.com/reference/triangle-inequality-theorem/">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=20260813f">
+  <link rel="icon" href="/favicon-192.png?v=20260813f" type="image/png" sizes="192x192">
+  <link rel="icon" href="/favicon-32.png?v=20260813f" type="image/png" sizes="32x32">
+  <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
+  <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="stylesheet" href="/style.css?v=20260903e">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css" crossorigin="anonymous">
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"></script>
+  <script>
+    document.addEventListener("DOMContentLoaded", function () {
+      renderMathInElement(document.body, {
+        delimiters: [
+          {left: "$$", right: "$$", display: true},
+          {left: "\\[", right: "\\]", display: true},
+          {left: "\\(", right: "\\)", display: false}
+        ],
+        throwOnError: false
+      });
+    });
+  </script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag("js", new Date());
+    gtag("config", "G-TLBY8P4GG9");
+  </script>
+  <script type="application/ld+json">
+  {"@context":"https://schema.org","@type":"DefinedTerm","name":"Triangle Inequality Theorem","description":"The triangle inequality theorem states that the sum of the lengths of any two sides of a triangle must be strictly greater than the length of the remaining side.","url":"https://ngpestelos.com/reference/triangle-inequality-theorem/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; scroll-behavior: smooth; }
+    body { line-height: 1.6; }
+    main { max-width: 48rem; margin: 0 auto; padding: 1.4rem 1.4rem 4rem; }
+    .back { font-family: "Segoe UI", Helvetica, Arial, sans-serif; font-size: 0.85rem; color: var(--mute); margin-bottom: 1.4rem; }
+    .back a { color: var(--link); text-decoration: none; }
+    .back a:hover { text-decoration: underline; }
+    .kicker { font-family: "Segoe UI", Helvetica, Arial, sans-serif; font-size: 0.78rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; color: var(--mute); margin-bottom: 0.2rem; }
+    h1 { font-size: clamp(1.9rem, 5vw, 2.4rem); font-weight: 400; border-bottom: 1px solid var(--line); padding-bottom: 0.4rem; margin-bottom: 0.8rem; }
+    .updated { font-family: "Segoe UI", Helvetica, Arial, sans-serif; font-size: 0.82rem; color: var(--mute); margin-bottom: 1.4rem; }
+    .unattributed { font-family: "Segoe UI", Helvetica, Arial, sans-serif; font-size: 0.85rem; color: var(--mute); font-style: italic; }
+    .lede { margin-bottom: 1.6rem; }
+    .lede strong:first-child { font-weight: 700; }
+    .toc { background: var(--well); border: 1px solid var(--line); border-radius: 4px; padding: 1.1rem 1.4rem; margin-bottom: 2rem; font-family: "Segoe UI", Helvetica, Arial, sans-serif; font-size: 0.9rem; }
+    .toc h2 { font-size: 1rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 0.5rem; color: var(--ink); border-bottom: none; padding-bottom: 0; }
+    .toc ol { list-style: none; padding-left: 0; }
+    .toc li { margin: 0.2rem 0; }
+    .toc a { color: var(--link); text-decoration: none; }
+    .toc a:hover { text-decoration: underline; }
+    h2 { font-size: 1.5rem; font-weight: 400; border-bottom: 1px solid var(--line); padding-bottom: 0.3rem; margin: 2rem 0 0.9rem; }
+    p { margin-bottom: 0.9rem; }
+    a { color: var(--link); }
+    a:visited { color: var(--link-visited); }
+    ul, ol { padding-left: 1.5rem; margin-bottom: 0.9rem; }
+    li { margin-bottom: 0.3rem; }
+    .cite { font-size: 0.75em; vertical-align: super; line-height: 0; text-decoration: none; }
+    .cite a { text-decoration: none; }
+    #see-also ul, #references ol { padding-left: 1.5rem; }
+    #see-also li, #references li { margin-bottom: 0.5rem; }
+    #references { font-size: 0.92rem; }
+    #references .backlink { margin-right: 0.3rem; text-decoration: none; }
+    @media print { .back { display: none !important; } }
+  </style>
+</head>
+<body class="reference">
+  <main>
+    <nav class="back" aria-label="Breadcrumb">
+      <a href="/reference/">&larr; Reference</a> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a>
+    </nav>
+
+    <p class="kicker">Mathematics · Euclidean Geometry</p>
+    <h1>Triangle Inequality Theorem</h1>
+    <p class="updated">Reference entry &middot; last updated September 13, 2026</p>
+
+    <p class="lede"><strong>Triangle inequality theorem</strong> states that for any non-degenerate triangle, the sum of the lengths of any two sides must be strictly greater than the length of the third side <span class="cite">[<a href="#ref-1">1</a>]</span>.</p>
+
+    <nav class="toc" aria-label="Table of contents">
+      <h2>Contents</h2>
+      <ol>
+        <li><a href="#first-principles">1. First principles and mathematical formulation</a></li>
+        <li><a href="#test-criterion">2. Existence test for side lengths</a></li>
+        <li><a href="#range-bounds">3. Finding the range of an unknown side</a></li>
+        <li><a href="#metric-spaces">4. Generalization to vectors and metric spaces</a></li>
+        <li><a href="#see-also">See also</a></li>
+        <li><a href="#references">References</a></li>
+      </ol>
+    </nav>
+
+    <h2 id="first-principles">1. First principles and mathematical formulation</h2>
+    <p>In Euclidean plane geometry, a straight line path represents the shortest distance between two points. If \(A\), \(B\), and \(C\) are three distinct non-collinear vertices, traveling directly from \(A\) to \(B\) is strictly shorter than traveling from \(A\) to \(C\) and then from \(C\) to \(B\) <span class="cite">[<a href="#ref-1">1</a>]</span>.</p>
+    <p>Let the side lengths opposite vertices \(A\), \(B\), and \(C\) be \(a\), \(b\), and \(c\). A valid non-degenerate triangle exists if and only if all three inequalities hold simultaneously:</p>
+    <p>$$a + b > c$$</p>
+    <p>$$a + c > b$$</p>
+    <p>$$b + c > a$$</p>
+    <p>If three points are collinear with \(C\) lying on segment \(AB\), the relation yields \(AC + CB = AB\). This forms a degenerate triangle of zero area <span class="cite">[<a href="#ref-2">2</a>]</span>.</p>
+
+    <h2 id="test-criterion">2. Existence test for side lengths</h2>
+    <p>To verify whether three given lengths \(\{a, b, c\}\) form a triangle, sorting the lengths simplifies the check. Let the sides be ordered such that:</p>
+    <p>$$a \le b \le c$$</p>
+    <p>Because \(c \ge b \ge a\), the conditions \(a + c > b\) and \(b + c > a\) are automatically satisfied for positive numbers. Therefore, verification requires only checking that the sum of the two shorter sides exceeds the longest side:</p>
+    <p>$$a + b > c$$</p>
+    <p>For example, side lengths \(3, 4, 8\) cannot form a triangle because \(3 + 4 = 7 \not> 8\). Side lengths \(5, 6, 9\) form a triangle because \(5 + 6 = 11 > 9\).</p>
+
+    <h2 id="range-bounds">3. Finding the range of an unknown side</h2>
+    <p>When two side lengths \(a\) and \(b\) are known, the third side \(x\) is bounded from both below and above by combining the three inequalities:</p>
+    <p>$$|a - b| < x < a + b$$</p>
+    <p>The lower bound \(|a - b|\) derives from rearranging \(a + x > b\) and \(b + x > a\). The upper bound \(a + b\) derives directly from \(a + b > x\). The third side must lie strictly within this open interval.</p>
+
+    <h2 id="metric-spaces">4. Generalization to vectors and metric spaces</h2>
+    <p>The geometric theorem extends as an axiom across analysis and linear algebra <span class="cite">[<a href="#ref-3">3</a>]</span>:</p>
+    <ul>
+      <li><strong>Normed vector spaces</strong>: For any vectors \(\mathbf{u}, \mathbf{v} \in V\):
+        <p>$$\|\mathbf{u} + \mathbf{v}\| \le \|\mathbf{u}\| + \|\mathbf{v}\|$$</p>
+      </li>
+      <li><strong>Metric spaces</strong>: A metric space \((M, d)\) requires distance function \(d\) to satisfy the triangle inequality for all points \(x, y, z \in M\):
+        <p>$$d(x, z) \le d(x, y) + d(y, z)$$</p>
+      </li>
+      <li><strong>Reverse triangle inequality</strong>: For real numbers and normed spaces:
+        <p>$$|\|\mathbf{u}\| - \|\mathbf{v}\|| \le \|\mathbf{u} - \mathbf{v}\|$$</p>
+      </li>
+    </ul>
+
+    <h2 id="see-also">See also</h2>
+    <ul id="see-also-list">
+      <li><a href="/reference/triangle-perimeter/">Triangle Perimeter (Geometry)</a></li>
+      <li><a href="/reference/vector/">Vector (Linear Algebra)</a></li>
+    </ul>
+
+    <h2 id="references">References</h2>
+    <ol id="references-list">
+      <li id="ref-1"><span class="backlink">^</span>Euclid, <em>Elements</em>, Book I, Proposition 20.</li>
+      <li id="ref-2"><span class="backlink">^</span>H.S.M. Coxeter, <em>Introduction to Geometry</em>, 2nd ed., John Wiley &amp; Sons, 1969.</li>
+      <li id="ref-3"><span class="backlink">^</span>Walter Rudin, <em>Principles of Mathematical Analysis</em>, 3rd ed., McGraw-Hill, 1976.</li>
+    </ol>
+  </main>
+</body>
+</html>

--- a/reference/triangle-perimeter/index.html
+++ b/reference/triangle-perimeter/index.html
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Triangle Perimeter (Geometry) &middot; Reference &middot; Nestor G Pestelos Jr</title>
+  <meta name="description" content="The perimeter of a triangle is the total length of its one-dimensional closed boundary, defined as the sum of its three side lengths. Formulas, special cases, and bounds.">
+  <meta property="og:title" content="Triangle Perimeter (Geometry) &middot; Reference">
+  <meta property="og:description" content="Formulas, special cases, Pythagorean derivations, semi-perimeter, and geometric bounds for the perimeter of a triangle.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://ngpestelos.com/reference/triangle-perimeter/">
+  <link rel="canonical" href="https://ngpestelos.com/reference/triangle-perimeter/">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=20260813f">
+  <link rel="icon" href="/favicon-192.png?v=20260813f" type="image/png" sizes="192x192">
+  <link rel="icon" href="/favicon-32.png?v=20260813f" type="image/png" sizes="32x32">
+  <link rel="icon" href="/favicon.ico?v=20260813f" sizes="48x48 32x32 16x16">
+  <link rel="icon" href="/favicon.svg?v=20260813f" type="image/svg+xml">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="stylesheet" href="/style.css?v=20260903e">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css" crossorigin="anonymous">
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"></script>
+  <script>
+    document.addEventListener("DOMContentLoaded", function () {
+      renderMathInElement(document.body, {
+        delimiters: [
+          {left: "$$", right: "$$", display: true},
+          {left: "\\[", right: "\\]", display: true},
+          {left: "\\(", right: "\\)", display: false}
+        ],
+        throwOnError: false
+      });
+    });
+  </script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLBY8P4GG9"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag("js", new Date());
+    gtag("config", "G-TLBY8P4GG9");
+  </script>
+  <script type="application/ld+json">
+  {"@context":"https://schema.org","@type":"DefinedTerm","name":"Triangle Perimeter (Geometry)","description":"The perimeter of a triangle is the total length of its one-dimensional closed boundary, defined as the sum of its three side lengths.","url":"https://ngpestelos.com/reference/triangle-perimeter/","inDefinedTermSet":"https://ngpestelos.com/reference/"}
+  </script>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; scroll-behavior: smooth; }
+    body { line-height: 1.6; }
+    main { max-width: 48rem; margin: 0 auto; padding: 1.4rem 1.4rem 4rem; }
+    .back { font-family: "Segoe UI", Helvetica, Arial, sans-serif; font-size: 0.85rem; color: var(--mute); margin-bottom: 1.4rem; }
+    .back a { color: var(--link); text-decoration: none; }
+    .back a:hover { text-decoration: underline; }
+    .kicker { font-family: "Segoe UI", Helvetica, Arial, sans-serif; font-size: 0.78rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; color: var(--mute); margin-bottom: 0.2rem; }
+    h1 { font-size: clamp(1.9rem, 5vw, 2.4rem); font-weight: 400; border-bottom: 1px solid var(--line); padding-bottom: 0.4rem; margin-bottom: 0.8rem; }
+    .updated { font-family: "Segoe UI", Helvetica, Arial, sans-serif; font-size: 0.82rem; color: var(--mute); margin-bottom: 1.4rem; }
+    .unattributed { font-family: "Segoe UI", Helvetica, Arial, sans-serif; font-size: 0.85rem; color: var(--mute); font-style: italic; }
+    .lede { margin-bottom: 1.6rem; }
+    .lede strong:first-child { font-weight: 700; }
+    .toc { background: var(--well); border: 1px solid var(--line); border-radius: 4px; padding: 1.1rem 1.4rem; margin-bottom: 2rem; font-family: "Segoe UI", Helvetica, Arial, sans-serif; font-size: 0.9rem; }
+    .toc h2 { font-size: 1rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 0.5rem; color: var(--ink); border-bottom: none; padding-bottom: 0; }
+    .toc ol { list-style: none; padding-left: 0; }
+    .toc li { margin: 0.2rem 0; }
+    .toc a { color: var(--link); text-decoration: none; }
+    .toc a:hover { text-decoration: underline; }
+    h2 { font-size: 1.5rem; font-weight: 400; border-bottom: 1px solid var(--line); padding-bottom: 0.3rem; margin: 2rem 0 0.9rem; }
+    p { margin-bottom: 0.9rem; }
+    a { color: var(--link); }
+    a:visited { color: var(--link-visited); }
+    ul, ol { padding-left: 1.5rem; margin-bottom: 0.9rem; }
+    li { margin-bottom: 0.3rem; }
+    .cite { font-size: 0.75em; vertical-align: super; line-height: 0; text-decoration: none; }
+    .cite a { text-decoration: none; }
+    #see-also ul, #references ol { padding-left: 1.5rem; }
+    #see-also li, #references li { margin-bottom: 0.5rem; }
+    #references { font-size: 0.92rem; }
+    #references .backlink { margin-right: 0.3rem; text-decoration: none; }
+    @media print { .back { display: none !important; } }
+  </style>
+</head>
+<body class="reference">
+  <main>
+    <nav class="back" aria-label="Breadcrumb">
+      <a href="/reference/">&larr; Reference</a> &middot; <a href="#" onclick="window.print(); return false;">Print this page</a>
+    </nav>
+
+    <p class="kicker">Mathematics · Euclidean Geometry</p>
+    <h1>Triangle Perimeter (Geometry)</h1>
+    <p class="updated">Reference entry &middot; last updated September 13, 2026</p>
+
+    <p class="lede"><strong>Triangle perimeter</strong> denotes the total linear length of the three line segments that bound a triangle in the Euclidean plane <span class="cite">[<a href="#ref-1">1</a>]</span>.</p>
+
+    <nav class="toc" aria-label="Table of contents">
+      <h2>Contents</h2>
+      <ol>
+        <li><a href="#first-principles">1. First principles and basic formula</a></li>
+        <li><a href="#special-cases">2. Special triangles</a></li>
+        <li><a href="#semi-perimeter">3. Semi-perimeter and geometric applications</a></li>
+        <li><a href="#constraints">4. Inequality constraints and existence bounds</a></li>
+        <li><a href="#see-also">See also</a></li>
+        <li><a href="#references">References</a></li>
+      </ol>
+    </nav>
+
+    <h2 id="first-principles">1. First principles and basic formula</h2>
+    <p>In Euclidean geometry, a triangle is a polygon with three vertices and three edges. Let the lengths of the three sides be \(a\), \(b\), and \(c\). The perimeter \(P\) is the scalar sum of these lengths <span class="cite">[<a href="#ref-1">1</a>]</span>:</p>
+    <p>$$P = a + b + c$$</p>
+    <p>Perimeter is a one-dimensional measure. Its physical unit matches the unit of edge length (such as meters, centimeters, or units in a Cartesian coordinate system) <span class="cite">[<a href="#ref-2">2</a>]</span>.</p>
+    <p>On a Cartesian coordinate plane with vertices \(A(x_1, y_1)\), \(B(x_2, y_2)\), and \(C(x_3, y_3)\), side lengths derive from the Euclidean distance formula:</p>
+    <p>$$P = \sqrt{(x_2 - x_1)^2 + (y_2 - y_1)^2} + \sqrt{(x_3 - x_2)^2 + (y_3 - y_2)^2} + \sqrt{(x_1 - x_3)^2 + (y_1 - y_3)^2}$$</p>
+
+    <h2 id="special-cases">2. Special triangles</h2>
+    <p>Symmetries reduce the number of independent measurements needed to determine \(P\) <span class="cite">[<a href="#ref-1">1</a>]</span>:</p>
+    <ul>
+      <li><strong>Equilateral triangle</strong>: All three sides have equal length \(a\).
+        <p>$$P = 3a$$</p>
+      </li>
+      <li><strong>Isosceles triangle</strong>: Two legs have equal length \(a\) and the base has length \(b\).
+        <p>$$P = 2a + b$$</p>
+      </li>
+      <li><strong>Right triangle</strong>: Legs \(a\) and \(b\) form a right angle, with hypotenuse \(c = \sqrt{a^2 + b^2}\) by the Pythagorean theorem <span class="cite">[<a href="#ref-1">1</a>]</span>.
+        <p>$$P = a + b + \sqrt{a^2 + b^2}$$</p>
+      </li>
+      <li><strong>Isosceles right triangle (45-45-90)</strong>: Legs have length \(a\), yielding hypotenuse \(a\sqrt{2}\).
+        <p>$$P = 2a + a\sqrt{2} = a(2 + \sqrt{2})$$</p>
+      </li>
+    </ul>
+
+    <h2 id="semi-perimeter">3. Semi-perimeter and geometric applications</h2>
+    <p>The semi-perimeter \(s\) is defined as half of the total perimeter <span class="cite">[<a href="#ref-1">1</a>]</span>:</p>
+    <p>$$s = \frac{P}{2} = \frac{a + b + c}{2}$$</p>
+    <p>The semi-perimeter appears in fundamental geometric identities:</p>
+    <ul>
+      <li><strong>Heron's formula</strong>: Computes the area \(K\) of a triangle from its side lengths without requiring an explicit height:
+        <p>$$K = \sqrt{s(s - a)(s - b)(s - c)}$$</p>
+      </li>
+      <li><strong>Inradius</strong>: The radius \(r\) of the incircle tangent to all three sides satisfies \(K = r \cdot s\), so:
+        <p>$$r = \frac{K}{s} = \frac{2K}{P}$$</p>
+      </li>
+    </ul>
+
+    <h2 id="constraints">4. Inequality constraints and existence bounds</h2>
+    <p>A set of three positive real numbers \(\{a, b, c\}\) forms a non-degenerate triangle if and only if each side is strictly shorter than the sum of the remaining two sides. This is the triangle inequality theorem <span class="cite">[<a href="#ref-1">1</a>]</span>:</p>
+    <p>$$a + b > c, \quad a + c > b, \quad b + c > a$$</p>
+    <p>Consequently, no single edge may exceed or equal the semi-perimeter:</p>
+    <p>$$\max(a, b, c) < s = \frac{P}{2}$$</p>
+    <p class="unattributed">Degenerate triangles where \(a + b = c\) collapse into a line segment of length \(c\), yielding perimeter \(P = 2c\) with zero interior area.</p>
+
+    <h2 id="see-also">See also</h2>
+    <ul id="see-also-list">
+      <li><a href="/reference/triangle-inequality-theorem/">Triangle Inequality Theorem</a></li>
+      <li><a href="/reference/polygon-perimeter/">Polygon Perimeter</a></li>
+    </ul>
+
+    <h2 id="references">References</h2>
+    <ol id="references-list">
+      <li id="ref-1"><span class="backlink">^</span>Euclid, <em>Elements</em>, Book I, Proposition 20 (Triangle Inequality) and Proposition 47 (Pythagorean Theorem).</li>
+      <li id="ref-2"><span class="backlink">^</span>H.S.M. Coxeter, <em>Introduction to Geometry</em>, 2nd ed., John Wiley &amp; Sons, 1969.</li>
+    </ol>
+  </main>
+</body>
+</html>

--- a/scripts/test_site_discoverability.py
+++ b/scripts/test_site_discoverability.py
@@ -549,6 +549,18 @@ class ReferenceSeoTests(unittest.TestCase):
                         f"Numbered TOC in {path.parent.name} missing 'list-style: none' styling",
                     )
 
+    def test_geometry_references_registered(self):
+        html = (REF / "index.html").read_text(encoding="utf-8")
+        locs = sitemap_locs(SITEMAP.read_text(encoding="utf-8"))
+        geom_slugs = ("triangle-perimeter", "triangle-inequality-theorem", "polygon-perimeter")
+        for slug in geom_slugs:
+            self.assertIn(f'href="/reference/{slug}/"', html, f"Missing from reference/index.html: {slug}")
+            self.assertIn(f"https://ngpestelos.com/reference/{slug}/", locs, f"Missing from sitemap.xml: {slug}")
+            entry_html = (REF / slug / "index.html").read_text(encoding="utf-8")
+            self.assertIn("application/ld+json", entry_html)
+            self.assertIn('"@type":"DefinedTerm"', entry_html)
+            self.assertIn('id="first-principles"', entry_html)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1372,4 +1372,19 @@
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
+  <url>
+    <loc>https://ngpestelos.com/reference/triangle-perimeter/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://ngpestelos.com/reference/triangle-inequality-theorem/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://ngpestelos.com/reference/polygon-perimeter/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
## Summary

Closes #123.
Addresses Phase 1 of #124.

Adds three foundational geometry reference pages to `ngpestelos.com/reference/`:
- `/reference/triangle-perimeter/`: Euclidean triangle perimeter ( = a + b + c$), special triangles (equilateral, isosceles, right/Pythagorean, 45-45-90), semi-perimeter applications (Heron's formula, inradius), and existence bounds.
- `/reference/triangle-inequality-theorem/`: Formal triangle inequality definition (+b>c$, +c>b$, +c>a$), sorted existence test ( \le b \le c \implies a+b>c$), unknown side bounds ($|a-b| < x < a+b$), and vector/metric space generalizations.
- `/reference/polygon-perimeter/`: General polygon perimeter formula, regular polygons (=ns=2nR\sin(\pi/n)$), standard quadrilaterals, and composite shape exterior boundary calculation.

## Verification
- Discoverability & theme test suites pass: `python3 scripts/test_site_discoverability.py` (29 tests OK) and `python3 scripts/test_site_theme.py` (6 tests OK).
- Added regression test `test_geometry_references_registered`.
- Passed de-AI voice scan (zero em-dashes in prose, middots in titles, Schema.org `DefinedTerm` JSON-LD, `id="first-principles"` first section on every page).